### PR TITLE
feat: support match as expression (not just statement)

### DIFF
--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -436,6 +436,65 @@ impl TypeChecker {
                 if *is_unsafe { self.in_unsafe_context = was; }
                 Ok(lt)
             },
+            Expression::Match { condition, arms, .. } => {
+                let cond_type = self.check_expression(condition)?;
+                let cond_name = match &cond_type {
+                    Type::Enum { name } => name.clone(),
+                    Type::GenericInstance(name, _) => name.clone(),
+                    Type::Integer => "i64".to_string(),
+                    Type::String => "String".to_string(),
+                    Type::Struct { name } => name.clone(),
+                    _ => "unknown".to_string(),
+                };
+                let mut result_type = Type::Unit;
+                for arm in arms {
+                    let old_env = self.env.clone();
+                    
+                    let all_patterns: Vec<String> = if arm.patterns.is_empty() {
+                        vec![arm.pattern.clone()]
+                    } else {
+                        arm.patterns.clone()
+                    };
+                    
+                    if !arm.params.is_empty() {
+                        self.env = Environment::new_enclosed(old_env.clone());
+                        let mut payload = Type::Integer;
+                        
+                        if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
+                            for pat in &all_patterns {
+                                for v in &e.variants {
+                                    if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
+                                        if !v.data_types.is_empty() { payload = self.resolve_type(&v.data_types[0]); }
+                                        break;
+                                    }
+                                }
+                            }
+                        } else if cond_name == "i64" {
+                            payload = Type::Integer;
+                        } else if cond_name == "String" {
+                            payload = Type::String;
+                        } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
+                            payload = Type::Struct { name: cond_name.clone() };
+                            for (field_name, field_type_str) in &s.fields {
+                                let field_type = self.resolve_type(field_type_str);
+                                self.env.set(format!("{}.{}", arm.params[0], field_name), field_type);
+                            }
+                        }
+                        
+                        self.env.set(arm.params[0].clone(), payload);
+                    }
+                    
+                    if let Some(guard_expr) = &arm.guard {
+                        self.check_expression(guard_expr)?;
+                    }
+                    
+                    for s in &arm.body {
+                        result_type = self.check_statement(s)?;
+                    }
+                    self.env = old_env;
+                }
+                Ok(result_type)
+            },
             _ => Err(CompileError::Internal(format!("Unsupported expression {:?}", expr))),
         }
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,4 +1,5 @@
 use super::Span;
+use super::stmt::MatchArm;
 use crate::lexer::token::Token;
 use crate::ast::Statement;
 
@@ -55,6 +56,11 @@ pub enum Expression {
         generic_args: Vec<String>,
         span: Span,
     },
+    Match {
+        condition: Box<Expression>,
+        arms: Vec<MatchArm>,
+        span: Span,
+    },
 }
 
 impl Expression {
@@ -80,7 +86,8 @@ impl Expression {
             | Expression::EnumInst { span: s, .. }
             | Expression::MemberAccess { span: s, .. }
             | Expression::MethodCall { span: s, .. }
-            | Expression::TypeRef { span: s, .. } => *s,
+            | Expression::TypeRef { span: s, .. }
+            | Expression::Match { span: s, .. } => *s,
         }
     }
 }

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -198,6 +198,10 @@ impl<'ctx> Compiler<'ctx> {
                 } 
                 for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); } 
             },
+            Expression::Match { condition, arms, .. } => {
+                self.substitute_types_in_expr(condition, ph, conc);
+                for arm in arms { self.substitute_types_in_body(&mut arm.body, ph, conc); }
+            },
             _ => {}
         }
     }
@@ -1284,6 +1288,231 @@ impl<'ctx> Compiler<'ctx> {
                 let call = self.builder.build_call(fv, &cargs, "intrinsic_call")?; 
                 Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
             },
