### PR TITLE
feat: add loop expression for infinite loops

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -149,6 +149,7 @@ impl<'a> Lexer<'a> {
                             "spawn" => TokenKind::Spawn,
                             "break" => TokenKind::Break,
                             "continue" => TokenKind::Continue,
+                            "loop" => TokenKind::Loop,
                             "true" => TokenKind::True,
                             "false" => TokenKind::False,
                             _ => TokenKind::Identifier(ident),

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -18,7 +18,7 @@ pub enum TokenKind {
     Use, Pub, Async, Unsafe, Require, Extern,
     Interface, Impl, Channel,
     For, In, Type, SelfToken, Spawn,
-    Break, Continue,
+    Break, Continue, Loop,
     
     // AI-Native & Logic
     Intent, 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -502,6 +502,13 @@ impl<'a> Parser<'a> {
                 self.next_token();
                 Some(Statement::Continue(span))
             },
+            TokenKind::Loop => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                let body = self.parse_block();
+                let condition = Expression::Boolean(true, span.clone());
+                Some(Statement::While { condition, body, span })
+            },
             TokenKind::Match => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();

--- a/tests/fixtures/language/loop_basic.ai
+++ b/tests/fixtures/language/loop_basic.ai
@@ -1,0 +1,24 @@
+fn main() {
+    let mut i = 0
+    loop {
+        i = i + 1
+        if i == 10 {
+            break
+        }
+    }
+    io.println(string.from_int(i))
+
+    let mut sum = 0
+    let mut j = 1
+    loop {
+        sum = sum + j
+        j = j + 1
+        if j > 5 {
+            break
+        }
+    }
+    io.println(string.from_int(sum))
+
+    io.println("loop tests done")
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -104,6 +104,8 @@ fn test_string_escapes() { assert_snapshot!(run_aion_test("language/string_escap
 fn test_break_continue() { assert_snapshot!(run_aion_test("language/break_continue")); }
 #[test]
 fn test_string_methods() { assert_snapshot!(run_aion_test("stdlib/string_methods")); }
+#[test]
+fn test_loop_basic() { assert_snapshot!(run_aion_test("language/loop_basic")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__loop_basic.snap
+++ b/tests/snapshots/integration__loop_basic.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/loop_basic\")"
+---
+10
+15
+loop tests done


### PR DESCRIPTION
## Summary
- Add `loop { body }` as syntactic sugar for `while true { body }`
- Desugared in the parser — no codegen/checker changes needed
- Requires `break` (already merged in #45) to exit
- 6 lines of code total

Closes #39