### PR TITLE
fix: mem_zero handles struct types; add mem_zero_ptr intrinsic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - **Strict Conciseness**: Respond directly and without unnecessary politeness to save output tokens. Get straight to the point (no "hello", "I will do it", or "here is").
 - **Quiet Shell Commands**: Always use quiet flags (`-q`, `--quiet`, or `> /dev/null`) for shell commands when detailed output is not needed (e.g. dependency installation, successful builds).
 - **Doc Freshness**: When modifying code behavior, architecture, or workflow, update the corresponding `docs/*.md` file in the same commit. Never leave stale docs — they will mislead future sessions.
+- **Test Coverage**: When adding or changing compiler/lexer/parser/codegen behavior, add or update test fixtures under `tests/fixtures/` covering the new behavior (nominal case + edge cases). Run `INSTA_UPDATE=always cargo test` to generate snapshots, then verify their content before committing. Never ship a behavior change without an accompanying test.
 
 ## Project Overview
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -80,8 +80,11 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
   via `aion_char_to_str` — do not use this for integer formatting.
 - **Comparison**: `==` and `!=` compare string content via `aion_str_eq`
   when both operands are `String`; otherwise pointer comparison.
-- **Safety**: `unsafe` blocks required for pointer dereferences, FFI,
-  and specific intrinsics (see `docs/SPEC_SANDBOX.md`).
+- **`mem_zero`**: `@intrinsic("mem_zero")` returns a null pointer (8 bytes). `@intrinsic("mem_zero", Type)` returns a properly-sized zero constant for struct/enum types by looking up the actual LLVM struct type. For primitives, returns the zero value of that type.
+- **`mem_zero_ptr`**: `@intrinsic("mem_zero_ptr", ptr, size)` calls `aion_memzero` to zero `size` bytes of existing memory. Used for in-place zeroing of bucket arrays and reusable buffers.
+- **`mem_is_null`**: `@intrinsic("mem_is_null", ptr)` returns `true` if the pointer is null.
+- **`sizeof`**: `@intrinsic("sizeof", Type)` returns the LLVM size of the type in bytes. Works on both variable instances and type names.
+- **Safety**: `unsafe` blocks required for pointer dereferences, FFI, and specific intrinsics (see `docs/SPEC_SANDBOX.md`).
 
 ## 4. Temporal Primitives
 
@@ -162,7 +165,6 @@ The Aion-written compiler lives in `compiler/`:
 - No RAII / destructors (GC-only memory model).
 - LLVM opaque pointers require explicit type casting in edge cases.
 - Cross-compilation targets are not yet supported (x86_64-linux only).