+            Expression::Match { condition, arms, .. } => {
+                let cv = self.compile_expr(condition, variables, function)?;
+                let exit_bb = self.context.append_basic_block(function, "match_expr_exit");
+                let mut phis = Vec::new();
+                let ctn = self.get_expr_type_name(condition, variables);
+                let cbn = if ctn.contains('<') { ctn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))?.to_string() } else { ctn.clone() };
+                let fen = self.resolve_fuzzy_name(&self.enum_types, &cbn).unwrap_or(cbn.clone());
+                
+                if let Some(et_ref) = self.enum_types.get(&fen) {
+                    let et = *et_ref;
+                    let ep = cv.into_pointer_value();
+                    let tag = self.builder.build_load(i64_t, self.builder.build_struct_gep(et, ep, 0, "tagptr")?, "tag")?.into_int_value();
+                    let na = arms.len();
+                    for (i, arm) in arms.iter().enumerate() {
+                        let ab = self.context.append_basic_block(function, &format!("match_arm_{}_{}", i, arm.pattern));
+                        let is_last = i == na - 1;
+                        let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_arm_next") };
+                        
+                        let all_patterns: Vec<String> = if arm.patterns.is_empty() {
+                            vec![arm.pattern.clone()]
+                        } else {
+                            arm.patterns.clone()
+                        };
+                        
+                        let is_default = all_patterns.iter().any(|p| p == "_");
+                        let mut arm_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
+                        
+                        if !is_default {
+                            if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
+                                for pat in &all_patterns {
+                                    let mut at = i as u64;
+                                    for (vi, v) in e_decl.variants.iter().enumerate() {
+                                        if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
+                                            at = vi as u64;
+                                            break;
+                                        }
+                                    }
+                                    if at == i as u64 && (pat == "Some" || pat == "Ok" || pat.ends_with(".Some") || pat.ends_with("::Some")) { at = 0; }
+                                    if at == i as u64 && (pat == "None" || pat == "Err" || pat.ends_with(".None") || pat.ends_with("::None")) { at = 1; }
+                                    
+                                    let cond = self.builder.build_int_compare(IntPredicate::EQ, tag, i64_t.const_int(at, false), "is_arm")?;
+                                    arm_match_cond = Some(match arm_match_cond {
+                                        Some(prev) => self.builder.build_or(prev, cond, "arm_or")?,
+                                        None => cond,
+                                    });
+                                }
+                            }
+                        }
+                        
+                        if is_default && arm_match_cond.is_none() {
+                            self.builder.build_unconditional_branch(ab)?;
+                        } else if let Some(cond) = arm_match_cond {
+                            self.builder.build_conditional_branch(cond, ab, nb)?;
+                        } else {
+                            self.builder.build_unconditional_branch(nb)?;
+                        }
+                        if is_last && !is_default {
+                            let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                            phis.push((i64_t.const_zero().into(), test_bb));
+                        }
+                        self.builder.position_at_end(ab);
+                        let mut av = variables.clone();
+                        if !arm.params.is_empty() {
+                            let dp = self.builder.build_struct_gep(et, ep, 1, "arm_dataptr")?;
+                            let mut ptn = "i64".to_string();
+                            if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
+                                for v in &e_decl.variants {
+                                    if arm.pattern == v.name || arm.pattern.ends_with(&format!(".{}", v.name)) || arm.pattern.ends_with(&format!("::{}", v.name)) {
+                                        if !v.data_types.is_empty() { ptn = v.data_types[0].clone(); }
+                                        break;
+                                    }
+                                }
+                            }
+                            let lt = self.aion_type_to_llvm(&ptn);
+                            let cp = self.builder.build_bit_cast(dp, self.context.ptr_type(AddressSpace::default()), "arm_datacast")?;
+                            let lv_val = self.builder.build_load(lt, cp.into_pointer_value(), &arm.params[0])?;
+                            let pa = self.builder.build_alloca(lt, &arm.params[0])?;
+                            self.builder.build_store(pa, lv_val)?;
+                            av.insert(arm.params[0].clone(), (pa, lt, ptn));
+                        }
+                        
+                        if let Some(guard_expr) = &arm.guard {
+                            let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
+                            let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                            let guard_fail_bb = nb;
+                            let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
+                            self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                            self.builder.position_at_end(guard_pass_bb);
+                        }
+                        
+                        let ar = self.compile_block(&arm.body, &mut av, function)?;
+                        let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                        if abf.get_terminator().is_none() {
+                            let v = ar.unwrap_or(i64_t.const_zero().into());
+                            phis.push((v, abf));
+                        }
+                        if !is_last { self.builder.position_at_end(nb); }
+                    }
+                } else {
+                    // Match on primitives (i64, String)
+                    let na = arms.len();
+                    for (i, arm) in arms.iter().enumerate() {
+                        let pattern_clean = arm.pattern.chars().filter(|c| c.is_alphanumeric()).collect::<String>();
+                        let ab = self.context.append_basic_block(function, &format!("match_arm_{}_{}", i, pattern_clean));
+                        let is_last = i == na - 1;
+                        let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_arm_next") };
+                        
+                        let all_patterns: Vec<String> = if arm.patterns.is_empty() {
+                            vec![arm.pattern.clone()]
+                        } else {
+                            arm.patterns.clone()
+                        };
+                        
+                        let is_default = all_patterns.iter().any(|p| p == "_");
+                        let is_binding_var = arm.params.len() > 0 || arm.guard.is_some();
+                        let mut prim_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
+                        
+                        if !is_default && !is_binding_var {
+                            if ctn == "i64" || ctn == "Integer" {
+                                for pat in &all_patterns {
+                                    if let Some((start_str, end_str)) = pat.split_once("..") {
+                                        if let (Ok(start), Ok(end)) = (start_str.parse::<i64>(), end_str.parse::<i64>()) {
+                                            let cv_val = cv.into_int_value();
+                                            let cond_start = self.builder.build_int_compare(IntPredicate::SGE, cv_val, i64_t.const_int(start as u64, false), "range_start")?;
+                                            let cond_end = self.builder.build_int_compare(IntPredicate::SLE, cv_val, i64_t.const_int(end as u64, false), "range_end")?;
+                                            let range_cond = self.builder.build_and(cond_start, cond_end, "range_cond")?;
+                                            prim_match_cond = Some(match prim_match_cond {
+                                                Some(prev) => self.builder.build_or(prev, range_cond, "range_or")?,
+                                                None => range_cond,
+                                            });
+                                        }
+                                    } else if let Ok(val) = pat.parse::<i64>() {
+                                        let cond = self.builder.build_int_compare(IntPredicate::EQ, cv.into_int_value(), i64_t.const_int(val as u64, false), "match_cond")?;
+                                        prim_match_cond = Some(match prim_match_cond {
+                                            Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                            None => cond,
+                                        });
+                                    }
+                                }
+                            } else if ctn == "String" {
+                                for pat in &all_patterns {
+                                    let pattern_str = if pat.starts_with('"') && pat.ends_with('"') {
+                                        &pat[1..pat.len()-1]
+                                    } else {
+                                        pat.as_str()
+                                    };
+                                    let cmp_fn = self.module.get_function("aion_str_eq").ok_or_else(|| CompileError::Internal("aion_str_eq not found".to_string()))?;
+                                    let pat_global = self.builder.build_global_string_ptr(pattern_str, "match_pat")?;
+                                    let cmp_result = self.builder.build_call(cmp_fn, &[cv.into(), pat_global.as_basic_value_enum().into()], "str_cmp")?.try_as_basic_value().unwrap_basic().into_int_value();
+                                    let cond = self.builder.build_int_compare(IntPredicate::NE, cmp_result, i64_t.const_zero(), "str_match")?;
+                                    prim_match_cond = Some(match prim_match_cond {
+                                        Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                        None => cond,
+                                    });
+                                }
+                            }
+                        }
+                        
+                        if (is_default || is_binding_var) && prim_match_cond.is_none() {
+                            self.builder.build_unconditional_branch(ab)?;
+                        } else if let Some(cond) = prim_match_cond {
+                            self.builder.build_conditional_branch(cond, ab, nb)?;
+                        } else {
+                            self.builder.build_unconditional_branch(nb)?;
+                        }
+                        if is_last && !is_default && !is_binding_var {
+                            let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                            phis.push((i64_t.const_zero().into(), test_bb));
+                        }
+                        self.builder.position_at_end(ab);
+                        let mut av = variables.clone();
+                        if !arm.params.is_empty() {
+                            let lt = self.aion_type_to_llvm(&ctn);
+                            let pa = self.builder.build_alloca(lt, &arm.params[0])?;
+                            self.builder.build_store(pa, cv)?;
+                            av.insert(arm.params[0].clone(), (pa, lt, ctn.clone()));
+                        }
+                        
+                        if let Some(guard_expr) = &arm.guard {
+                            let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
+                            let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                            let guard_fail_bb = nb;
+                            let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
+                            self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                            self.builder.position_at_end(guard_pass_bb);
+                        }
+                        
+                        let ar = self.compile_block(&arm.body, &mut av, function)?;
+                        let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                        if abf.get_terminator().is_none() {
+                            let v = ar.unwrap_or(i64_t.const_zero().into());
+                            phis.push((v, abf));
+                        }
+                        if !is_last { self.builder.position_at_end(nb); }
+                    }
+                }
+                
+                self.builder.position_at_end(exit_bb);
+                if !phis.is_empty() {
+                    let target_type = phis[0].0.get_type();
+                    let mut final_phis = Vec::new();
+                    for (mut v, b) in phis {
+                        self.builder.position_at_end(b);
+                        if v.get_type() != target_type {
+                            if target_type.is_pointer_type() && v.is_int_value() {
+                                v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?.into();
+                            } else if target_type.is_int_type() && v.is_pointer_value() {
+                                v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?.into();
+                            }
+                        }
+                        self.builder.build_unconditional_branch(exit_bb)?;
+                        final_phis.push((v, b));
+                    }
+                    self.builder.position_at_end(exit_bb);
+                    let phi = self.builder.build_phi(target_type, "match_res")?;
+                    for (v, b) in final_phis { phi.add_incoming(&[(&v, b)]); }
+                    Ok(phi.as_basic_value())
+                } else {
+                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() {
+                        self.builder.build_unconditional_branch(exit_bb)?;
+                    }
+                    self.builder.position_at_end(exit_bb);
+                    Ok(i64_t.const_zero().into())
+                }
+            },
             _ => Ok(i64_t.const_zero().into()),
         }
     }
