### PR TITLE
feat: complete stdlib string module

### DIFF
--- a/stdlib/std/string.ai
+++ b/stdlib/std/string.ai
@@ -27,15 +27,150 @@ pub fn equals(s1: String, s2: String) -> bool {
     return @intrinsic("str_eq", s1, s2)
 }
 
-pub fn contains(haystack: String, needle: String) -> bool {
-    // Basic implementation for now
-    false 
-}
-
 pub fn at(s: String, i: i64) -> i64 {
     @intrinsic("str_at", s, i)
 }
 
 pub fn substr(s: String, start: i64, len: i64) -> String {
     @intrinsic("str_substr", s, start, len)
+}
+
+pub fn contains(haystack: String, needle: String) -> bool {
+    let h_len = std.string.len(haystack)
+    let n_len = std.string.len(needle)
+    if n_len == 0 { return true }
+    if n_len > h_len { return false }
+    let mut i = 0
+    let mut found = false
+    let mut done = false
+    while i <= h_len - n_len && !done {
+        let chunk = std.string.substr(haystack, i, n_len)
+        if std.string.equals(chunk, needle) {
+            found = true
+            done = true
+        } else {
+            i = i + 1
+        }
+    }
+    return found
+}
+
+pub fn starts_with(s: String, prefix: String) -> bool {
+    let p_len = std.string.len(prefix)
+    let s_len = std.string.len(s)
+    if p_len > s_len { return false }
+    let chunk = std.string.substr(s, 0, p_len)
+    return std.string.equals(chunk, prefix)
+}
+
+pub fn ends_with(s: String, suffix: String) -> bool {
+    let sf_len = std.string.len(suffix)
+    let s_len = std.string.len(s)
+    if sf_len > s_len { return false }
+    let chunk = std.string.substr(s, s_len - sf_len, sf_len)
+    return std.string.equals(chunk, suffix)
+}
+
+pub fn find(haystack: String, needle: String) -> i64 {
+    let h_len = std.string.len(haystack)
+    let n_len = std.string.len(needle)
+    if n_len == 0 { return 0 }
+    if n_len > h_len { return -1 }
+    let mut i = 0
+    let mut result = -1
+    let mut done = false
+    while i <= h_len - n_len && !done {
+        let chunk = std.string.substr(haystack, i, n_len)
+        if std.string.equals(chunk, needle) {
+            result = i
+            done = true
+        } else {
+            i = i + 1
+        }
+    }
+    return result
+}
+
+pub fn trim(s: String) -> String {
+    let s_len = std.string.len(s)
+    let mut start = 0
+    let mut done = false
+    while start < s_len && !done {
+        let c = std.string.at(s, start)
+        if c == 32 || c == 9 || c == 10 || c == 13 {
+            start = start + 1
+        } else {
+            done = true
+        }
+    }
+    let mut end = s_len - 1
+    done = false
+    while end >= start && !done {
+        let c = std.string.at(s, end)
+        if c == 32 || c == 9 || c == 10 || c == 13 {
+            end = end - 1
+        } else {
+            done = true
+        }
+    }
+    if start > end { return "" }
+    return std.string.substr(s, start, end - start + 1)
+}
+
+pub fn to_upper(s: String) -> String {
+    let s_len = std.string.len(s)
+    let mut result = ""
+    let mut i = 0
+    while i < s_len {
+        let c = std.string.at(s, i)
+        if c >= 97 && c <= 122 {
+            result = std.string.concat(result, @intrinsic("char_to_str", c - 32))
+        } else {
+            result = std.string.concat(result, std.string.substr(s, i, 1))
+        }
+        i = i + 1
+    }
+    return result
+}
+
+pub fn to_lower(s: String) -> String {
+    let s_len = std.string.len(s)
+    let mut result = ""
+    let mut i = 0
+    while i < s_len {
+        let c = std.string.at(s, i)
+        if c >= 65 && c <= 90 {
+            result = std.string.concat(result, @intrinsic("char_to_str", c + 32))
+        } else {
+            result = std.string.concat(result, std.string.substr(s, i, 1))
+        }
+        i = i + 1
+    }
+    return result
+}
+
+pub fn replace(s: String, from: String, to: String) -> String {
+    let s_len = std.string.len(s)
+    let f_len = std.string.len(from)
+    if f_len == 0 { return s }
+    let mut result = ""
+    let mut i = 0
+    let mut done = false
+    while i < s_len && !done {
+        if i <= s_len - f_len {
+            let chunk = std.string.substr(s, i, f_len)
+            if std.string.equals(chunk, from) {
+                result = std.string.concat(result, to)
+                i = i + f_len
+            } else {
+                result = std.string.concat(result, std.string.substr(s, i, 1))
+                i = i + 1
+            }
+        } else {
+            result = std.string.concat(result, std.string.substr(s, i, 1))
+            i = i + 1
+            if i >= s_len { done = true }
+        }
+    }
+    return result
 }

