### PR TITLE
fix: resolve method resolution on non-generic imported types

### DIFF
--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -373,15 +373,18 @@ impl TypeChecker {
                 };
 
                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
-                let cand = format!("{}::{}", full, method);
-                let ft = self.env.get(&cand).ok_or_else(|| self.err(format!("method '{}' not found on '{}'", method, full), &method_expr))?;
+                let cand_colon = format!("{}::{}", full, method);
+                let cand_dot = format!("{}.{}", full, method);
+                let ft = self.env.get(&cand_colon)
+                    .or_else(|| self.env.get(&cand_dot))
+                    .ok_or_else(|| self.err(format!("method '{}' not found on '{}'", method, full), &method_expr))?;
                 if let Type::Function { is_unsafe, ref return_type } = ft {
                     if is_unsafe && !self.in_unsafe_context {
                         return Err(self.err(format!("unsafe method call '{}'", method), &method_expr));
                     }
                     for arg in arguments { self.check_expression(arg)?; }
                     Ok(*return_type.clone())
-                } else { Err(self.err(format!("'{}' is not a function", cand), &method_expr)) }
+                } else { Err(self.err(format!("'{}' is not a function", cand_colon), &method_expr)) }
             },
             Expression::Cast { target, .. } => Ok(self.resolve_type(target)),
             Expression::StructInst { name, .. } => {

--- a/src/analysis/environment.rs
+++ b/src/analysis/environment.rs
@@ -29,7 +29,11 @@ impl Environment {
         
         // Fuzzy lookup: check if name matches a fully qualified name suffix
         for (key, val) in &self.store {
-            if key.ends_with(name) && (key.len() == name.len() || key.as_bytes()[key.len() - name.len() - 1] == b'.') {
+            if key.ends_with(name) && (key.len() == name.len() || {
+                let sep_idx = key.len() - name.len() - 1;
+                let b = key.as_bytes()[sep_idx];
+                b == b'.' || (sep_idx >= 1 && key.as_bytes()[sep_idx - 1] == b':' && b == b':')
+            }) {
                 return Some(val.clone());
             }
         }


### PR DESCRIPTION
## Summary
- Fix method resolution for non-generic imported types (e.g., `vector.Vector`)
- Environment fuzzy resolution now handles both `::` and `.` separators
- MethodCall handler tries both separator formats like Call handler does

## Changes
- `src/analysis/environment.rs`: Fuzzy lookup accepts both `.` and `::` separators
- `src/analysis/checker.rs`: MethodCall tries `full::method` then `full.method`

## Testing
- All 61 tests pass (2 pre-existing FS test failures on main excluded)
- Method-related tests all pass: `test_method_chaining`, `test_vector_*`, `test_result_methods`, etc.

Closes #31