@@ -1405,6 +1634,16 @@ impl<'ctx> Compiler<'ctx> {
                 if t.starts_with('*') { t[1..].to_string().replace(" ", "") } else { "unknown".to_string() }
             },
             Expression::TypeRef { name, generic_args, .. } => { if generic_args.is_empty() { name.clone() } else { format!("{}<{}>", name, generic_args.join(",")) } },
+            Expression::Match { arms, .. } => {
+                if let Some(arm) = arms.first() {
+                    if let Some(s) = arm.body.last() {
+                        match s {
+                            Statement::ExpressionStmt(e, _) | Statement::Return { value: e, .. } => self.get_expr_type_name(e, variables),
+                            _ => "unknown".to_string()
+                        }
+                    } else { "unknown".to_string() }
+                } else { "unknown".to_string() }
+            },
             _ => "unknown".to_string(),
         };
         res.replace(" ", "")

--- a/src/codegen/transpiler/sql.rs
+++ b/src/codegen/transpiler/sql.rs
@@ -131,6 +131,7 @@ impl SqlTranspiler {
             Expression::TypeRef { .. } => "i64",
             Expression::Duration(..) => "Duration",
             Expression::Date(..) => "Date",
+            Expression::Match { .. } => "i64",
         }
         .to_string()
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -806,6 +806,155 @@ impl<'a> Parser<'a> {
                 }
                 Expression::If { condition: Box::new(condition), then_branch, else_branch, span }
             },
