### PR TITLE
refactor: remove redundant mem_zero loop in HashMap::clear()

### DIFF
--- a/stdlib/std/collections/map.ai
+++ b/stdlib/std/collections/map.ai
@@ -191,21 +191,13 @@ impl HashMap<V> {
             }
             i = i + 1;
         }
-        // Deallocate old bucket array and allocate a fresh zeroed one.
-        // mem_zero only writes a single pointer (8 bytes) which is insufficient
-        // to clear a full Entry<V> struct (24 bytes).  A fresh allocation from
-        // GC_malloc is properly zero-initialised.
+        // Allocate a fresh bucket array.  Using mem_zero here is not
+        // sufficient because the intrinsic only emits a single pointer
+        // constant (8 bytes) while Entry<V> occupies 24 bytes at the
+        // LLVM level.  A fresh GC_malloc is properly zero-initialised.
         unsafe { core.heap.dealloc(self.buckets as *u8); }
         self.cap = 16;
         let buckets = unsafe { core.heap.alloc(self.cap * 8) as *Entry<V> };
-        let mut ri = 0;
-        while ri < self.cap {
-            unsafe {
-                let p = buckets.offset(ri);
-                *p = unsafe { @intrinsic("mem_zero") };
-            }
-            ri = ri + 1;
-        }
         self.buckets = buckets;
         self.len = 0;
     }


### PR DESCRIPTION
## Summary

Refs #62

### What
Removes the redundant `mem_zero` initialisation loop from `HashMap::clear()`. Since `GC_malloc` already returns zero-initialised memory, explicitly zeroing each bucket slot is unnecessary. This also reduces reliance on the `mem_zero` intrinsic which is known to only emit 8 bytes (a single pointer constant) — insufficient for multi-field structs.

### Why not a full fix for #62
The root cause is that `aion_type_to_llvm` maps all struct types to LLVM `ptr_type`, discarding size information. This means `compile_lvalue` never returns an LLVM struct type, so the assignment codegen cannot emit a properly-sized store. A full fix requires restructuring the type mapping layer — tracked in #62.