-- `mem_zero` intrinsic cannot zero multi-field structs (#62).
 - `instantiate_function` and `substitute_types_in_expr` still use naive
   string-based type resolution (#67).
 - f-string interpolation requires explicit `string.from_*` wrapping for

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,7 @@ editors/          — Editor integrations (vscode/)
 
 ## Known Pitfalls (discovered during bug fixing)
 
-- **All structs → `ptr_type` at LLVM level**: `aion_type_to_llvm` maps every struct/enum/string type to an opaque pointer. Field access uses GEP with the LLVM struct type for offset calculation, but load/store operations are always pointer-sized (8 bytes). Consequence: `@intrinsic("mem_zero")` only emits 8 bytes of zeros — it cannot zero a multi-field struct (see #62). A proper fix requires restructuring the type mapping layer so struct LLVM types carry actual field type/size information.
+- **All structs → `ptr_type` at LLVM level**: `aion_type_to_llvm` maps every struct/enum/string type to an opaque pointer. Field access uses GEP with the LLVM struct type for offset calculation, but load/store operations are always pointer-sized (8 bytes). `@intrinsic("mem_zero", Type)` now looks up the actual LLVM struct type from `struct_types` and returns a properly-sized zero constant. `@intrinsic("mem_zero_ptr", ptr, size)` calls `aion_memzero` to zero existing memory blocks (fixed #62).
 
 - **String-based type resolution in codegen**: `get_expr_type_name` and `instantiate_function` resolve types via string manipulation (e.g., `replace("V", "String")`). This corrupts type names when a generic parameter appears as a substring of another type name (e.g., `"V"` in `"Vector"` → `"Stringector"`, fixed in #61). `substitute_generic_params()` handles this by replacing only `<Param>` patterns. The same fragility remains in `instantiate_function` and `substitute_types_in_expr` (see #67).
 

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -379,6 +379,7 @@ impl<'ctx> Compiler<'ctx> {
         self.module.add_function("aion_get_argc", i64_t.fn_type(&[], false), None); 
         self.module.add_function("aion_get_argv_index", pt.fn_type(&[i64_t.into()], false), None); 
         self.module.add_function("aion_malloc", pt.fn_type(&[i64_t.into()], false), None); 
+        self.module.add_function("aion_memzero", self.context.void_type().fn_type(&[pt.into(), i64_t.into()], false), None); 
         self.module.add_function("aion_str_at", i64_t.fn_type(&[pt.into(), i64_t.into()], false), None); 
         self.module.add_function("aion_str_substr", pt.fn_type(&[pt.into(), i64_t.into(), i64_t.into()], false), None); 
         self.module.add_function("aion_char_to_str", pt.fn_type(&[i64_t.into()], false), None);
@@ -1300,12 +1301,29 @@ impl<'ctx> Compiler<'ctx> {
                             Expression::TypeRef { name, .. } => name.clone(), 
                             _ => "i64".to_string() 
                         };
+                        if let Some(sn) = self.resolve_fuzzy_name(&self.struct_types, &tnm) {
+                            if let Some(st) = self.struct_types.get(&sn) {
+                                return Ok(st.const_zero().into());
+                            }
+                        }
+                        if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, &tnm) {
+                            if let Some(et) = self.enum_types.get(&en) {
+                                return Ok(et.const_zero().into());
+                            }
+                        }
                         let lt = self.aion_type_to_llvm(&tnm);
                         if lt.is_pointer_type() { return Ok(lt.into_pointer_type().const_null().into()); }
                         if lt.is_int_type() { return Ok(lt.into_int_type().const_zero().into()); }
                         if lt.is_float_type() { return Ok(lt.into_float_type().const_zero().into()); }
                     }
                     return Ok(pt.const_null().into());
+                }
+                if an == "mem_zero_ptr" && aa.len() >= 2 {
+                    let ptr = self.compile_expr(&aa[0], variables, function)?.into_pointer_value();
+                    let size = self.compile_expr(&aa[1], variables, function)?.into_int_value();
+                    let fnc = self.module.get_function("aion_memzero").ok_or_else(|| CompileError::Internal("aion_memzero not found".to_string()))?;
+                    self.builder.build_call(fnc, &[ptr.into(), size.into()], "memzero")?;
+                    return Ok(i64_t.const_zero().into());
                 }
                 let lnm = match an.as_str() { "str_len" => "strlen".to_string(), "str_ptr" => return Ok(self.compile_expr(&aa[0], variables, function)?), "fs_read_to_string" => "aion_read_file".to_string(), "fs_write" => "aion_write_file".to_string(), "fs_append" => "aion_append_file".to_string(), "exit" => "exit".to_string(), _ if an.starts_with("libc.") => an.replace("libc.", ""), _ => format!("aion_{}", an) };
                 let fv = self.module.get_function(&lnm).ok_or_else(|| CompileError::Internal(format!("Intrinsic '{}' not found", lnm)))?; 

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -28,6 +28,10 @@ void aion_free(void* ptr) {
     // GC handles freeing
 }
 
+void aion_memzero(void* ptr, size_t size) {
+    memset(ptr, 0, size);
+}
+
 void aion_io_print(const char* msg) {
     if (msg) printf("%s", msg);
     fflush(stdout);

--- a/stdlib/std/collections/map.ai
+++ b/stdlib/std/collections/map.ai
@@ -191,14 +191,10 @@ impl HashMap<V> {
             }
             i = i + 1;
         }
-        // Allocate a fresh bucket array.  Using mem_zero here is not
-        // sufficient because the intrinsic only emits a single pointer
-        // constant (8 bytes) while Entry<V> occupies 24 bytes at the
-        // LLVM level.  A fresh GC_malloc is properly zero-initialised.
-        unsafe { core.heap.dealloc(self.buckets as *u8); }
-        self.cap = 16;
-        let buckets = unsafe { core.heap.alloc(self.cap * 8) as *Entry<V> };
-        self.buckets = buckets;
+        // Zero the bucket array in-place. GC_malloc already returns zeroed
+        // memory, but after insert/removal the buckets may contain stale
+        // pointers. aion_memzero properly zeroes all cap*8 bytes.
+        unsafe { @intrinsic("mem_zero_ptr", self.buckets as *u8, self.cap * 8) };
         self.len = 0;
     }
 

--- a/tests/fixtures/stdlib/memzero_struct.ai
+++ b/tests/fixtures/stdlib/memzero_struct.ai
@@ -1,0 +1,50 @@
+use std.collections.map
+use std.string
+
+struct Counter {
+    count: i64,
+    label: String,
+}
+
+fn main() {
+    // Test 1: mem_zero_ptr on a raw buffer
+    let buf = unsafe { core.heap.alloc(24) as *i64 };
+    unsafe { 
+        *buf = 42;
+        @intrinsic("mem_zero_ptr", buf as *u8, 8);
+    }
+    let val = unsafe { *buf };
+    let val_str = string.from_int(val)
+    io.println(val_str)
+    
+    // Test 2: HashMap clear() properly zeroes buckets
+    let mut map = HashMap<String>.new()
+    map.insert("one", "first")
+    map.insert("two", "second")
+    
+    if map.contains_key("one") {
+        io.println("before clear: one exists")
+    }
+    
+    map.clear()
+    
+    if map.contains_key("one") {
+        io.println("after clear: one still exists (BUG)")
+    } else {
+        io.println("after clear: one gone")
+    }
+    
+    if map.contains_key("two") {
+        io.println("after clear: two still exists (BUG)")
+    } else {
+        io.println("after clear: two gone")
+    }
+    
+    // Test 3: re-insert after clear works
+    map.insert("three", "third")
+    if map.contains_key("three") {
+        io.println("re-insert works")
+    }
+    
+    return 0
+}

--- a/tests/fixtures/stdlib/memzero_typed.ai
+++ b/tests/fixtures/stdlib/memzero_typed.ai
@@ -1,0 +1,51 @@
+use std.string
+use core.heap
+
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+fn main() {
+    // Test 1: mem_zero without an argument returns a null pointer (8 bytes).
+    // Used throughout HashMap for null-initializing bucket slots.
+    let null_ptr = unsafe { @intrinsic("mem_zero") as *i64 }
+    let is_null = unsafe { @intrinsic("mem_is_null", null_ptr) }
+    if is_null {
+        io.println("mem_zero no-arg is null")
+    } else {
+        io.println("BUG: mem_zero no-arg not null")
+    }
+
+    // Test 2: mem_zero with a struct type produces a zeroed struct.
+    // Write a struct pointer into a slot, then overwrite with mem_zero(Triple).
+    // The slot should go from non-zero (pointer) to zero (zeroed struct).
+    let p = unsafe { core.heap.alloc(24) as *Triple }
+    unsafe { *p = Triple { a: 7, b: 8, c: 9 } }
+    let raw = unsafe { p as *i64 }
+    let before = unsafe { *raw }
+    if before != 0 {
+        io.println("before mem_zero: non-zero")
+    } else {
+        io.println("BUG: before mem_zero: zero")
+    }
+
+    unsafe { *p = @intrinsic("mem_zero", Triple) }
+    let after = unsafe { *raw }
+    if after == 0 {
+        io.println("after mem_zero(Triple): zero")
+    } else {
+        io.println("BUG: after mem_zero(Triple): non-zero")
+    }
+
+    // Test 3: mem_zero on a primitive type returns the zero value.
+    let zero_int = @intrinsic("mem_zero", i64)
+    if zero_int == 0 {
+        io.println("mem_zero(i64) is zero")
+    } else {
+        io.println("BUG: mem_zero(i64) non-zero")
+    }
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -165,6 +165,8 @@ fn test_sql_advanced() { assert_snapshot!(run_aion_test("stdlib/sql_advanced"));
 fn test_json_parse_basic() { assert_snapshot!(run_aion_test("stdlib/json_parse_basic")); }
 #[test]
 fn test_memzero_struct() { assert_snapshot!(run_aion_test("stdlib/memzero_struct")); }
+#[test]
+fn test_memzero_typed() { assert_snapshot!(run_aion_test("stdlib/memzero_typed")); }
 
 // --- Compiler Tests ---
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -163,6 +163,8 @@ fn test_dataframe_basic() { assert_snapshot!(run_aion_test("stdlib/dataframe_bas
 fn test_sql_advanced() { assert_snapshot!(run_aion_test("stdlib/sql_advanced")); }
 #[test]
 fn test_json_parse_basic() { assert_snapshot!(run_aion_test("stdlib/json_parse_basic")); }
+#[test]
+fn test_memzero_struct() { assert_snapshot!(run_aion_test("stdlib/memzero_struct")); }
 
 // --- Compiler Tests ---
 

--- a/tests/snapshots/integration__memzero_struct.snap
+++ b/tests/snapshots/integration__memzero_struct.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/memzero_struct\")"
+---
+0
+before clear: one exists
+after clear: one gone
+after clear: two gone
+re-insert works

--- a/tests/snapshots/integration__memzero_typed.snap
+++ b/tests/snapshots/integration__memzero_typed.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/memzero_typed\")"
+---
+mem_zero no-arg is null
+before mem_zero: non-zero
+after mem_zero(Triple): zero
+mem_zero(i64) is zero


### PR DESCRIPTION
## Summary
Fixes #62 — `@intrinsic("mem_zero")` only emitted 8 bytes of zeros, insufficient for multi-field structs.

## Changes

### mem_zero with type argument
`@intrinsic("mem_zero", Type)` now looks up the actual LLVM struct type from `struct_types`/`enum_types` and returns `st.const_zero()` — a properly-sized zero constant for the struct. Previously it mapped everything to `ptr_type` and returned `ptr.const_null()` (8 bytes).

### New mem_zero_ptr intrinsic
`@intrinsic("mem_zero_ptr", ptr, size)` calls `aion_memzero(ptr, size)` in the runtime (`memset(ptr, 0, size)`). Used for in-place zeroing of existing memory blocks.

### HashMap.clear() fixed
Rewritten to use `mem_zero_ptr` on existing buckets instead of deallocating + re-allocating. Removes the workaround comment about `mem_zero` being insufficient.

### Runtime
Added `aion_memzero(void* ptr, size_t size)` to `src/runtime.c`.

## Test
New fixture `tests/fixtures/stdlib/memzero_struct.ai` validates:
1. `mem_zero_ptr` on a raw buffer (value goes to 0)
2. `HashMap.clear()` properly zeroes buckets (no stale entries)
3. Re-insert after clear works

All 72 tests pass.

## Docs
- `docs/SPEC.md`: documented `mem_zero`, `mem_zero_ptr`, `mem_is_null`, `sizeof` intrinsics. Removed #62 from Known Limitations.
- `docs/architecture.md`: updated Known Pitfalls section.

Closes #62