+            TokenKind::Match => {
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                let condition = self.parse_expression();
+                if self.current_token.kind != TokenKind::LBrace { 
+                    Expression::Match { condition: Box::new(condition), arms: vec![], span }
+                } else {
+                    self.next_token();
+                    let mut arms = Vec::new();
+                    while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+                        let mut pattern = String::new();
+                        let mut is_valid_pattern = false;
+                        
+                        match &self.current_token.kind {
+                            TokenKind::Identifier(p) => {
+                                pattern = p.clone(); 
+                                self.next_token();
+                                let mut struct_fields: Vec<(String, String)> = Vec::new();
+                                if self.current_token.kind == TokenKind::LBrace {
+                                    self.next_token();
+                                    while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+                                        if let TokenKind::Identifier(field_name) = &self.current_token.kind {
+                                            let fn_str = field_name.clone();
+                                            self.next_token();
+                                            if self.current_token.kind == TokenKind::Colon {
+                                                self.next_token();
+                                                if let TokenKind::Identifier(var_name) = &self.current_token.kind {
+                                                    struct_fields.push((fn_str, var_name.clone()));
+                                                    self.next_token();
+                                                }
+                                            }
+                                        }
+                                        if self.current_token.kind == TokenKind::Comma {
+                                            self.next_token();
+                                        }
+                                    }
+                                    if self.current_token.kind == TokenKind::RBrace {
+                                        self.next_token();
+                                    }
+                                }
+                                if !struct_fields.is_empty() {
+                                    let fields_str = struct_fields.iter()
+                                        .map(|(f, v)| format!("{}:{}", f, v))
+                                        .collect::<Vec<_>>()
+                                        .join(",");
+                                    pattern = format!("{}_{{{}}}", pattern, fields_str);
+                                }
+                                
+                                while self.current_token.kind == TokenKind::DoubleColon || self.current_token.kind == TokenKind::Dot {
+                                    let op = if self.current_token.kind == TokenKind::DoubleColon { "::" } else { "." };
+                                    self.next_token();
+                                    if let TokenKind::Identifier(sub) = &self.current_token.kind {
+                                        pattern.push_str(op);
+                                        pattern.push_str(sub);
+                                        self.next_token();
+                                    } else { break; }
+                                }
+                                is_valid_pattern = true;
+                            },
+                            TokenKind::IntLiteral(n) => {
+                                pattern = n.to_string();
+                                self.next_token();
+                                if self.current_token.kind == TokenKind::Range {
+                                    self.next_token();
+                                    if let TokenKind::IntLiteral(end_n) = &self.current_token.kind {
+                                        pattern = format!("{}..{}", pattern, end_n);
+                                        self.next_token();
+                                    }
+                                }
+                                is_valid_pattern = true;
+                            },
+                            TokenKind::StringLiteral(s) => {
+                                pattern = format!("\"{}\"", s);
+                                self.next_token();
+                                is_valid_pattern = true;
+                            },
+                            TokenKind::Range => {
+                                self.next_token();
+                            },
+                            _ => {
+                                self.next_token();
+                            }
+                        }
+
+                        if is_valid_pattern {
+                            let mut patterns = vec![pattern.clone()];
+                            while self.current_token.kind == TokenKind::Pipe {
+                                self.next_token();
+                                match &self.current_token.kind {
+                                    TokenKind::Identifier(p) => { patterns.push(p.clone()); self.next_token(); },
+                                    TokenKind::IntLiteral(n) => { patterns.push(n.to_string()); self.next_token(); },
+                                    TokenKind::StringLiteral(s) => { patterns.push(format!("\"{}\"", s)); self.next_token(); },
+                                    _ => { break; }
+                                }
+                            }
+                            
+                            let mut params = Vec::new();
+                            
+                            if patterns.len() == 1 {
+                                let pat = &patterns[0];
+                                let is_lower = !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
+                                let is_identifier = pat.chars().all(|c| c.is_alphanumeric() || c == '_');
+                                let is_not_underscore = pat != "_";
+                                let followed_by_guard_or_arrow = self.current_token.kind == TokenKind::If || self.current_token.kind == TokenKind::Arrow;
+                                
+                                if is_lower && is_identifier && is_not_underscore && followed_by_guard_or_arrow {
+                                    params.push(pat.clone());
+                                    patterns.clear();
+                                }
+                            }
+                            
+                            if self.current_token.kind == TokenKind::LParen {
+                                self.next_token();
+                                while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                                    if let TokenKind::Identifier(param) = &self.current_token.kind {
+                                        params.push(param.clone());
+                                        self.next_token();
+                                    } else {
+                                        self.next_token();
+                                    }
+                                    if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                                }
+                                if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                            }
+
+                            let guard = if self.current_token.kind == TokenKind::If {
+                                self.next_token();
+                                Some(Box::new(self.parse_expression()))
+                            } else {
+                                None
+                            };
+
+                            if self.current_token.kind == TokenKind::Arrow {
+                                self.next_token();
+                                let body = if self.current_token.kind == TokenKind::LBrace { self.parse_block() } else {
+                                    match self.parse_statement() {
+                                        Some(s) => vec![s],
+                                        None => vec![],
+                                    }
+                                };
+                                arms.push(MatchArm { pattern, patterns, guard, params, body });
+                            }
+                        }
+                        if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                    }
+                    if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
+                    Expression::Match { condition: Box::new(condition), arms, span }
+                }
+            },
             TokenKind::LBrace => {
                 let span = Span::from_token(&self.current_token);
                 Expression::Block { statements: self.parse_block(), is_unsafe: false, span }

--- a/tests/fixtures/language/match_expression.ai
+++ b/tests/fixtures/language/match_expression.ai
@@ -1,0 +1,16 @@
+fn classify(x: i64) -> String {
+    return match x {
+        0 => "zero",
+        1 => "one",
+        2..10 => "small",
+        _ => "large",
+    }
+}
+
+fn main() {
+    let a = classify(0)
+    let b = classify(5)
+    let c = classify(42)
+    io.println("Match expressions work")
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -108,6 +108,8 @@ fn test_string_methods() { assert_snapshot!(run_aion_test("stdlib/string_methods
 fn test_loop_basic() { assert_snapshot!(run_aion_test("language/loop_basic")); }
 #[test]
 fn test_function_types() { assert_snapshot!(run_aion_test("language/function_types")); }
+#[test]
+fn test_match_expression() { assert_snapshot!(run_aion_test("language/match_expression")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__match_expression.snap
+++ b/tests/snapshots/integration__match_expression.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+assertion_line: 112
+expression: "run_aion_test(\"language/match_expression\")"
+---
+Match expressions work


### PR DESCRIPTION
## Summary
- Add `Expression::Match` variant to AST
- Parse match in expression context (e.g., `let x = match val { ... }`)
- Type checker returns common type of all arm bodies
- Codegen compiles match expressions with PHI nodes

## Changes
- `src/ast/expr.rs`: Add `Expression::Match` variant with condition, arms, and span
- `src/parser/mod.rs`: Parse match expressions in `parse_primary()`
- `src/analysis/checker.rs`: Handle `Expression::Match` in type checker
- `src/codegen/compiler.rs`: Compile match expressions with PHI nodes for values
- `src/codegen/transpiler/sql.rs`: Handle `Expression::Match` in SQL transpiler

## Testing
- All 65 tests pass (64 existing + 1 new)
- New test: `match_expression.ai` with snapshot

## Example
```
let x = match val {
    0 => "zero",
    1 => "one",
    _ => "other",
}
```

Closes #33