--- a/tests/fixtures/stdlib/string_methods.ai
+++ b/tests/fixtures/stdlib/string_methods.ai
@@ -1,0 +1,55 @@
+use std.string
+use std.io
+
+fn main() {
+    // contains
+    io.print("contains(hello, ell): ")
+    io.println(if string.contains("hello", "ell") { "true" } else { "false" })
+
+    io.print("contains(hello, xyz): ")
+    io.println(if string.contains("hello", "xyz") { "true" } else { "false" })
+
+    io.print("contains(hello, ): ")
+    io.println(if string.contains("hello", "") { "true" } else { "false" })
+
+    // starts_with
+    io.print("starts_with(hello, hel): ")
+    io.println(if string.starts_with("hello", "hel") { "true" } else { "false" })
+
+    io.print("starts_with(hello, world): ")
+    io.println(if string.starts_with("hello", "world") { "true" } else { "false" })
+
+    // ends_with
+    io.print("ends_with(hello, llo): ")
+    io.println(if string.ends_with("hello", "llo") { "true" } else { "false" })
+
+    io.print("ends_with(hello, world): ")
+    io.println(if string.ends_with("hello", "world") { "true" } else { "false" })
+
+    // find
+    io.print("find(hello world, world): ")
+    io.println(string.from_int(string.find("hello world", "world")))
+
+    io.print("find(hello, xyz): ")
+    io.println(string.from_int(string.find("hello", "xyz")))
+
+    // trim
+    io.print("trim(  hello  ): [")
+    io.print(string.trim("  hello  "))
+    io.println("]")
+
+    // replace
+    io.print("replace(hello world, world, Aion): ")
+    io.println(string.replace("hello world", "world", "Aion"))
+
+    // to_upper
+    io.print("to_upper(hello): ")
+    io.println(string.to_upper("hello"))
+
+    // to_lower
+    io.print("to_lower(HELLO): ")
+    io.println(string.to_lower("HELLO"))
+
+    io.println("all string tests done")
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -102,6 +102,8 @@ fn test_recursion_deep() { assert_snapshot!(run_aion_test("language/recursion_de
 fn test_string_escapes() { assert_snapshot!(run_aion_test("language/string_escapes")); }
 #[test]
 fn test_break_continue() { assert_snapshot!(run_aion_test("language/break_continue")); }
+#[test]
+fn test_string_methods() { assert_snapshot!(run_aion_test("stdlib/string_methods")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__string_methods.snap
+++ b/tests/snapshots/integration__string_methods.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/string_methods\")"
+---
+contains(hello, ell): true
+contains(hello, xyz): false
+contains(hello, ): true
+starts_with(hello, hel): true
+starts_with(hello, world): false
+ends_with(hello, llo): true
+ends_with(hello, world): false
+find(hello world, world): 6
+find(hello, xyz): -1
+trim(  hello  ): [hello]
+replace(hello world, world, Aion): hello Aion
+to_upper(hello): HELLO
+to_lower(HELLO): hello
+all string tests done


### PR DESCRIPTION
## Summary
Add pure-Aion implementations of essential string operations:
- `contains` — substring search (was a stub returning `false`)
- `starts_with` / `ends_with` — prefix/suffix check
- `find` — index-of substring search
- `trim` — whitespace removal
- `replace` — substring replacement
- `to_upper` / `to_lower` — case conversion via `@intrinsic("char_to_str")`

All implementations use existing primitives (`at`, `substr`, `len`, `concat`).

Closes #34, closes #30