### PR TITLE
test: add string pattern matching in match expressions

### DIFF
--- a/tests/fixtures/language/string_match.ai
+++ b/tests/fixtures/language/string_match.ai
@@ -1,0 +1,27 @@
+fn main() {
+    let keyword = "true"
+
+    match keyword {
+        "true" | "false" => io.println("boolean keyword"),
+        "null" => io.println("null keyword"),
+        _ => io.println("other")
+    }
+
+    let kw2 = "null"
+
+    match kw2 {
+        "true" | "false" => io.println("boolean keyword"),
+        "null" => io.println("null keyword"),
+        _ => io.println("other")
+    }
+
+    let kw3 = "hello"
+
+    match kw3 {
+        "true" | "false" => io.println("boolean keyword"),
+        "null" => io.println("null keyword"),
+        _ => io.println("other")
+    }
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -94,6 +94,8 @@ fn test_struct_return() { assert_snapshot!(run_aion_test("language/struct_return
 fn test_parse_result() { assert_snapshot!(run_aion_test("language/parse_result")); }
 #[test]
 fn test_char_literal() { assert_snapshot!(run_aion_test("language/char_literal")); }
+#[test]
+fn test_string_match() { assert_snapshot!(run_aion_test("language/string_match")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__string_match.snap
+++ b/tests/snapshots/integration__string_match.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/string_match\")"
+---
+boolean keyword
+null keyword
+other


### PR DESCRIPTION
## Summary
- String pattern matching in `match` expressions (with `|` alternation) was **already implemented** in the compiler but lacked test coverage
- Add integration test covering basic string literal matching, wildcard fallback, and pipe alternation

Closes #16