### PR TITLE
fix: @sizeof now works on variable instances

### DIFF
--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -1255,7 +1255,14 @@ impl<'ctx> Compiler<'ctx> {
                 }
                 if an == "sizeof" && !aa.is_empty() { 
                     let tnm = match &aa[0] { 
-                        Expression::Identifier(s, _) => s.clone(), 
+                        Expression::Identifier(s, _) => {
+                            // First check if it's a variable in the environment
+                            if let Some((_, _, vtn)) = variables.get(s) {
+                                vtn.clone()
+                            } else {
+                                s.clone()
+                            }
+                        },
                         Expression::TypeRef { name, .. } => name.clone(), 
                         _ => "i64".to_string() 
                     }; 

--- a/tests/fixtures/language/sizeof_variables.ai
+++ b/tests/fixtures/language/sizeof_variables.ai
@@ -1,0 +1,24 @@
+use std.io
+use std.string
+
+struct Point {
+    x: i64,
+    y: i64
+}
+
+fn main() {
+    let n = 42
+    let size1 = @sizeof(n)
+    io.println(string.from_int(size1))
+
+    let p = Point { x: 10, y: 20 }
+    let size2 = @sizeof(p)
+    io.println(string.from_int(size2))
+
+    let s = "hello"
+    let size3 = @sizeof(s)
+    io.println(string.from_int(size3))
+
+    let size4 = @sizeof(i64)
+    io.println(string.from_int(size4))
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -112,6 +112,8 @@ fn test_function_types() { assert_snapshot!(run_aion_test("language/function_typ
 fn test_match_expression() { assert_snapshot!(run_aion_test("language/match_expression")); }
 #[test]
 fn test_option_result_methods() { assert_snapshot!(run_aion_test("language/option_result_methods")); }
+#[test]
+fn test_sizeof_variables() { assert_snapshot!(run_aion_test("language/sizeof_variables")); }
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__sizeof_variables.snap
+++ b/tests/snapshots/integration__sizeof_variables.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: run_aion_test("language/sizeof_variables")
+---
+8
+16
+8
+8


### PR DESCRIPTION
## Summary
- `@sizeof(x)` now works when `x` is a variable, not just a type name
- Looks up the variable's type in the environment before falling back to treating the identifier as a type name
- `@sizeof(i64)` still works as before

## Changes
- `src/codegen/compiler.rs`: In the `sizeof` intrinsic handler, check if the identifier is a variable in the environment and use its type
- `tests/fixtures/language/sizeof_variables.ai`: Test with `i64`, struct, and string variables
- `tests/snapshots/integration__sizeof_variables.snap`: Snapshot

## Testing
- All 67 tests pass
- `@sizeof(n)` where `n: i64` → 8 ✅
- `@sizeof(p)` where `p: Point` → 16 ✅
- `@sizeof(s)` where `s: String` → 8 ✅ (pointer)
- `@sizeof(i64)` → 8 ✅ (type name still works)

Closes #43