### PR TITLE
fix: ensure tests/tmp directory exists for filesystem tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ aion_app_*
 output
 test_file.txt
 tests/test_file.txt
-tests/tmp/
+tests/tmp/*
+!tests/tmp/.gitkeep
+!tests/tmp/.gitignore
 test_fs_output.txt
 
 # Existing

--- a/tests/tmp/.gitignore
+++ b/tests/tmp/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep


### PR DESCRIPTION
## Summary
- Fix failing `test_fs_write_read` and `test_std_fs_read_write` tests
- Tests write to `tests/tmp/` but directory didn't exist in git

## Changes
- Add `tests/tmp/.gitkeep` to track empty directory
- Add `tests/tmp/.gitignore` to ignore test artifacts
- Update root `.gitignore` to allow `.gitkeep` and `.gitignore` in `tests/tmp/`

## Testing
- All 63 tests now pass (previously 61/63)

Closes #49