### PR TITLE
docs: update file paths after module reorganization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,6 +98,6 @@ This document outlines the technical path to transform Aion from its current Rus
 - [x] Lexer / Parser EBNF v0.5.
 - [x] Type Checker (Safety & Temporal & Security Enforcement).
 - [x] CodeGen LLVM (Native & Dynamic Strings & Function Returns).
-- [x] Modular Compiler Architecture (`src/compiler.rs`).
+- [x] Modular Compiler Architecture (`src/codegen/`).
 - [x] **EXHAUSTIVITY GOAL**: Real Enum Tagged Unions and deep Pattern Matching.
 - [x] **CORE STABILITY**: Correct struct pass-by-pointer, string content comparison, and generic unwrap type safety.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2,9 +2,9 @@
 
 ## 1. Architecture
 Aion is a direct-to-LLVM compiler with a strict safety-first pipeline.
--   **Frontend**: Hand-written Lexer (`lexer.rs`) and Recursive Descent Parser (`parser.rs`).
--   **Middle**: Type Checker (`checker.rs`) with scoped environments, fuzzy resolution, and strict generic validation.
--   **Backend**: Direct LLVM IR generation (`compiler.rs`) using `inkwell` (LLVM 15+ Opaque Pointers).
+-   **Frontend**: Hand-written Lexer (`lexer/`) and Recursive Descent Parser (`parser/`).
+-   **Middle**: Type Checker (`analysis/`) with scoped environments, fuzzy resolution, and strict generic validation.
+-   **Backend**: Direct LLVM IR generation (`codegen/`) using `inkwell` (LLVM 15+ Opaque Pointers).
 -   **Runtime**: Minimal C runtime (`runtime.c`) for I/O, threading, and AI tensor primitives.
 -   **Orchestration**: Docker-first execution via `./aion` wrapper. Host `cargo` commands are strictly forbidden for compilation.
 

--- a/docs/SPEC_TIME.md
+++ b/docs/SPEC_TIME.md
@@ -52,4 +52,4 @@ io.println(Duration("P1DT2H")) // Parses string at runtime
 - [x] **Codegen**:
     *   `Duration` stored as milliseconds in `i64`.
     *   `Date` stored as millisecond timestamp in `i64`.
-    *   Arithmetic intrinsics implemented in `src/lib.rs`.
+    *   Arithmetic intrinsics implemented in `src/lib.rs` (orchestration layer).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,19 +4,30 @@
 src/              — Rust compiler (lexer → parser → type checker → LLVM codegen)
   main.rs         — CLI entrypoint: build / run / doc / transpile subcommands
   lib.rs          — compile_file(): orchestrates lexer → parser → checker → compiler
-  compiler.rs     — LLVM IR generation via inkwell (Rust bindings for LLVM)
-  runtime.c       — C runtime: I/O, string ops, GC init, FFI builtins
-  lexer.rs        — Tokenizer (char → token stream)
-  parser.rs       — Token stream → AST (returns Result<Program, Vec<CompileError>>)
-  ast.rs          — AST node definitions with Span (Program, Declaration, Expression, Statement)
-  token.rs        — Token and TokenKind definitions
-  types.rs        — Type system (Type enum with from_str/Display)
   error.rs        — CompileError enum (Type, Unsafe, NotFound, NotFunction, InvalidOperator, Inkwell, Io, Import, Internal)
-  checker.rs      — TypeChecker: safety and type verification pass
-  environment.rs  — Scoped symbol table for type checker
-  transpiler/     — Transpilation backends
-    mod.rs        — Module root
-    sql.rs        — SQL transpiler (Aion → PostgreSQL functions)
+  runtime.c       — C runtime: I/O, string ops, GC init, FFI builtins
+  lexer/          — Tokenizer (char → token stream)
+    mod.rs        — Re-exports Token, TokenKind, Lexer
+    token.rs      — Token and TokenKind definitions
+    lexer.rs      — Lexer implementation
+  ast/            — AST node definitions
+    mod.rs        — Re-exports + Span struct
+    expr.rs       — Expression enum
+    stmt.rs       — Statement enum + MatchArm
+    decl.rs       — Declaration, Function, Struct, Enum, Interface, ImplBlock, Program, Import
+  parser/         — Token stream → AST (returns Result<Program, Vec<CompileError>>)
+    mod.rs        — Parser struct + parse_program + parse_import
+  analysis/       — Type system and verification
+    mod.rs        — Re-exports TypeChecker, Environment, Type
+    types.rs      — Type enum with from_str/Display
+    checker.rs    — TypeChecker: safety and type verification pass
+    environment.rs — Scoped symbol table for type checker
+  codegen/        — LLVM IR generation via inkwell (Rust bindings for LLVM)
+    mod.rs        — Re-exports Compiler
+    compiler.rs   — LLVM code generation
+    transpiler/   — Transpilation backends
+      mod.rs      — Module root
+      sql.rs      — SQL transpiler (Aion → PostgreSQL functions)
 stdlib/           — Aion standard library (written in Aion, .ai files)
   core/           — Core memory primitives (heap.ai, memory.ai)
   std/            — Standard library modules (io, fs, collections, math, etc.)


### PR DESCRIPTION
Update 4 documentation files to reflect the new directory structure from PR #22:

- `docs/architecture.md`: Updated `src/` tree diagram with new module layout
- `docs/SPEC.md`: Changed `lexer.rs` → `lexer/`, `parser.rs` → `parser/`, `checker.rs` → `analysis/`, `compiler.rs` → `codegen/`
- `ROADMAP.md`: Updated `src/compiler.rs` → `src/codegen/`
- `docs/SPEC_TIME.md`: Clarified `src/lib.rs` role

Closes #8