### PR TITLE
feat: add string.to_float() intrinsic (closes #14)

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -75,6 +75,7 @@ impl TypeChecker {
         self.env.set("string.concat".to_string(), Type::Function { is_unsafe: false, return_type: Box::new(Type::String) });
         self.env.set("string.from_int".to_string(), Type::Function { is_unsafe: false, return_type: Box::new(Type::String) });
         self.env.set("string.from_float".to_string(), Type::Function { is_unsafe: false, return_type: Box::new(Type::String) });
+        self.env.set("string.to_float".to_string(), Type::Function { is_unsafe: false, return_type: Box::new(Type::Float) });
         
         // i64 methods as functions
         self.env.set("i64.abs".to_string(), Type::Function { is_unsafe: false, return_type: Box::new(Type::Integer) });

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -56,6 +56,7 @@ impl<'ctx> Compiler<'ctx> {
         let builtins = vec![
             ("io.println", "aion_io_println", "void", false), ("io.print", "aion_io_print", "void", false), ("io.read_line", "aion_io_read_line", "String", false),
             ("string.from_int", "aion_int_to_str", "String", false), ("string.from_float", "aion_float_to_str", "String", false),
+            ("string.to_float", "aion_str_to_float", "f64", false),
             ("fs_read_to_string", "aion_read_file", "String", false), ("fs_write", "aion_write_file", "i32", false), ("fs_exists", "aion_fs_exists", "i64", false), ("fs_append", "aion_append_file", "i32", false),
             ("aion_getenv", "aion_getenv", "String", false), ("aion_get_argc", "aion_get_argc", "i64", false), ("aion_get_argv_index", "aion_get_argv_index", "String", false),
             ("aion_exit", "exit", "void", false), ("exit", "exit", "void", false), ("aion_malloc", "aion_malloc", "ptr", false), ("aion_realloc", "aion_realloc", "ptr", false), ("aion_free", "aion_free", "void", false),
@@ -359,6 +360,7 @@ impl<'ctx> Compiler<'ctx> {
         self.module.add_function("aion_str_concat", pt.fn_type(&[pt.into(), pt.into()], false), None); 
         self.module.add_function("aion_int_to_str", pt.fn_type(&[i64_t.into()], false), None); 
         self.module.add_function("aion_float_to_str", pt.fn_type(&[self.context.f64_type().into()], false), None); 
+        self.module.add_function("aion_str_to_float", self.context.f64_type().fn_type(&[pt.into()], false), None); 
         self.module.add_function("aion_read_file", pt.fn_type(&[pt.into()], false), None); 
         self.module.add_function("aion_write_file", i64_t.fn_type(&[pt.into(), pt.into()], false), None); 
         self.module.add_function("aion_append_file", i64_t.fn_type(&[pt.into(), pt.into()], false), None); 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -82,6 +82,14 @@ char* aion_float_to_str(double f) {
     return buf;
 }
 
+double aion_str_to_float(const char* s) {
+    if (!s) return 0.0;
+    char* end;
+    double result = strtod(s, &end);
+    if (end == s) return 0.0;
+    return result;
+}
+
 long long aion_str_eq(const char* s1, const char* s2) {
     if (!s1 || !s2) return s1 == s2;
     return strcmp(s1, s2) == 0;

--- a/stdlib/std/string.ai
+++ b/stdlib/std/string.ai
@@ -16,6 +16,10 @@ pub fn from_float(f: f64) -> String {
     @intrinsic("float_to_str", f)
 }
 
+pub fn to_float(s: String) -> f64 {
+    @intrinsic("str_to_float", s)
+}
+
 pub fn equals(s1: String, s2: String) -> bool {
     let len1 = std.string.len(s1);
     let len2 = std.string.len(s2);


### PR DESCRIPTION
## Summary
- Add `aion_str_to_float` C runtime function using `strtod()`
- Wire up as `str_to_float` intrinsic in compiler
- Add `string.to_float(s: String) -> f64` to stdlib
- Register in type checker builtins

Enables JSON number parsing and any float-from-string conversion.