### PR TITLE
feat: add break and continue statements for loops

### DIFF
--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -188,6 +188,8 @@ impl TypeChecker {
                 for s in body { self.check_statement(s)?; }
                 Ok(Type::Unit)
             },
+            Statement::Break(_) => Ok(Type::Unit),
+            Statement::Continue(_) => Ok(Type::Unit),
             Statement::UnsafeBlock(body, _) => {
                 let was = self.in_unsafe_context; self.in_unsafe_context = true;
                 for s in body { self.check_statement(s)?; }

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -12,6 +12,8 @@ pub enum Statement {
     Spawn(Vec<Statement>, Span),
     Match { condition: Expression, arms: Vec<MatchArm>, span: Span },
     UnsafeBlock(Vec<Statement>, Span),
+    Break(Span),
+    Continue(Span),
     NoOp,
 }
 

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::collections::{HashMap, HashSet};
+use inkwell::basic_block::BasicBlock;
 use inkwell::context::Context;
 use inkwell::builder::Builder;
 use inkwell::module::Module;
@@ -22,6 +23,8 @@ pub struct Compiler<'ctx> {
     pub decls: HashMap<String, Declaration>,
     pub compiled_instances: HashSet<String>,
     source: String,
+    loop_exit_blocks: Vec<BasicBlock<'ctx>>,
+    loop_cond_blocks: Vec<BasicBlock<'ctx>>,
 }
 
 impl<'ctx> Compiler<'ctx> {
@@ -42,6 +45,8 @@ impl<'ctx> Compiler<'ctx> {
             decls: HashMap::new(), 
             compiled_instances: HashSet::new(),
             source: source.to_string(),
+            loop_exit_blocks: Vec::new(),
+            loop_cond_blocks: Vec::new(),
         };
         compiler.register_builtins();
         compiler
@@ -533,12 +538,26 @@ impl<'ctx> Compiler<'ctx> {
                     let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
                     self.builder.build_conditional_branch(self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "loopcond")?, bb, eb)?;
                     self.builder.position_at_end(bb); 
+                    self.loop_exit_blocks.push(eb);
+                    self.loop_cond_blocks.push(cb);
                     let mut bvars = variables.clone(); 
                     self.compile_block(body, &mut bvars, function)?; 
+                    self.loop_exit_blocks.pop();
+                    self.loop_cond_blocks.pop();
                     if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
                         self.builder.build_unconditional_branch(cb)?; 
                     } 
                     self.builder.position_at_end(eb); 
+                    lv = None;
+                },
+                Statement::Break(_) => {
+                    let eb = self.loop_exit_blocks.last().ok_or_else(|| CompileError::Internal("break outside loop".to_string()))?;
+                    self.builder.build_unconditional_branch(*eb)?;
+                    lv = None;
+                },
+                Statement::Continue(_) => {
+                    let cb = self.loop_cond_blocks.last().ok_or_else(|| CompileError::Internal("continue outside loop".to_string()))?;
+                    self.builder.build_unconditional_branch(*cb)?;
                     lv = None;
                 },
                 Statement::Match { condition, arms, .. } => {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -147,6 +147,8 @@ impl<'a> Lexer<'a> {
                             "type" => TokenKind::Type,
                             "self" => TokenKind::SelfToken,
                             "spawn" => TokenKind::Spawn,
+                            "break" => TokenKind::Break,
+                            "continue" => TokenKind::Continue,
                             "true" => TokenKind::True,
                             "false" => TokenKind::False,
                             _ => TokenKind::Identifier(ident),

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -18,6 +18,7 @@ pub enum TokenKind {
     Use, Pub, Async, Unsafe, Require, Extern,
     Interface, Impl, Channel,
     For, In, Type, SelfToken, Spawn,
+    Break, Continue,
     
     // AI-Native & Logic
     Intent, 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -492,6 +492,16 @@ impl<'a> Parser<'a> {
                 let body = self.parse_block();
                 Some(Statement::While { condition, body, span })
             },
+            TokenKind::Break => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Some(Statement::Break(span))
+            },
+            TokenKind::Continue => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                Some(Statement::Continue(span))
+            },
             TokenKind::Match => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();

--- a/tests/fixtures/language/break_continue.ai
+++ b/tests/fixtures/language/break_continue.ai
@@ -1,0 +1,33 @@
+fn main() {
+    let mut i = 0
+    while i < 10 {
+        if i == 5 {
+            break
+        }
+        i = i + 1
+    }
+    io.println(string.from_int(i))
+
+    let mut sum = 0
+    let mut j = 0
+    while j < 10 {
+        j = j + 1
+        if j % 2 == 0 {
+            continue
+        }
+        sum = sum + j
+    }
+    io.println(string.from_int(sum))
+
+    let mut count = 0
+    while true {
+        count = count + 1
+        if count == 100 {
+            break
+        }
+    }
+    io.println(string.from_int(count))
+
+    io.println("all break/continue tests done")
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -100,6 +100,8 @@ fn test_string_match() { assert_snapshot!(run_aion_test("language/string_match")
 fn test_recursion_deep() { assert_snapshot!(run_aion_test("language/recursion_deep")); }
 #[test]
 fn test_string_escapes() { assert_snapshot!(run_aion_test("language/string_escapes")); }
+#[test]
+fn test_break_continue() { assert_snapshot!(run_aion_test("language/break_continue")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__break_continue.snap
+++ b/tests/snapshots/integration__break_continue.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/break_continue\")"
+---
+5
+25
+100
+all break/continue tests done


### PR DESCRIPTION
## Summary
- Add `break` and `continue` as first-class loop control flow
- Lexer: `Break`/`Continue` keywords
- AST: `Statement::Break`/`Statement::Continue` variants  
- Parser: standalone statement parsing
- Checker: accept as `Type::Unit`
- Codegen: stack-based loop context tracking — break branches to exit block, continue to condition block

Tested: break exits loop, continue skips iteration, `while true` with break.

Closes #32