### PR TITLE
ci: add PR title conventional commit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
     branches: [main]
 
 jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check PR title follows conventional commit format
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          echo "PR title: $title"
+          if echo "$title" | grep -qP '^(feat|fix|refactor|docs|test|chore)(\(.+\))?: '; then
+            echo "ok"
+          else
+            echo "PR title must match: type: description (e.g. feat: add foo, fix: correct bar)"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a GitHub Actions job that validates PR titles follow the conventional commit format (`type: description`).

### Check
- Triggers only on PRs (`if: github.event_name == 'pull_request'`)
- Fails if the title doesn't match `^(feat|fix|refactor|docs|test|chore): `
- Runs in ~1 second (no Docker build needed)

This enforces the naming convention documented in `docs/workflow.md`.