### PR TITLE
refactor: Phase 1 — Spans, Type enum, Parser Result (Issues #2, #3, #4)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,5 +1,21 @@
 use crate::token::Token;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    pub line: usize,
+    pub col: usize,
+}
+
+impl Span {
+    pub const fn zero() -> Self {
+        Self { line: 0, col: 0 }
+    }
+
+    pub fn from_token(tok: &Token) -> Self {
+        Self { line: tok.line, col: tok.col }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Program {
     pub module_name: Option<String>,
@@ -25,14 +41,14 @@ pub enum Declaration {
 #[derive(Debug, Clone)]
 pub struct Interface {
     pub name: String,
-    pub methods: Vec<Function>, // Method signatures
+    pub methods: Vec<Function>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ImplBlock {
     pub target_name: String,
     pub generic_params: Vec<String>,
-    pub interface_name: Option<String>, // Optional: impl Interface for Target
+    pub interface_name: Option<String>,
     pub functions: Vec<Function>,
 }
 
@@ -40,11 +56,11 @@ pub struct ImplBlock {
 pub struct Function {
     pub name: String,
     pub generic_params: Vec<String>,
-    pub params: Vec<(String, String, Option<Box<Expression>>)>,  // (name, type, default_value)
+    pub params: Vec<(String, String, Option<Box<Expression>>)>,
     pub return_type: String,
-    pub body: Option<Vec<Statement>>, 
-    pub modifiers: Vec<Token>,        
-    pub attributes: Vec<(String, String)>, 
+    pub body: Option<Vec<Statement>>,
+    pub modifiers: Vec<Token>,
+    pub attributes: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,21 +81,21 @@ pub struct Enum {
 #[derive(Debug, Clone)]
 pub struct EnumVariant {
     pub name: String,
-    pub data_types: Vec<String>, 
+    pub data_types: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Statement {
-    Let { name: String, value: Expression, intent: Option<String>, is_mut: bool },
-    Return { value: Expression, intent: Option<String> },
-    ExpressionStmt(Expression),
-    If { condition: Expression, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>> },
-    Assignment { target: Expression, value: Expression },
-    While { condition: Expression, body: Vec<Statement> },
-    For { var: String, range: Expression, body: Vec<Statement> },
-    Spawn(Vec<Statement>),
-    Match { condition: Expression, arms: Vec<MatchArm> },
-    UnsafeBlock(Vec<Statement>),
+    Let { name: String, value: Expression, intent: Option<String>, is_mut: bool, span: Span },
+    Return { value: Expression, intent: Option<String>, span: Span },
+    ExpressionStmt(Expression, Span),
+    If { condition: Expression, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>>, span: Span },
+    Assignment { target: Expression, value: Expression, span: Span },
+    While { condition: Expression, body: Vec<Statement>, span: Span },
+    For { var: String, range: Expression, body: Vec<Statement>, span: Span },
+    Spawn(Vec<Statement>, Span),
+    Match { condition: Expression, arms: Vec<MatchArm>, span: Span },
+    UnsafeBlock(Vec<Statement>, Span),
     NoOp,
 }
 
@@ -94,63 +110,81 @@ pub struct MatchArm {
 
 #[derive(Debug, Clone)]
 pub enum Expression {
-    Integer(i64),
-    Float(f64),
-    String(String),
-    Duration(u64, u32), // secs, nanos
-    Date(i64),          // timestamp
-    Identifier(String),
-    Boolean(bool),
-    Infix { left: Box<Expression>, operator: Token, right: Box<Expression> },
-    Call { 
-        function: String, 
+    Integer(i64, Span),
+    Float(f64, Span),
+    String(String, Span),
+    Duration(u64, u32, Span),
+    Date(i64, Span),
+    Identifier(String, Span),
+    Boolean(bool, Span),
+    Infix { left: Box<Expression>, operator: Token, right: Box<Expression>, span: Span },
+    Call {
+        function: String,
         generic_args: Vec<String>,
         arguments: Vec<Expression>,
-        line: usize,
-        col: usize,
+        span: Span,
     },
-    StructInst { 
-        name: String, 
+    StructInst {
+        name: String,
         generic_args: Vec<String>,
-        fields: Vec<(String, Expression)> 
+        fields: Vec<(String, Expression)>,
+        span: Span,
     },
-    Range { start: Box<Expression>, end: Box<Expression> },
-    Block { statements: Vec<Statement>, is_unsafe: bool },
-    If { condition: Box<Expression>, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>> },
-    Deref { expr: Box<Expression> },
-    Cast { expr: Box<Expression>, target: String },
-    Intrinsic { name: String, arguments: Vec<Expression> },
-    EnumInst { 
-        name: String, 
+    Range { start: Box<Expression>, end: Box<Expression>, span: Span },
+    Block { statements: Vec<Statement>, is_unsafe: bool, span: Span },
+    If { condition: Box<Expression>, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>>, span: Span },
+    Deref { expr: Box<Expression>, span: Span },
+    Cast { expr: Box<Expression>, target: String, span: Span },
+    Intrinsic { name: String, arguments: Vec<Expression>, span: Span },
+    EnumInst {
+        name: String,
         variant: String,
         generic_args: Vec<String>,
-        arguments: Vec<Expression> 
+        arguments: Vec<Expression>,
+        span: Span,
     },
     MemberAccess {
         receiver: Box<Expression>,
         member: String,
+        span: Span,
     },
     MethodCall {
         receiver: Box<Expression>,
         method: String,
         generic_args: Vec<String>,
         arguments: Vec<Expression>,
-        line: usize,
-        col: usize,
+        span: Span,
     },
     TypeRef {
         name: String,
         generic_args: Vec<String>,
+        span: Span,
     },
 }
 
 impl Expression {
-    pub fn span(&self) -> (usize, usize) {
+    pub fn span(&self) -> Span {
         match self {
-            Expression::Infix { operator, .. } => (operator.line, operator.col),
-            Expression::Call { line, col, .. } => (*line, *col),
-            Expression::MethodCall { line, col, .. } => (*line, *col),
-            _ => (0, 0),
+            Expression::Integer(_, s)
+            | Expression::Float(_, s)
+            | Expression::String(_, s)
+            | Expression::Duration(_, _, s)
+            | Expression::Date(_, s)
+            | Expression::Identifier(_, s)
+            | Expression::Boolean(_, s)
+            | Expression::Infix { span: s, .. }
+            | Expression::Call { span: s, .. }
+            | Expression::StructInst { span: s, .. }
+            | Expression::Range { span: s, .. }
+            | Expression::Block { span: s, .. }
+            | Expression::If { span: s, .. }
+            | Expression::Deref { span: s, .. }
+            | Expression::Cast { span: s, .. }
+            | Expression::Intrinsic { span: s, .. }
+            | Expression::EnumInst { span: s, .. }
+            | Expression::MemberAccess { span: s, .. }
+            | Expression::MethodCall { span: s, .. }
+            | Expression::TypeRef { span: s, .. } => *s,
         }
     }
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Statement, Expression, Program, Declaration};
+use crate::ast::{Span, Statement, Expression, Program, Declaration};
 use crate::types::Type;
 use crate::environment::Environment;
 use crate::token::{Token, TokenKind};
@@ -40,8 +40,8 @@ impl TypeChecker {
     }
 
     fn err(&self, msg: impl Into<String>, expr: &Expression) -> CompileError {
-        let (line, col) = expr.span();
-        CompileError::new(msg, line, col).with_snippet(&self.source)
+        let span = expr.span();
+        CompileError::new(msg, span.line, span.col).with_snippet(&self.source)
     }
 
     fn resolve_type(&self, name: &str) -> Type {
@@ -200,30 +200,30 @@ impl TypeChecker {
                 self.env.set(name.clone(), val_type);
                 Ok(Type::Unit)
             },
-            Statement::Assignment { target, value } => {
+            Statement::Assignment { target, value, .. } => {
                 self.check_expression(target)?;
                 self.check_expression(value)?;
                 Ok(Type::Unit)
             },
             Statement::Return { value, .. } => { self.check_expression(value)?; Ok(Type::Unit) },
-            Statement::ExpressionStmt(expr) => self.check_expression(expr),
-            Statement::If { condition, then_branch, else_branch } => {
+            Statement::ExpressionStmt(expr, _) => self.check_expression(expr),
+            Statement::If { condition, then_branch, else_branch, .. } => {
                 self.check_expression(condition)?;
                 for s in then_branch { self.check_statement(s)?; }
                 if let Some(eb) = else_branch { for s in eb { self.check_statement(s)?; } }
                 Ok(Type::Unit)
             },
-            Statement::While { condition, body } => {
+            Statement::While { condition, body, .. } => {
                 self.check_expression(condition)?;
                 for s in body { self.check_statement(s)?; }
                 Ok(Type::Unit)
             },
-            Statement::UnsafeBlock(body) => {
+            Statement::UnsafeBlock(body, _) => {
                 let was = self.in_unsafe_context; self.in_unsafe_context = true;
                 for s in body { self.check_statement(s)?; }
                 self.in_unsafe_context = was; Ok(Type::Unit)
             },
-            Statement::Match { condition, arms } => {
+            Statement::Match { condition, arms, .. } => {
                 let cond_type = self.check_expression(condition)?;
                 let cond_name = match &cond_type {
                     Type::Enum { name } => name.clone(),
@@ -294,21 +294,21 @@ impl TypeChecker {
 
     fn check_expression(&mut self, expr: &Expression) -> Result<Type, CompileError> {
         match expr {
-            Expression::Integer(_) => Ok(Type::Integer),
-            Expression::Float(_) => Ok(Type::Float),
-            Expression::Boolean(_) => Ok(Type::Boolean),
-            Expression::String(_) => Ok(Type::String),
-            Expression::Duration(_, _) => Ok(Type::Duration),
-            Expression::Date(_) => Ok(Type::Date),
-            Expression::TypeRef { name, generic_args } => {
+            Expression::Integer(..) => Ok(Type::Integer),
+            Expression::Float(..) => Ok(Type::Float),
+            Expression::Boolean(..) => Ok(Type::Boolean),
+            Expression::String(..) => Ok(Type::String),
+            Expression::Duration(..) => Ok(Type::Duration),
+            Expression::Date(..) => Ok(Type::Date),
+            Expression::TypeRef { name, generic_args, .. } => {
                 let mut ga = Vec::new();
                 for arg in generic_args { ga.push(self.env.get(arg).unwrap_or(Type::Unknown)); }
                 Ok(Type::GenericInstance(name.clone(), ga))
             },
-            Expression::Identifier(name) => {
+            Expression::Identifier(name, _) => {
                 if let Some(t) = self.env.get(name) { return Ok(t); }
                 if let Some((var, field)) = name.split_once('.')
-                    && let Ok(rt) = self.check_expression(&Expression::Identifier(var.to_string())) {
+                    && let Ok(rt) = self.check_expression(&Expression::Identifier(var.to_string(), Span::zero())) {
                         let tn = match rt { Type::GenericInstance(n, _) | Type::Struct { name: n } => n, _ => "".to_string() };
                         if !tn.is_empty() {
                             let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
@@ -317,15 +317,16 @@ impl TypeChecker {
                     }
                 Ok(Type::Unknown)
             },
-            Expression::Infix { left, operator, right } => {
+            Expression::Infix { left, operator, right, .. } => {
                 let t1 = self.check_expression(left)?;
                 let t2 = self.check_expression(right)?;
                 self.check_compatibility(t1, t2, operator)
             },
-            Expression::Call { function, arguments, line, col, .. } => {
-                let call_expr = Expression::Call { function: function.clone(), generic_args: vec![], arguments: arguments.clone(), line: *line, col: *col };
+            Expression::Call { function, arguments, .. } => {
+                let span = expr.span();
+                let call_expr = Expression::Call { function: function.clone(), generic_args: vec![], arguments: arguments.clone(), span };
                 if let Some((receiver_name, method_name)) = function.rsplit_once('.') {
-                    let receiver_expr = Expression::Identifier(receiver_name.to_string());
+                    let receiver_expr = Expression::Identifier(receiver_name.to_string(), Span::zero());
                     if let Ok(rt) = self.check_expression(&receiver_expr) {
                         let mut is_ptr = false;
                         if let Type::Pointer(_) = rt { is_ptr = true; }
@@ -368,16 +369,16 @@ impl TypeChecker {
                     Ok(*return_type.clone())
                 } else { Err(self.err(format!("'{}' is not a function", function), &call_expr)) }
             },
-            Expression::MemberAccess { receiver, member } => {
+            Expression::MemberAccess { receiver, member, .. } => {
                 let rt = self.check_expression(receiver)?;
-                let (line, col) = receiver.span();
-                let tn = match rt { Type::GenericInstance(ref n, _) | Type::Struct { name: ref n } => n.clone(), _ => return Err(CompileError::new(format!("member access on {:?}", rt), line, col).with_snippet(&self.source)) };
+                let span = receiver.span();
+                let tn = match rt { Type::GenericInstance(ref n, _) | Type::Struct { name: ref n } => n.clone(), _ => return Err(CompileError::new(format!("member access on {:?}", rt), span.line, span.col).with_snippet(&self.source)) };
                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
                 self.env.get(&format!("{}.{}", full, member))
-                    .ok_or_else(|| CompileError::new(format!("field '{}' not found on struct '{}'", member, full), line, col).with_snippet(&self.source))
+                    .ok_or_else(|| CompileError::new(format!("field '{}' not found on struct '{}'", member, full), span.line, span.col).with_snippet(&self.source))
             },
-            Expression::MethodCall { receiver, method, generic_args: _, arguments, line, col } => {
-                let method_expr = Expression::MethodCall { receiver: receiver.clone(), method: method.clone(), generic_args: vec![], arguments: arguments.clone(), line: *line, col: *col };
+            Expression::MethodCall { receiver, method, generic_args: _, arguments, .. } => {
+                let method_expr = Expression::MethodCall { receiver: receiver.clone(), method: method.clone(), generic_args: vec![], arguments: arguments.clone(), span: expr.span() };
                 let rt = self.check_expression(receiver)?;
                 
                 // Special case for Pointer.offset()
@@ -418,15 +419,15 @@ impl TypeChecker {
                 let full = self.resolve_fuzzy_name(&self.decls, name).unwrap_or(name.clone());
                 Ok(Type::Enum { name: full })
             },
-            Expression::Deref { expr } => {
+            Expression::Deref { expr, .. } => {
                 let rt = self.check_expression(expr)?;
                 if let Type::Pointer(t) = rt { Ok(*t) } else { Ok(Type::Integer) }
             },
-            Expression::Intrinsic { name, arguments } => {
+            Expression::Intrinsic { name, arguments, .. } => {
                 let mut actual_name = name.clone();
                 let mut args = arguments.as_slice();
                 if name == "intrinsic" && !arguments.is_empty()
-                    && let Expression::String(s) = &arguments[0] {
+                    && let Expression::String(s, _) = &arguments[0] {
                         actual_name = s.clone();
                         args = &arguments[1..];
                     }
@@ -438,14 +439,14 @@ impl TypeChecker {
                 else if actual_name.starts_with("ai_tensor_") { Ok(Type::Struct { name: "std.ai.tensor.Tensor".to_string() }) }
                 else { Ok(Type::Integer) }
             },
-            Expression::If { condition, then_branch, else_branch } => {
+            Expression::If { condition, then_branch, else_branch, .. } => {
                 self.check_expression(condition)?;
                 let mut lt = Type::Unit;
                 for s in then_branch { lt = self.check_statement(s)?; }
                 if let Some(eb) = else_branch { for s in eb { self.check_statement(s)?; } }
                 Ok(lt)
             },
-            Expression::Block { statements, is_unsafe } => {
+            Expression::Block { statements, is_unsafe, .. } => {
                 let was = self.in_unsafe_context;
                 if *is_unsafe { self.in_unsafe_context = true; }
                 let mut lt = Type::Unit;

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -48,44 +48,13 @@ impl TypeChecker {
         if let Some(t) = self.type_params.get(name) {
             return t.clone();
         }
-        
         let trimmed = name.trim();
-        if let Some(stripped) = trimmed.strip_prefix('*') {
-            return Type::Pointer(Box::new(self.resolve_type(stripped.trim())));
+        if let Some(t) = self.env.get(trimmed) { return t; }
+        if let Some(ref module) = self.current_module {
+            let full_name = format!("{}.{}", module, trimmed);
+            if let Some(t) = self.env.get(&full_name) { return t; }
         }
-
-        match trimmed {
-            "i64" | "u64" | "i32" | "u32" | "i8" | "u8" => Type::Integer,
-            "f64" => Type::Float,
-            "bool" => Type::Boolean,
-            "String" => Type::String,
-            "Date" => Type::Date,
-            "Duration" => Type::Duration,
-            "void" | "Unit" => Type::Unit,
-            _ => {
-                if let Some(t) = self.env.get(trimmed) { return t; }
-                if let Some(ref module) = self.current_module {
-                    let full_name = format!("{}.{}", module, trimmed);
-                    if let Some(t) = self.env.get(&full_name) { return t; }
-                }
-                if trimmed.contains('<') && trimmed.ends_with('>') {
-                    if let Some(start) = trimmed.find('<') {
-                        let base = trimmed[..start].to_string();
-                        let args_str = &trimmed[start+1..trimmed.len()-1];
-                        let mut ga = Vec::new();
-                        // Simple split by comma (doesn't handle nested generics perfectly, but sufficient for Phase 1)
-                        for part in args_str.split(',') {
-                            let pt = part.trim().to_string();
-                            if !pt.is_empty() {
-                                ga.push(self.resolve_type(&pt));
-                            }
-                        }
-                        return Type::GenericInstance(base, ga);
-                    }
-                }
-                Type::Placeholder(trimmed.to_string())
-            }
-        }
+        Type::from_str(trimmed)
     }
 
     fn register_builtins(&mut self) {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -96,15 +96,17 @@ impl<'ctx> Compiler<'ctx> {
     }
 
     fn aion_type_to_llvm(&self, tn: &str) -> BasicTypeEnum<'ctx> {
-        let clean = tn.replace(" ", ""); 
-        if clean.starts_with('*') || clean == "ptr" || clean == "String" { 
-            return self.context.ptr_type(AddressSpace::default()).into(); 
-        }
-        match clean.as_str() {
-            "i64" | "u64" | "Integer" | "bool" | "Boolean" | "Date" | "Duration" | "void" | "Unit" => self.context.i64_type().into(),
-            "i32" | "u32" => self.context.i32_type().into(), 
-            "i8" | "u8" => self.context.i8_type().into(), 
-            "f64" | "Float" => self.context.f64_type().into(),
+        self.type_to_llvm(&crate::types::Type::from_str(tn))
+    }
+
+    fn type_to_llvm(&self, ty: &crate::types::Type) -> BasicTypeEnum<'ctx> {
+        use crate::types::Type;
+        match ty {
+            Type::Integer | Type::Boolean | Type::Date | Type::Duration | Type::Unit => self.context.i64_type().into(),
+            Type::Float => self.context.f64_type().into(),
+            Type::String | Type::Pointer(_) | Type::Enum { .. } | Type::Struct { .. } | Type::GenericInstance(..) => {
+                self.context.ptr_type(AddressSpace::default()).into()
+            }
             _ => self.context.ptr_type(AddressSpace::default()).into(),
         }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -48,8 +48,8 @@ impl<'ctx> Compiler<'ctx> {
     }
 
     fn err(&self, msg: impl Into<String>, expr: &Expression) -> CompileError {
-        let (line, col) = expr.span();
-        CompileError::new(msg, line, col).with_snippet(&self.source)
+        let span = expr.span();
+        CompileError::new(msg, span.line, span.col).with_snippet(&self.source)
     }
 
     fn register_builtins(&mut self) {
@@ -113,18 +113,18 @@ impl<'ctx> Compiler<'ctx> {
         for s in b.iter_mut() {
             match s {
                 Statement::Let { value, .. } => self.substitute_types_in_expr(value, ph, conc),
-                Statement::Assignment { target, value } => { 
+                Statement::Assignment { target, value, .. } => { 
                     self.substitute_types_in_expr(target, ph, conc); 
                     self.substitute_types_in_expr(value, ph, conc); 
                 },
                 Statement::Return { value, .. } => self.substitute_types_in_expr(value, ph, conc),
-                Statement::ExpressionStmt(e) => self.substitute_types_in_expr(e, ph, conc),
-                Statement::If { condition, then_branch, else_branch } => { 
+                Statement::ExpressionStmt(e, _) => self.substitute_types_in_expr(e, ph, conc),
+                Statement::If { condition, then_branch, else_branch, .. } => { 
                     self.substitute_types_in_expr(condition, ph, conc); 
                     self.substitute_types_in_body(then_branch, ph, conc); 
                     if let Some(eb) = else_branch { self.substitute_types_in_body(eb, ph, conc); } 
                 },
-                Statement::While { condition, body } => { 
+                Statement::While { condition, body, .. } => { 
                     self.substitute_types_in_expr(condition, ph, conc); 
                     self.substitute_types_in_body(body, ph, conc); 
                 },
@@ -132,8 +132,8 @@ impl<'ctx> Compiler<'ctx> {
                     self.substitute_types_in_expr(range, ph, conc); 
                     self.substitute_types_in_body(body, ph, conc); 
                 },
-                Statement::UnsafeBlock(stmts) | Statement::Spawn(stmts) => self.substitute_types_in_body(stmts, ph, conc),
-                Statement::Match { condition, arms } => { 
+                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => self.substitute_types_in_body(stmts, ph, conc),
+                Statement::Match { condition, arms, .. } => { 
                     self.substitute_types_in_expr(condition, ph, conc); 
                     for arm in arms { self.substitute_types_in_body(&mut arm.body, ph, conc); } 
                 },
@@ -169,16 +169,16 @@ impl<'ctx> Compiler<'ctx> {
                 } 
                 for (_, val) in fields { self.substitute_types_in_expr(val, ph, conc); } 
             },
-            Expression::Cast { expr, target } => { 
+            Expression::Cast { expr, target, .. } => { 
                 self.substitute_types_in_expr(expr, ph, conc); 
                 for i in 0..ph.len() { *target = target.replace(&ph[i], &conc[i]); } 
             },
-            Expression::Deref { expr } => self.substitute_types_in_expr(expr, ph, conc),
+            Expression::Deref { expr, .. } => self.substitute_types_in_expr(expr, ph, conc),
             Expression::Intrinsic { arguments, .. } => { 
                 for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); } 
             },
             Expression::Block { statements, .. } => self.substitute_types_in_body(statements, ph, conc),
-            Expression::Identifier(n) => { 
+            Expression::Identifier(n, _) => { 
                 for i in 0..ph.len() { *n = n.replace(&ph[i], &conc[i]); } 
             },
             Expression::MemberAccess { receiver, .. } => self.substitute_types_in_expr(receiver, ph, conc),
@@ -439,7 +439,7 @@ impl<'ctx> Compiler<'ctx> {
                     variables.insert(name.clone(), (a, vt, vtn));
                     lv = None;
                 },
-                Statement::Assignment { target, value } => { 
+                Statement::Assignment { target, value, .. } => { 
                     let (ptr, tt) = self.compile_lvalue(target, variables, function)?; 
                     let mut v = self.compile_expr(value, variables, function)?; 
                     if tt.is_struct_type() && v.get_type().is_pointer_type() { 
@@ -465,7 +465,7 @@ impl<'ctx> Compiler<'ctx> {
                     } 
                     lv = Some(v); 
                 },
-                Statement::If { condition, then_branch, else_branch } => {
+                Statement::If { condition, then_branch, else_branch, .. } => {
                     let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
                     let comp = self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "ifcond")?;
                     let tb = self.context.append_basic_block(function, "then"); 
@@ -519,7 +519,7 @@ impl<'ctx> Compiler<'ctx> {
                         lv = None; 
                     }
                 },
-                Statement::While { condition, body } => {
+                Statement::While { condition, body, .. } => {
                     let cb = self.context.append_basic_block(function, "while_cond"); 
                     let bb = self.context.append_basic_block(function, "while_body"); 
                     let eb = self.context.append_basic_block(function, "while_exit");
@@ -536,7 +536,7 @@ impl<'ctx> Compiler<'ctx> {
                     self.builder.position_at_end(eb); 
                     lv = None;
                 },
-                Statement::Match { condition, arms } => {
+                Statement::Match { condition, arms, .. } => {
                     let cv = self.compile_expr(condition, variables, function)?; 
                     let exit_bb = self.context.append_basic_block(function, "matchexit"); 
                     let mut phis = Vec::new();
@@ -784,8 +784,8 @@ impl<'ctx> Compiler<'ctx> {
                         }
                     } else { lv = None; }
                 },
-                Statement::ExpressionStmt(e) => { lv = Some(self.compile_expr(e, variables, function)?); },
-                Statement::UnsafeBlock(stmts) | Statement::Spawn(stmts) => { lv = self.compile_block(stmts, variables, function)?; },
+                Statement::ExpressionStmt(e, _) => { lv = Some(self.compile_expr(e, variables, function)?); },
+                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => { lv = self.compile_block(stmts, variables, function)?; },
                 _ => { lv = None; }
             }
         }
@@ -795,7 +795,7 @@ impl<'ctx> Compiler<'ctx> {
     fn compile_lvalue(&mut self, e: &Expression, variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>, function: FunctionValue<'ctx>) -> Result<(PointerValue<'ctx>, BasicTypeEnum<'ctx>), CompileError> {
         let pt = self.context.ptr_type(AddressSpace::default());
         match e {
-            Expression::Identifier(name) => {
+            Expression::Identifier(name, _) => {
                 if let Some((vn, fnm)) = name.split_once('.') { 
                     if let Some((vptr, vt, vtn)) = variables.get(vn) { 
                         let btn = if vtn.contains('<') { vtn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))? } else { vtn }; 
@@ -811,7 +811,7 @@ impl<'ctx> Compiler<'ctx> {
                 }
                 if let Some((ptr, vt, _)) = variables.get(name) { Ok((*ptr, *vt)) } else { Err(self.err(format!("variable '{}' not found", name), e)) }
             },
-            Expression::MemberAccess { receiver, member } => {
+            Expression::MemberAccess { receiver, member, .. } => {
                 let (rp, rt_llvm) = self.compile_lvalue(receiver, variables, function)?; 
                 let rtn = self.get_expr_type_name(receiver, variables); 
                 let ftn = self.get_field_type(&rtn, member);
@@ -824,7 +824,7 @@ impl<'ctx> Compiler<'ctx> {
                 let st_ptr = self.builder.build_load(rt_llvm, rp, "st_load")?.into_pointer_value();
                 Ok((self.builder.build_struct_gep(st, st_ptr, idx, member)?, self.aion_type_to_llvm(&ftn)))
             },
-            Expression::Deref { expr } => { 
+            Expression::Deref { expr, .. } => { 
                 let v = self.compile_expr(expr, variables, function)?; 
                 let tn = self.get_expr_type_name(expr, variables); 
                 let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" }); 
@@ -839,11 +839,11 @@ impl<'ctx> Compiler<'ctx> {
         let i64_t = self.context.i64_type(); 
         let pt = self.context.ptr_type(AddressSpace::default());
         match e {
-            Expression::Integer(n) => Ok(i64_t.const_int(*n as u64, false).into()),
-            Expression::Float(f_val) => Ok(self.context.f64_type().const_float(*f_val).into()),
-            Expression::Boolean(b) => Ok(i64_t.const_int(if *b { 1 } else { 0 }, false).into()),
-            Expression::String(s) => Ok(self.builder.build_global_string_ptr(&format!("{}\0", s), "aion_str")?.as_basic_value_enum()),
-            Expression::Identifier(name) => { 
+            Expression::Integer(n, _) => Ok(i64_t.const_int(*n as u64, false).into()),
+            Expression::Float(f_val, _) => Ok(self.context.f64_type().const_float(*f_val).into()),
+            Expression::Boolean(b, _) => Ok(i64_t.const_int(if *b { 1 } else { 0 }, false).into()),
+            Expression::String(s, _) => Ok(self.builder.build_global_string_ptr(&format!("{}\0", s), "aion_str")?.as_basic_value_enum()),
+            Expression::Identifier(name, _) => { 
                 if let Some((ptr, vt, _)) = variables.get(name) { 
                     Ok(self.builder.build_load(*vt, *ptr, name)?) 
                 } else { 
@@ -861,7 +861,7 @@ impl<'ctx> Compiler<'ctx> {
                 let mut aa = arguments.clone(); 
                 let mut is_mc = false;
                 if let Some((rn, mn)) = fnm.rsplit_once('.') {
-                     let re = Expression::Identifier(rn.to_string());
+                     let re = Expression::Identifier(rn.to_string(), Span::zero());
                      let tn = self.get_expr_type_name(&re, variables);
                      if (tn.starts_with('*') || tn.contains("ptr")) && mn == "offset" && arguments.len() == 1 {
                          let idx = self.compile_expr(&arguments[0], variables, function)?.into_int_value();
@@ -927,7 +927,7 @@ impl<'ctx> Compiler<'ctx> {
                 }?; 
                 Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
             },
-            Expression::Infix { left, operator, right } => {
+            Expression::Infix { left, operator, right, .. } => {
                 if operator.kind == TokenKind::And || operator.kind == TokenKind::Or { 
                     let lhs = self.compile_expr(left, variables, function)?; 
                     let li = match lhs { BasicValueEnum::IntValue(i) => i, _ => return Err(CompileError::Internal("Expected boolean".to_string())) }; 
@@ -958,7 +958,7 @@ impl<'ctx> Compiler<'ctx> {
 
                 // Special case for 'inside' which needs to peek at 'right' before compiling it
                 if operator.kind == TokenKind::Inside {
-                    if let Expression::Infix { left: r_left, operator: r_op, right: r_right } = &**right {
+                    if let Expression::Infix { left: r_left, operator: r_op, right: r_right, .. } = &**right {
                         if r_op.kind == TokenKind::Range {
                             let l = lhs.into_int_value();
                             let min = self.compile_expr(r_left, variables, function)?.into_int_value();
@@ -1047,7 +1047,7 @@ impl<'ctx> Compiler<'ctx> {
                 }
                 Ok(ptr.into())
             },
-            Expression::EnumInst { name, variant, arguments, generic_args } => {
+            Expression::EnumInst { name, variant, arguments, generic_args, .. } => {
                 if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, name) {
                     let et = *self.enum_types.get(&en).ok_or_else(|| CompileError::Internal(format!("Enum type '{}' not found", en)))?;
                     let pr = match self.builder.build_call(self.module.get_function("aion_malloc").ok_or_else(|| CompileError::Internal("aion_malloc not found".to_string()))?, &[et.size_of().ok_or_else(|| CompileError::Internal("Enum size unknown".to_string()))?.into()], "enum_alloc")?.try_as_basic_value() { 
@@ -1068,7 +1068,7 @@ impl<'ctx> Compiler<'ctx> {
                     }
                     Ok(pr.into())
                 } else {
-                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), line: 0, col: 0 };
+                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), span: Span::zero() };
                     self.compile_expr(&call_expr, variables, function)
                 }
             },
@@ -1118,7 +1118,7 @@ impl<'ctx> Compiler<'ctx> {
                 let call = self.builder.build_call(fv, &ca, "call")?; 
                 Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
             },
-            Expression::Cast { target, expr } => {
+            Expression::Cast { target, expr, .. } => {
                 let v = self.compile_expr(expr, variables, function)?;
                 let t_clean = target.replace(" ", "");
                 let dest = self.aion_type_to_llvm(&t_clean);
@@ -1138,14 +1138,14 @@ impl<'ctx> Compiler<'ctx> {
                     Ok(self.builder.build_bit_cast(v, dest, "cast")?)
                 }
             },
-            Expression::Deref { expr } => { 
+            Expression::Deref { expr, .. } => { 
                 let v = self.compile_expr(expr, variables, function)?; 
                 let tn = self.get_expr_type_name(expr, variables); 
                 let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" }); 
                 let p = if v.is_int_value() { self.builder.build_int_to_ptr(v.into_int_value(), pt, "i2p")? } else { v.into_pointer_value() }; 
                 Ok(self.builder.build_load(et, p, "deref")?) 
             },
-            Expression::If { condition, then_branch, else_branch } => {
+            Expression::If { condition, then_branch, else_branch, .. } => {
                 let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
                 let comp = self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "ifcond")?;
                 let tb = self.context.append_basic_block(function, "then"); 
@@ -1204,15 +1204,15 @@ impl<'ctx> Compiler<'ctx> {
                 let mut lv_vars = variables.clone(); 
                 Ok(self.compile_block(statements, &mut lv_vars, function)?.unwrap_or(i64_t.const_zero().into())) 
             },
-            Expression::Intrinsic { name, arguments } => {
+            Expression::Intrinsic { name, arguments, .. } => {
                 let mut an = name.clone(); 
                 let mut aa = arguments.clone(); 
                 if name == "intrinsic" && !arguments.is_empty() { 
-                    if let Expression::String(s) = &arguments[0] { an = s.clone(); aa.remove(0); } 
+                    if let Expression::String(s, _) = &arguments[0] { an = s.clone(); aa.remove(0); } 
                 }
                 if an == "sizeof" && !aa.is_empty() { 
                     let tnm = match &aa[0] { 
-                        Expression::Identifier(s) => s.clone(), 
+                        Expression::Identifier(s, _) => s.clone(), 
                         Expression::TypeRef { name, .. } => name.clone(), 
                         _ => "i64".to_string() 
                     }; 
@@ -1241,7 +1241,7 @@ impl<'ctx> Compiler<'ctx> {
                 if an == "mem_zero" {
                     if !aa.is_empty() {
                         let tnm = match &aa[0] { 
-                            Expression::Identifier(s) => s.clone(), 
+                            Expression::Identifier(s, _) => s.clone(), 
                             Expression::TypeRef { name, .. } => name.clone(), 
                             _ => "i64".to_string() 
                         };
@@ -1287,11 +1287,11 @@ impl<'ctx> Compiler<'ctx> {
     }
     fn get_expr_type_name(&self, e: &Expression, variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>) -> String {
         let res = match e {
-            Expression::Integer(_) => "i64".to_string(), 
-            Expression::Float(_) => "f64".to_string(), 
-            Expression::Boolean(_) => "bool".to_string(), 
-            Expression::String(_) => "String".to_string(),
-            Expression::Identifier(name) => {
+            Expression::Integer(_, _) => "i64".to_string(), 
+            Expression::Float(_, _) => "f64".to_string(), 
+            Expression::Boolean(_, _) => "bool".to_string(), 
+            Expression::String(_, _) => "String".to_string(),
+            Expression::Identifier(name, _) => {
                 let parts: Vec<&str> = name.split('.').collect();
                 if parts.len() > 1 {
                     let mut ct = if let Some((_, _, t)) = variables.get(parts[0]) { t.clone() } else { "unknown".to_string() };
@@ -1303,10 +1303,10 @@ impl<'ctx> Compiler<'ctx> {
             Expression::Call { function: name, generic_args, .. } => {
                 if let Some((rn, mn)) = name.rsplit_once('.') {
                     if mn == "offset" {
-                        let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string()), variables);
+                        let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string(), Span::zero()), variables);
                         if rt.starts_with('*') { return rt.replace(" ", ""); }
                     }
-                    let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string()), variables);
+                    let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string(), Span::zero()), variables);
                     if rt != "unknown" {
                         let (btn, tga) = if rt.contains('<') {
                             let p: Vec<&str> = rt.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect();
@@ -1331,7 +1331,7 @@ impl<'ctx> Compiler<'ctx> {
                 }
                 "unknown".to_string()
             },
-            Expression::MemberAccess { receiver, member } => { let rt = self.get_expr_type_name(receiver, variables); self.get_field_type(&rt, member) },
+            Expression::MemberAccess { receiver, member, .. } => { let rt = self.get_expr_type_name(receiver, variables); self.get_field_type(&rt, member) },
             Expression::MethodCall { receiver, method, generic_args, .. } => {
                 let rt = self.get_expr_type_name(receiver, variables); 
                 if method == "offset" && rt.starts_with('*') { return rt.clone(); }
@@ -1357,11 +1357,11 @@ impl<'ctx> Compiler<'ctx> {
                 let sn = self.resolve_fuzzy_name(&self.struct_types, name).unwrap_or(name.clone());
                 if generic_args.is_empty() { sn.replace(" ", "") } else { format!("{}<{}>", sn, generic_args.join(",")).replace(" ", "") }
             },
-            Expression::EnumInst { name, variant, arguments, generic_args } => {
+            Expression::EnumInst { name, variant, arguments, generic_args, .. } => {
                 if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, name) {
                     if generic_args.is_empty() { en.replace(" ", "") } else { format!("{}<{}>", en, generic_args.join(",")).replace(" ", "") }
                 } else {
-                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), line: 0, col: 0 };
+                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), span: Span::zero() };
                     self.get_expr_type_name(&call_expr, variables)
                 }
             },
@@ -1369,16 +1369,16 @@ impl<'ctx> Compiler<'ctx> {
             Expression::Block { statements, .. } => {
                 if let Some(s) = statements.last() {
                     match s {
-                        Statement::ExpressionStmt(e) | Statement::Return { value: e, .. } => self.get_expr_type_name(e, variables),
+                        Statement::ExpressionStmt(e, _) | Statement::Return { value: e, .. } => self.get_expr_type_name(e, variables),
                         _ => "unknown".to_string()
                     }
                 } else { "unknown".to_string() }
             },
-            Expression::Deref { expr } => {
+            Expression::Deref { expr, .. } => {
                 let t = self.get_expr_type_name(expr, variables);
                 if t.starts_with('*') { t[1..].to_string().replace(" ", "") } else { "unknown".to_string() }
             },
-            Expression::TypeRef { name, generic_args } => { if generic_args.is_empty() { name.clone() } else { format!("{}<{}>", name, generic_args.join(",")) } },
+            Expression::TypeRef { name, generic_args, .. } => { if generic_args.is_empty() { name.clone() } else { format!("{}<{}>", name, generic_args.join(",")) } },
             _ => "unknown".to_string(),
         };
         res.replace(" ", "")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,10 @@ fn process_imports(program: &mut Program, visited: &mut HashSet<PathBuf>) -> Res
         let source = fs::read_to_string(&path).map_err(|e| CompileError::Io(format!("Failed to read {:?}: {}", path, e)))?;
         let lexer = Lexer::new(&source);
         let mut parser = Parser::new(lexer);
-        let mut imported_program = parser.parse_program();
+        let mut imported_program = parser.parse_program().map_err(|e| {
+            let msgs: Vec<String> = e.iter().map(|e| e.to_string()).collect();
+            CompileError::Import(format!("Import parse errors in {:?}: {}", path, msgs.join("; ")))
+        })?;
         
         // Rename local declarations before recursion to avoid double-prefixing
         let prefix = import.path.join(".");
@@ -78,7 +81,10 @@ pub fn transpile_sql(input_path: &str) -> Result<String, CompileError> {
     let source = fs::read_to_string(input_path).map_err(|e| CompileError::Io(e.to_string()))?;
     let lexer = Lexer::new(&source);
     let mut parser = Parser::new(lexer);
-    let program = parser.parse_program();
+    let program = parser.parse_program().map_err(|e| CompileError::Type {
+        message: format!("Parse errors: {}", e.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")),
+        line: 0, col: 0, snippet: None,
+    })?;
     
     let mut transpiler = SqlTranspiler::new();
     Ok(transpiler.transpile(&program))
@@ -88,7 +94,10 @@ pub fn compile_file(input_path: &str, output_path: &str) -> Result<(), CompileEr
     let source = fs::read_to_string(input_path).map_err(|e| CompileError::Io(e.to_string()))?;
     let lexer = Lexer::new(&source);
     let mut parser = Parser::new(lexer);
-    let mut program = parser.parse_program();
+    let mut program = parser.parse_program().map_err(|e| CompileError::Type {
+        message: format!("Parse errors: {}", e.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")),
+        line: 0, col: 0, snippet: None,
+    })?;
 
     // 0. Resolve Imports
     let mut visited = HashSet::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,9 +55,6 @@ impl<'a> Parser<'a> {
                             self.next_token();
                         }
                     } else {
-                        // If it's not an intent, we shouldn't consume it here.
-                        // But wait, what else starts with :: at top level? Nothing yet.
-                        // For safety, let's just break if we don't know what it is or error.
                         eprintln!("{}", self.error("Syntax Error: Unexpected :: at top level"));
                         self.next_token();
                     }
@@ -338,14 +335,13 @@ impl<'a> Parser<'a> {
                     if self.current_token.kind == TokenKind::Colon {
                         self.next_token();
                         let param_type = self.parse_type_name();
-                        // Check for default value
                         if self.current_token.kind == TokenKind::Eq {
                             self.next_token();
                             default_val = Some(Box::new(self.parse_expression()));
                         }
                         params.push((p_name, param_type, default_val));
                     } else {
-                        params.push((p_name, "i64".to_string(), default_val));  // Default type i64
+                        params.push((p_name, "i64".to_string(), default_val));
                     }
                 } else {
                     self.next_token();
@@ -405,10 +401,12 @@ impl<'a> Parser<'a> {
                     }
                     Some(Statement::NoOp)
                 } else {
-                    Some(Statement::ExpressionStmt(self.parse_expression()))
+                    let span = Span::from_token(&self.current_token);
+                    Some(Statement::ExpressionStmt(self.parse_expression(), span))
                 }
             },
             TokenKind::Let => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let is_mut = if self.current_token.kind == TokenKind::Mut { self.next_token(); true } else { false };
                 let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
@@ -417,21 +415,23 @@ impl<'a> Parser<'a> {
                     self.next_token(); 
                     let value = self.parse_expression(); 
                     if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::Let { name, value, intent: None, is_mut }) 
+                    Some(Statement::Let { name, value, intent: None, is_mut, span }) 
                 } else { None }
             },
             TokenKind::Return => { 
+                let span = Span::from_token(&self.current_token);
                 self.next_token(); 
                 let value = if self.current_token.kind == TokenKind::Semicolon || self.current_token.kind == TokenKind::RBrace {
-                    Expression::Integer(0) // Return 0/void
+                    Expression::Integer(0, Span::zero())
                 } else {
                     self.parse_expression()
                 };
                 if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                let stmt = Statement::Return { value, intent: None };
+                let stmt = Statement::Return { value, intent: None, span };
                 Some(stmt)
             },
             TokenKind::If => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
                 let then_branch = self.parse_block();
@@ -445,15 +445,18 @@ impl<'a> Parser<'a> {
                     } else {
                         else_branch = Some(self.parse_block());
                     }
-                }                Some(Statement::If { condition, then_branch, else_branch })
+                }
+                Some(Statement::If { condition, then_branch, else_branch, span })
             },
             TokenKind::While => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
                 let body = self.parse_block();
-                Some(Statement::While { condition, body })
+                Some(Statement::While { condition, body, span })
             },
             TokenKind::Match => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
                 if self.current_token.kind != TokenKind::LBrace { return None; }
@@ -467,7 +470,6 @@ impl<'a> Parser<'a> {
                         TokenKind::Identifier(p) => {
                             pattern = p.clone(); 
                             self.next_token();
-                            // Check for struct pattern: Point { x: a, y: b }
                             let mut struct_fields: Vec<(String, String)> = Vec::new();
                             if self.current_token.kind == TokenKind::LBrace {
                                 self.next_token();
@@ -513,7 +515,6 @@ impl<'a> Parser<'a> {
                         TokenKind::IntLiteral(n) => {
                             pattern = n.to_string();
                             self.next_token();
-                            // Check if this is a range pattern (e.g., 1..5)
                             if self.current_token.kind == TokenKind::Range {
                                 self.next_token();
                                 if let TokenKind::IntLiteral(end_n) = &self.current_token.kind {
@@ -529,17 +530,14 @@ impl<'a> Parser<'a> {
                             is_valid_pattern = true;
                         },
                         TokenKind::Range => {
-                            // This shouldn't happen here - ranges are handled in expression parsing
                             self.next_token();
                         },
                         _ => {
-                            // Skip unexpected token to avoid infinite loop
                             self.next_token();
                         }
                     }
 
                     if is_valid_pattern {
-                        // Support multiple patterns with |
                         let mut patterns = vec![pattern.clone()];
                         while self.current_token.kind == TokenKind::Pipe {
                             self.next_token();
@@ -553,8 +551,6 @@ impl<'a> Parser<'a> {
                         
                         let mut params = Vec::new();
                         
-                        // If pattern is a lowercase identifier and followed by guard or arrow,
-                        // treat it as a binding variable (not a pattern to match)
                         if patterns.len() == 1 {
                             let pat = &patterns[0];
                             let is_lower = !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
@@ -582,7 +578,6 @@ impl<'a> Parser<'a> {
                             if self.current_token.kind == TokenKind::RParen { self.next_token(); }
                         }
 
-                        // Parse guard (if condition)
                         let guard = if self.current_token.kind == TokenKind::If {
                             self.next_token();
                             Some(Box::new(self.parse_expression()))
@@ -604,34 +599,37 @@ impl<'a> Parser<'a> {
                     if self.current_token.kind == TokenKind::Comma { self.next_token(); }
                 }
                 if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-                Some(Statement::Match { condition, arms })
+                Some(Statement::Match { condition, arms, span })
             },
             TokenKind::Unsafe => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if self.current_token.kind == TokenKind::LBrace {
-                    Some(Statement::UnsafeBlock(self.parse_block()))
+                    Some(Statement::UnsafeBlock(self.parse_block(), span))
                 } else {
                     None
                 }
             },
             TokenKind::Spawn => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if self.current_token.kind == TokenKind::LBrace {
-                    Some(Statement::Spawn(self.parse_block()))
+                    Some(Statement::Spawn(self.parse_block(), span))
                 } else {
                     None
                 }
             },
             _ => {
+                let span = Span::from_token(&self.current_token);
                 let expr = self.parse_expression();
                 if self.current_token.kind == TokenKind::Eq {
                     self.next_token();
                     let value = self.parse_expression();
                     if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::Assignment { target: expr, value })
+                    Some(Statement::Assignment { target: expr, value, span })
                 } else {
                     if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::ExpressionStmt(expr))
+                    Some(Statement::ExpressionStmt(expr, span))
                 }
             },
         }
@@ -651,7 +649,7 @@ impl<'a> Parser<'a> {
                 
             if op.kind == TokenKind::As {
                 let target = self.parse_type_name();
-                left = Expression::Cast { expr: Box::new(left), target };
+                left = Expression::Cast { expr: Box::new(left), target, span: Span::from_token(&op) };
                 continue;
             }
 
@@ -660,16 +658,20 @@ impl<'a> Parser<'a> {
                 left = match right {
                     Expression::Call { function, mut arguments, generic_args, .. } => {
                         arguments.insert(0, left);
-                        Expression::Call { function, generic_args, arguments, line: op.line, col: op.col }
+                        Expression::Call { function, generic_args, arguments, span: Span::from_token(&op) }
                     },
-                    Expression::Identifier(function) => {
-                        Expression::Call { function, generic_args: vec![], arguments: vec![left], line: op.line, col: op.col }
+                    Expression::Identifier(function, _) => {
+                        Expression::Call { function, generic_args: vec![], arguments: vec![left], span: Span::from_token(&op) }
                     },
-                    _ => Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right) }
+                    _ => {
+                        let op_span = Span::from_token(&op);
+                        Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right), span: op_span }
+                    }
                 };
             } else {
                 let right = self.parse_infix(op_prec);
-                left = Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right) };
+                let op_span = Span::from_token(&op);
+                left = Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right), span: op_span };
             }
         }
         left
@@ -711,7 +713,6 @@ impl<'a> Parser<'a> {
             true
         }
     
-    
 
     fn parse_generic_args(&mut self) -> Vec<String> {
         let mut args = Vec::new();
@@ -734,6 +735,7 @@ impl<'a> Parser<'a> {
     fn parse_primary(&mut self) -> Expression {
         let mut expr = match self.current_token.clone().kind {
             TokenKind::If => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
                 let then_branch = self.parse_block();
@@ -747,26 +749,32 @@ impl<'a> Parser<'a> {
                     } else {
                         else_branch = Some(self.parse_block());
                     }
-                }                Expression::If { condition: Box::new(condition), then_branch, else_branch }
+                }
+                Expression::If { condition: Box::new(condition), then_branch, else_branch, span }
             },
             TokenKind::LBrace => {
-                Expression::Block { statements: self.parse_block(), is_unsafe: false }
+                let span = Span::from_token(&self.current_token);
+                Expression::Block { statements: self.parse_block(), is_unsafe: false, span }
             },
             TokenKind::SelfToken => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
-                Expression::Identifier("self".to_string())
+                Expression::Identifier("self".to_string(), span)
             },
             TokenKind::Star => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
-                Expression::Deref { expr: Box::new(self.parse_primary()) }
+                Expression::Deref { expr: Box::new(self.parse_primary()), span }
             },
             TokenKind::Bang => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let inner = self.parse_primary();
                 Expression::Infix { 
                     left: Box::new(inner),
                     operator: Token::new(TokenKind::EqEq, self.current_token.line, self.current_token.col),
-                    right: Box::new(Expression::Boolean(false)) 
+                    right: Box::new(Expression::Boolean(false, Span::zero())),
+                    span,
                 }
             },
             TokenKind::LParen => {
@@ -775,31 +783,66 @@ impl<'a> Parser<'a> {
                 if self.current_token.kind == TokenKind::RParen { self.next_token(); }
                 e
             },
-            TokenKind::True => { self.next_token(); Expression::Boolean(true) },
-            TokenKind::False => { self.next_token(); Expression::Boolean(false) },
+            TokenKind::True => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Boolean(true, span)
+            },
+            TokenKind::False => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Boolean(false, span)
+            },
             TokenKind::Minus => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if let TokenKind::IntLiteral(n) = self.current_token.clone().kind {
                     self.next_token();
-                    Expression::Integer(-n)
+                    Expression::Integer(-n, span)
                 } else if let TokenKind::FloatLiteral(f) = self.current_token.clone().kind {
                     self.next_token();
-                    Expression::Float(-f)
+                    Expression::Float(-f, span)
                 } else {
                     Expression::Infix {
-                        left: Box::new(Expression::Integer(0)),
+                        left: Box::new(Expression::Integer(0, Span::zero())),
                         operator: Token::new(TokenKind::Minus, self.current_token.line, self.current_token.col),
-                        right: Box::new(self.parse_primary())
+                        right: Box::new(self.parse_primary()),
+                        span,
                     }
                 }
             },
-            TokenKind::IntLiteral(n) => { self.next_token(); Expression::Integer(n) },
-            TokenKind::FloatLiteral(f) => { self.next_token(); Expression::Float(f) },
-            TokenKind::StringLiteral(s) => { self.next_token(); Expression::String(s) },
-            TokenKind::FString(s) => { self.next_token(); self.parse_fstring(s) },
-            TokenKind::DurationLiteral(s, n) => { self.next_token(); Expression::Duration(s, n) },
-            TokenKind::DateLiteral(ts) => { self.next_token(); Expression::Date(ts) },
+            TokenKind::IntLiteral(n) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Integer(n, span)
+            },
+            TokenKind::FloatLiteral(f) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Float(f, span)
+            },
+            TokenKind::StringLiteral(s) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::String(s, span)
+            },
+            TokenKind::FString(s) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                self.parse_fstring(s, span)
+            },
+            TokenKind::DurationLiteral(s, n) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Duration(s, n, span)
+            },
+            TokenKind::DateLiteral(ts) => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Expression::Date(ts, span)
+            },
             TokenKind::At => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if let TokenKind::Identifier(name) = self.current_token.clone().kind {
                     self.next_token();
@@ -811,23 +854,25 @@ impl<'a> Parser<'a> {
                             if self.current_token.kind == TokenKind::Comma { self.next_token(); }
                         }
                         if self.current_token.kind == TokenKind::RParen { self.next_token(); }
-                        Expression::Intrinsic { name, arguments: args }
+                        Expression::Intrinsic { name, arguments: args, span }
                     } else {
-                        Expression::Identifier(format!("invalid_attribute_{}", name))
+                        Expression::Identifier(format!("invalid_attribute_{}", name), span)
                     }
                 } else {
-                    Expression::Identifier("invalid_at_usage".to_string())
+                    Expression::Identifier("invalid_at_usage".to_string(), span)
                 }
             },
             TokenKind::Unsafe => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if self.current_token.kind == TokenKind::LBrace {
-                    Expression::Block { statements: self.parse_block(), is_unsafe: true }
+                    Expression::Block { statements: self.parse_block(), is_unsafe: true, span }
                 } else {
-                    Expression::Identifier("invalid_unsafe_usage".to_string())
+                    Expression::Identifier("invalid_unsafe_usage".to_string(), span)
                 }
             },
             TokenKind::Identifier(n) => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let mut full_name = n;
                 while self.current_token.kind == TokenKind::Dot {
@@ -840,23 +885,23 @@ impl<'a> Parser<'a> {
                 }
                 let generic_args = self.parse_generic_args();
                 if generic_args.is_empty() {
-                    Expression::Identifier(full_name)
+                    Expression::Identifier(full_name, span)
                 } else {
-                    Expression::TypeRef { name: full_name, generic_args }
+                    Expression::TypeRef { name: full_name, generic_args, span }
                 }
             },
             _ => { 
+                let span = Span::from_token(&self.current_token);
                 let tok = self.current_token.clone();
                 self.next_token(); 
-                Expression::Identifier(format!("invalid_token_{:?}", tok)) 
+                Expression::Identifier(format!("invalid_token_{:?}", tok), span)
             },
         };
 
         loop {
             match self.current_token.kind {
                 TokenKind::Dot => {
-                    let dot_line = self.current_token.line;
-                    let dot_col = self.current_token.col;
+                    let dot_span = Span::from_token(&self.current_token);
                     self.next_token();
                     if let TokenKind::Identifier(member) = self.current_token.clone().kind {
                         let member_name = member;
@@ -876,22 +921,22 @@ impl<'a> Parser<'a> {
                                 method: member_name, 
                                 generic_args: m_generic_args, 
                                 arguments: args,
-                                line: dot_line,
-                                col: dot_col,
+                                span: dot_span,
                             };
                         } else {
-                            if let Expression::Identifier(ref name) = expr {
-                                expr = Expression::Identifier(format!("{}.{}", name, member_name));
+                            if let Expression::Identifier(ref name, _) = expr {
+                                expr = Expression::Identifier(format!("{}.{}", name, member_name), dot_span);
                             } else if let Expression::TypeRef { ref name, .. } = expr {
-                                expr = Expression::Identifier(format!("{}.{}", name, member_name));
+                                expr = Expression::Identifier(format!("{}.{}", name, member_name), dot_span);
                             } else {
-                                expr = Expression::MemberAccess { receiver: Box::new(expr.clone()), member: member_name };
+                                expr = Expression::MemberAccess { receiver: Box::new(expr.clone()), member: member_name, span: dot_span };
                             }
                         }
                     } else { break; }
                 },
                 TokenKind::DoubleColon => {
                     if self.peek_at(0).kind == TokenKind::Intent { break; }
+                    let dc_span = Span::from_token(&self.current_token);
                     self.next_token();
                     if let TokenKind::Identifier(variant) = self.current_token.clone().kind {
                         let variant_name = variant;
@@ -912,20 +957,19 @@ impl<'a> Parser<'a> {
                             if self.current_token.kind == TokenKind::RParen { self.next_token(); }
                         }
                         let (name, mut combined_generic_args) = match expr {
-                            Expression::Identifier(ref n) => (n.clone(), vec![]),
-                            Expression::TypeRef { ref name, ref generic_args } => (name.clone(), generic_args.clone()),
+                            Expression::Identifier(ref n, _) => (n.clone(), vec![]),
+                            Expression::TypeRef { ref name, ref generic_args, .. } => (name.clone(), generic_args.clone()),
                             Expression::EnumInst { ref name, ref variant, ref generic_args, .. } => {
                                 (format!("{}.{}", name, variant), generic_args.clone())
                             }
                             _ => ("unknown_enum".to_string(), vec![]),
                         };
                         combined_generic_args.extend(m_generic_args);
-                        expr = Expression::EnumInst { name, variant: variant_name, generic_args: combined_generic_args, arguments: args };
+                        expr = Expression::EnumInst { name, variant: variant_name, generic_args: combined_generic_args, arguments: args, span: dc_span };
                     } else { break; }
                 },
                 TokenKind::LParen => {
-                    let call_line = self.current_token.line;
-                    let call_col = self.current_token.col;
+                    let call_span = Span::from_token(&self.current_token);
                     self.next_token();
                     let mut args = Vec::new();
                     while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
@@ -934,14 +978,14 @@ impl<'a> Parser<'a> {
                     }
                     if self.current_token.kind == TokenKind::RParen { self.next_token(); }
                     
-                    if let Expression::Identifier(ref name) = expr {
-                        expr = Expression::Call { function: name.clone(), generic_args: vec![], arguments: args, line: call_line, col: call_col };
-                    } else if let Expression::TypeRef { ref name, ref generic_args } = expr {
-                        expr = Expression::Call { function: name.clone(), generic_args: generic_args.clone(), arguments: args, line: call_line, col: call_col };
+                    if let Expression::Identifier(ref name, _) = expr {
+                        expr = Expression::Call { function: name.clone(), generic_args: vec![], arguments: args, span: call_span };
+                    } else if let Expression::TypeRef { ref name, ref generic_args, .. } = expr {
+                        expr = Expression::Call { function: name.clone(), generic_args: generic_args.clone(), arguments: args, span: call_span };
                     } else { break; }
                 },
                 TokenKind::LBrace => {
-                    let is_type_like = matches!(expr, Expression::Identifier(_) | Expression::TypeRef { .. });
+                    let is_type_like = matches!(expr, Expression::Identifier(..) | Expression::TypeRef { .. });
                     if !is_type_like { break; }
 
                     let next_tok = self.peek_at(0);
@@ -952,6 +996,7 @@ impl<'a> Parser<'a> {
                         } else { false };
                     
                     if is_struct {
+                        let struct_span = Span::from_token(&self.current_token);
                         self.next_token();
                         let mut fields = Vec::new();
                         while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
@@ -974,19 +1019,20 @@ impl<'a> Parser<'a> {
                         }
                         if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
                         let (name, generic_args) = match expr {
-                            Expression::Identifier(ref n) => (n.clone(), vec![]),
-                            Expression::TypeRef { ref name, ref generic_args } => (name.clone(), generic_args.clone()),
+                            Expression::Identifier(ref n, _) => (n.clone(), vec![]),
+                            Expression::TypeRef { ref name, ref generic_args, .. } => (name.clone(), generic_args.clone()),
                             _ => ("unknown_struct".to_string(), vec![]),
                         };
-                        expr = Expression::StructInst { name, generic_args, fields };
+                        expr = Expression::StructInst { name, generic_args, fields, span: struct_span };
                     } else { break; }
                 },
                 TokenKind::Lt => {
-                    if let Expression::Identifier(ref name) = expr {
+                    if let Expression::Identifier(ref name, _) = expr {
                         let n = name.clone();
+                        let ident_span = expr.span();
                         let generic_args = self.parse_generic_args();
                         if !generic_args.is_empty() {
-                            expr = Expression::TypeRef { name: n, generic_args };
+                            expr = Expression::TypeRef { name: n, generic_args, span: ident_span };
                         } else { break; }
                     } else { break; }
                 },
@@ -996,8 +1042,8 @@ impl<'a> Parser<'a> {
         expr
     }
 
-    fn parse_fstring(&mut self, s: String) -> Expression {
-        Expression::String(s)
+    fn parse_fstring(&mut self, s: String, span: Span) -> Expression {
+        Expression::String(s, span)
     }
 }
 
@@ -1013,7 +1059,7 @@ mod tests {
         let mut parser = Parser::new(lexer);
         let expr = parser.parse_expression();
         
-        if let Expression::Infix { left: _, operator, right } = expr {
+        if let Expression::Infix { left: _, operator, right, .. } = expr {
             assert_eq!(operator.kind, TokenKind::Plus);
             assert!(matches!(*right, Expression::Infix { .. }), "Expected right to be an infix expression");
             if let Expression::Infix { operator: op2, .. } = *right {
@@ -1026,7 +1072,6 @@ mod tests {
 
     #[test]
     fn test_parse_method_call() {
-        // Use Vector.new().len() to force MethodCall
         let input = "Vector.new().len()";
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,17 +1,19 @@
 use crate::token::{Token, TokenKind};
 use crate::lexer::Lexer;
 use crate::ast::*;
+use crate::error::CompileError;
 
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
     current_token: Token,
     peek_buffer: Vec<Token>,
+    errors: Vec<CompileError>,
 }
 
 impl<'a> Parser<'a> {
     pub fn new(mut lexer: Lexer<'a>) -> Self {
         let current_token = lexer.next_token();
-        Self { lexer, current_token, peek_buffer: Vec::new() }
+        Self { lexer, current_token, peek_buffer: Vec::new(), errors: Vec::new() }
     }
 
     fn next_token(&mut self) {
@@ -26,6 +28,15 @@ impl<'a> Parser<'a> {
         format!("{} at line {}, col {}", message, self.current_token.line, self.current_token.col)
     }
 
+    fn push_error(&mut self, message: impl Into<String>) {
+        self.errors.push(CompileError::Type {
+            message: message.into(),
+            line: self.current_token.line,
+            col: self.current_token.col,
+            snippet: None,
+        });
+    }
+
     fn peek_at(&mut self, n: usize) -> Token {
         while self.peek_buffer.len() <= n {
             self.peek_buffer.push(self.lexer.next_token());
@@ -33,7 +44,7 @@ impl<'a> Parser<'a> {
         self.peek_buffer[n].clone()
     }
 
-    pub fn parse_program(&mut self) -> Program {
+    pub fn parse_program(&mut self) -> Result<Program, Vec<CompileError>> {
         let mut module_name = None;
         let mut imports = Vec::new();
         let mut declarations = Vec::new();
@@ -49,13 +60,13 @@ impl<'a> Parser<'a> {
                 TokenKind::Use => imports.push(self.parse_import()),
                 TokenKind::DoubleColon => {
                     if self.peek_at(0).kind == TokenKind::Intent {
-                        self.next_token(); // consume ::
-                        self.next_token(); // consume intent
+                        self.next_token();
+                        self.next_token();
                         if let TokenKind::StringLiteral(_) = self.current_token.kind {
                             self.next_token();
                         }
                     } else {
-                        eprintln!("{}", self.error("Syntax Error: Unexpected :: at top level"));
+                        self.push_error("Syntax Error: Unexpected :: at top level");
                         self.next_token();
                     }
                 },
@@ -63,13 +74,17 @@ impl<'a> Parser<'a> {
                     if let Some(decl) = self.parse_declaration() {
                         declarations.push(decl);
                     } else {
-                        eprintln!("{}", self.error("Syntax Error: Unexpected token in declaration"));
+                        self.push_error("Syntax Error: Unexpected token in declaration");
                         self.next_token();
                     }
                 },
             }
         }
-        Program { module_name, imports, declarations }
+        if self.errors.is_empty() {
+            Ok(Program { module_name, imports, declarations })
+        } else {
+            Err(std::mem::take(&mut self.errors))
+        }
     }
 
     fn parse_path(&mut self) -> Vec<String> {
@@ -1086,7 +1101,7 @@ mod tests {
         let input = "fn add(a: i64, b: i64) -> i64 { return a + b; }";
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
-        let program = parser.parse_program();
+        let program = parser.parse_program().expect("parse should succeed");
         
         assert_eq!(program.declarations.len(), 1);
         let is_fn = matches!(program.declarations[0], Declaration::Function(_));

--- a/src/transpiler/sql.rs
+++ b/src/transpiler/sql.rs
@@ -94,7 +94,7 @@ impl SqlTranspiler {
                         self.collect_vars_from_stmts(&arm.body, vars);
                     }
                 }
-                Statement::UnsafeBlock(stmts) | Statement::Spawn(stmts) => {
+                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => {
                     self.collect_vars_from_stmts(stmts, vars);
                 }
                 _ => {}
@@ -104,11 +104,11 @@ impl SqlTranspiler {
 
     fn infer_type(&self, expr: &Expression) -> String {
         match expr {
-            Expression::Integer(_) => "i64",
-            Expression::Float(_) => "f64",
-            Expression::Boolean(_) => "bool",
-            Expression::String(_) => "String",
-            Expression::Identifier(_) => "i64",
+            Expression::Integer(..) => "i64",
+            Expression::Float(..) => "f64",
+            Expression::Boolean(..) => "bool",
+            Expression::String(..) => "String",
+            Expression::Identifier(..) => "i64",
             Expression::Infix { .. } => "i64",
             Expression::Call { function, .. } => {
                 if function.contains("println") || function.contains("print") {
@@ -128,8 +128,8 @@ impl SqlTranspiler {
             Expression::Deref { .. } => "i64",
             Expression::Intrinsic { .. } => "i64",
             Expression::TypeRef { .. } => "i64",
-            Expression::Duration(_, _) => "Duration",
-            Expression::Date(_) => "Date",
+            Expression::Duration(..) => "Duration",
+            Expression::Date(..) => "Date",
         }
         .to_string()
     }
@@ -161,7 +161,7 @@ impl SqlTranspiler {
                 self.transpile_expression(value);
                 self.buffer.push_str(";\n");
             }
-            Statement::Assignment { target, value } => {
+            Statement::Assignment { target, value, .. } => {
                 self.buffer.push_str("    ");
                 self.transpile_expression(target);
                 self.buffer.push_str(" := ");
@@ -172,6 +172,7 @@ impl SqlTranspiler {
                 condition,
                 then_branch,
                 else_branch,
+                ..
             } => {
                 self.buffer.push_str("    IF ");
                 self.transpile_expression(condition);
@@ -187,7 +188,7 @@ impl SqlTranspiler {
                 }
                 self.buffer.push_str("    END IF;\n");
             }
-            Statement::While { condition, body } => {
+            Statement::While { condition, body, .. } => {
                 self.buffer.push_str("    WHILE ");
                 self.transpile_expression(condition);
                 self.buffer.push_str(" LOOP\n");
@@ -196,12 +197,12 @@ impl SqlTranspiler {
                 }
                 self.buffer.push_str("    END LOOP;\n");
             }
-            Statement::ExpressionStmt(expr) => {
+            Statement::ExpressionStmt(expr, _) => {
                 self.buffer.push_str("    PERFORM ");
                 self.transpile_expression(expr);
                 self.buffer.push_str(";\n");
             }
-            Statement::Match { condition, arms } => {
+            Statement::Match { condition, arms, .. } => {
                 self.buffer.push_str("    CASE ");
                 self.transpile_expression(condition);
                 self.buffer.push('\n');
@@ -215,7 +216,7 @@ impl SqlTranspiler {
                 self.buffer.push_str("        ELSE NULL;\n");
                 self.buffer.push_str("    END CASE;\n");
             }
-            Statement::UnsafeBlock(stmts) => {
+            Statement::UnsafeBlock(stmts, _) => {
                 self.buffer.push_str("    -- UNSAFE BLOCK\n");
                 for s in stmts {
                     self.transpile_statement(s);
@@ -228,15 +229,16 @@ impl SqlTranspiler {
 
     fn transpile_expression(&mut self, expr: &Expression) {
         match expr {
-            Expression::Integer(n) => self.buffer.push_str(&n.to_string()),
-            Expression::Float(f_val) => self.buffer.push_str(&f_val.to_string()),
-            Expression::Boolean(b) => self.buffer.push_str(&b.to_string().to_uppercase()),
-            Expression::String(s) => self.buffer.push_str(&format!("'{}'", s)),
-            Expression::Identifier(s) => self.buffer.push_str(s),
+            Expression::Integer(n, _) => self.buffer.push_str(&n.to_string()),
+            Expression::Float(f_val, _) => self.buffer.push_str(&f_val.to_string()),
+            Expression::Boolean(b, _) => self.buffer.push_str(&b.to_string().to_uppercase()),
+            Expression::String(s, _) => self.buffer.push_str(&format!("'{}'", s)),
+            Expression::Identifier(s, _) => self.buffer.push_str(s),
             Expression::Infix {
                 left,
                 operator,
                 right,
+                ..
             } => {
                 self.transpile_expression(left);
                 let op = match &operator.kind {
@@ -274,12 +276,13 @@ impl SqlTranspiler {
             Expression::MemberAccess {
                 receiver,
                 member,
+                ..
             } => {
                 self.transpile_expression(receiver);
                 self.buffer.push('.');
                 self.buffer.push_str(member);
             }
-            Expression::Cast { expr, target } => {
+            Expression::Cast { expr, target, .. } => {
                 self.transpile_expression(expr);
                 self.buffer
                     .push_str(&format!("::{}", self.map_type(target)));
@@ -304,7 +307,7 @@ impl SqlTranspiler {
             Statement::Let { value, .. } => {
                 self.transpile_expression(value);
             }
-            Statement::ExpressionStmt(expr) => {
+            Statement::ExpressionStmt(expr, _) => {
                 self.transpile_expression(expr);
             }
             _ => self.buffer.push_str("NULL"),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
     Unit,
@@ -10,8 +12,71 @@ pub enum Type {
     Function { is_unsafe: bool, return_type: Box<Type> },
     Enum { name: String },
     Struct { name: String },
-    Placeholder(String), // Placeholder like 'T'
-    GenericInstance(String, Vec<Type>), // Concrete like 'Vector<i64>'
+    Placeholder(String),
+    GenericInstance(String, Vec<Type>),
     Pointer(Box<Type>),
     Unknown,
+}
+
+impl Type {
+    pub fn from_str(s: &str) -> Self {
+        let trimmed = s.trim();
+        if let Some(stripped) = trimmed.strip_prefix('*') {
+            return Type::Pointer(Box::new(Type::from_str(stripped.trim())));
+        }
+        match trimmed {
+            "i64" | "u64" | "i32" | "u32" | "i8" | "u8" => Type::Integer,
+            "f64" => Type::Float,
+            "bool" => Type::Boolean,
+            "String" => Type::String,
+            "Date" => Type::Date,
+            "Duration" => Type::Duration,
+            "void" | "Unit" => Type::Unit,
+            _ => {
+                if trimmed.contains('<') && trimmed.ends_with('>') {
+                    if let Some(start) = trimmed.find('<') {
+                        let base = trimmed[..start].to_string();
+                        let args_str = &trimmed[start + 1..trimmed.len() - 1];
+                        let mut ga = Vec::new();
+                        for part in args_str.split(',') {
+                            let pt = part.trim().to_string();
+                            if !pt.is_empty() {
+                                ga.push(Type::from_str(&pt));
+                            }
+                        }
+                        return Type::GenericInstance(base, ga);
+                    }
+                }
+                Type::Placeholder(trimmed.to_string())
+            }
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            Type::Unit => "void".to_string(),
+            Type::Integer => "i64".to_string(),
+            Type::Float => "f64".to_string(),
+            Type::Boolean => "bool".to_string(),
+            Type::String => "String".to_string(),
+            Type::Duration => "Duration".to_string(),
+            Type::Date => "Date".to_string(),
+            Type::Pointer(inner) => format!("*{}", inner.name()),
+            Type::Struct { name } => name.clone(),
+            Type::Enum { name } => name.clone(),
+            Type::GenericInstance(base, args) => {
+                let args_str: Vec<String> = args.iter().map(|a| a.name()).collect();
+                format!("{}<{}>", base, args_str.join(", "))
+            }
+            Type::Placeholder(name) => name.clone(),
+            Type::Function { return_type, .. } => format!("fn() -> {}", return_type.name()),
+            Type::Unknown => "unknown".to_string(),
+        }
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
 }


### PR DESCRIPTION
## Summary

- **Issue #2**: Add `Span` to all AST nodes (20 Expression + 10 Statement variants)
- **Issue #3**: Add `Type::from_str`/`Display`, simplify checker `resolve_type`, add `type_to_llvm`
- **Issue #4**: Parser returns `Result<Program, Vec<CompileError>>` instead of silently swallowing errors

## Test results
All 47 tests pass.