### PR TITLE
feat: add Vector utils — is_empty, first, last, contains, clear, swap, insert, remove, set

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -32,8 +32,7 @@ Common imports (`Option`, `Result`, `String`, `Vector`, `print`, `println`).
 ## 2. Data Structures & Algorithms
 
 ### `std.collections`
-- **`vector`** **[stable]** — `Vector<T>` (dynamic array). Missing `iter`,
-  `map`, `filter`, `fold` (tracked by issue #35).
+- **`vector`** **[stable]** — `Vector<T>` (dynamic array). Includes `new`, `push`, `pop`, `get`, `set`, `len`, `is_empty`, `first`, `last`, `contains`, `clear`, `swap`, `insert`, `remove`. Missing `iter`/`map`/`filter`/`fold` (blocked: no closures in Aion yet).
 - **`list`** **[stub]** — `LinkedList<T>` (singly linked).
 - **`map`** **[stable]** — `HashMap<V>` (generic V, string key). Includes
   `contains_key`, `keys`, `values`, `clear`, `remove`.

--- a/stdlib/std/collections/vector.ai
+++ b/stdlib/std/collections/vector.ai
@@ -58,6 +58,110 @@ impl Vector<T> {
         return self.len;
     }
 
+    pub fn is_empty(self) -> bool {
+        return self.len == 0;
+    }
+
+    pub fn first(self) -> Option<T> {
+        if self.len == 0 {
+            return Option::None;
+        }
+        return self.get(0);
+    }
+
+    pub fn last(self) -> Option<T> {
+        if self.len == 0 {
+            return Option::None;
+        }
+        return self.get(self.len - 1);
+    }
+
+    pub fn contains(self, value: T) -> bool {
+        let mut i = 0;
+        while i < self.len {
+            let elem = self.get(i).unwrap();
+            if elem == value {
+                return true;
+            }
+            i = i + 1;
+        }
+        return false;
+    }
+
+    pub fn clear(mut self) {
+        self.len = 0;
+    }
+
+    pub fn swap(mut self, i: i64, j: i64) {
+        if i < 0 || i >= self.len || j < 0 || j >= self.len {
+            return;
+        }
+        unsafe {
+            let p = self.ptr;
+            let pi = p.offset(i);
+            let pj = p.offset(j);
+            let tmp = *pi;
+            *pi = *pj;
+            *pj = tmp;
+        }
+    }
+
+    pub fn insert(mut self, index: i64, value: T) {
+        if index < 0 || index > self.len {
+            return;
+        }
+        if self.len == self.cap {
+            self.grow();
+        }
+        let mut i = self.len;
+        while i > index {
+            unsafe {
+                let p = self.ptr;
+                let src = p.offset(i - 1);
+                let dst = p.offset(i);
+                *dst = *src;
+            }
+            i = i - 1;
+        }
+        unsafe {
+            let p = self.ptr;
+            let dst = p.offset(index);
+            *dst = value;
+        }
+        self.len = self.len + 1;
+    }
+
+    pub fn remove(mut self, index: i64) -> Option<T> {
+        if index < 0 || index >= self.len {
+            return Option::None;
+        }
+        unsafe {
+            let p = self.ptr;
+            let src = p.offset(index);
+            let value = *src;
+            let mut i = index;
+            while i < self.len - 1 {
+                let src_ptr = p.offset(i + 1);
+                let dst_ptr = p.offset(i);
+                *dst_ptr = *src_ptr;
+                i = i + 1;
+            }
+            self.len = self.len - 1;
+            return Option::Some(value);
+        }
+    }
+
+    pub fn set(mut self, index: i64, value: T) {
+        if index < 0 || index >= self.len {
+            return;
+        }
+        unsafe {
+            let p = self.ptr;
+            let dst = p.offset(index);
+            *dst = value;
+        }
+    }
+
     fn grow(mut self) {
         let new_cap = if self.cap == 0 { 4 } else { self.cap * 2 };
         let byte_size = new_cap * @sizeof(T);

--- a/tests/fixtures/stdlib/vector_contains.ai
+++ b/tests/fixtures/stdlib/vector_contains.ai
@@ -1,0 +1,41 @@
+use std.collections.vector
+use std.string
+
+fn main() {
+    let mut v = Vector<i64>.new()
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    
+    if v.contains(20) {
+        io.println("contains 20")
+    } else {
+        io.println("BUG: missing 20")
+    }
+    
+    if v.contains(99) {
+        io.println("BUG: false positive 99")
+    } else {
+        io.println("does not contain 99")
+    }
+    
+    // String vector
+    let mut s = Vector<String>.new()
+    s.push("alpha")
+    s.push("beta")
+    s.push("gamma")
+    
+    if s.contains("beta") {
+        io.println("contains beta")
+    } else {
+        io.println("BUG: missing beta")
+    }
+    
+    if s.contains("zzz") {
+        io.println("BUG: false positive zzz")
+    } else {
+        io.println("does not contain zzz")
+    }
+    
+    return 0
+}

--- a/tests/fixtures/stdlib/vector_edge.ai
+++ b/tests/fixtures/stdlib/vector_edge.ai
@@ -1,0 +1,82 @@
+use std.collections.vector
+use std.string
+
+fn main() {
+    let mut v = Vector<i64>.new()
+
+    // Edge: operations on empty vector
+    if v.first().is_none() {
+        io.println("first on empty: None")
+    }
+    if v.last().is_none() {
+        io.println("last on empty: None")
+    }
+    if v.remove(0).is_none() {
+        io.println("remove on empty: None")
+    }
+    if v.contains(42) == false {
+        io.println("contains on empty: false")
+    }
+
+    // Edge: insert at front (index 0) — all elements shift
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    v.insert(0, 5)
+    let e0 = v.get(0).unwrap()
+    let e1 = v.get(1).unwrap()
+    let e2 = v.get(2).unwrap()
+    let e3 = v.get(3).unwrap()
+    io.println(string.from_int(e0))
+    io.println(string.from_int(e1))
+    io.println(string.from_int(e2))
+    io.println(string.from_int(e3))
+
+    // Edge: insert at end (index == len) — no shift, behaves like push
+    let cur_len = v.len()
+    v.insert(cur_len, 99)
+    let last_elem = v.last().unwrap()
+    io.println(string.from_int(last_elem))
+
+    // Edge: remove at last index — no shift
+    let before_len = v.len()
+    let removed_last = v.remove(before_len - 1).unwrap()
+    io.println(string.from_int(removed_last))
+    let after_len = v.len()
+    io.println(string.from_int(after_len))
+
+    // Edge: swap with same index — no-op
+    v.swap(0, 0)
+    let same = v.get(0).unwrap()
+    io.println(string.from_int(same))
+
+    // Edge: out-of-bounds operations are no-ops
+    v.set(999, 42)
+    let still_ok = v.get(0).unwrap()
+    io.println(string.from_int(still_ok))
+    v.swap(0, 999)
+    let after_bad_swap = v.get(0).unwrap()
+    io.println(string.from_int(after_bad_swap))
+    if v.remove(999).is_none() {
+        io.println("remove OOB: None")
+    }
+
+    // Edge: String vector insert/remove — pointer types, not i64
+    let mut sv = Vector<String>.new()
+    sv.push("alpha")
+    sv.push("gamma")
+    sv.insert(1, "beta")
+    let s0 = sv.get(0).unwrap()
+    let s1 = sv.get(1).unwrap()
+    let s2 = sv.get(2).unwrap()
+    io.println(s0)
+    io.println(s1)
+    io.println(s2)
+
+    let removed_str = sv.remove(0).unwrap()
+    io.println(removed_str)
+    let after_str = sv.get(0).unwrap()
+    io.println(after_str)
+
+    return 0
+}

--- a/tests/fixtures/stdlib/vector_utils.ai
+++ b/tests/fixtures/stdlib/vector_utils.ai
@@ -1,0 +1,74 @@
+use std.collections.vector
+use std.string
+
+fn main() {
+    let mut v = Vector<i64>.new()
+    
+    // Test is_empty
+    if v.is_empty() {
+        io.println("empty at start")
+    }
+    
+    v.push(10)
+    v.push(20)
+    v.push(30)
+    
+    if v.is_empty() == false {
+        io.println("not empty after push")
+    }
+    
+    // Test len
+    let n = v.len()
+    io.println(string.from_int(n))
+    
+    // Test first / last
+    let f = v.first().unwrap()
+    io.println(string.from_int(f))
+    let l = v.last().unwrap()
+    io.println(string.from_int(l))
+    
+    // Test get
+    let g = v.get(1).unwrap()
+    io.println(string.from_int(g))
+    
+    // Test set
+    v.set(1, 99)
+    let s = v.get(1).unwrap()
+    io.println(string.from_int(s))
+    
+    // Test swap
+    v.swap(0, 2)
+    let s0 = v.get(0).unwrap()
+    let s2 = v.get(2).unwrap()
+    io.println(string.from_int(s0))
+    io.println(string.from_int(s2))
+    
+    // Test insert
+    v.insert(1, 55)
+    let i0 = v.get(0).unwrap()
+    let i1 = v.get(1).unwrap()
+    let i2 = v.get(2).unwrap()
+    io.println(string.from_int(i0))
+    io.println(string.from_int(i1))
+    io.println(string.from_int(i2))
+    let new_len = v.len()
+    io.println(string.from_int(new_len))
+    
+    // Test remove
+    let removed = v.remove(0).unwrap()
+    io.println(string.from_int(removed))
+    let after_remove = v.get(0).unwrap()
+    io.println(string.from_int(after_remove))
+    let final_len = v.len()
+    io.println(string.from_int(final_len))
+    
+    // Test clear
+    v.clear()
+    let cleared = v.len()
+    io.println(string.from_int(cleared))
+    if v.is_empty() {
+        io.println("empty after clear")
+    }
+    
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -146,6 +146,10 @@ fn test_vector_generic() { assert_snapshot!(run_aion_test("stdlib/vector_generic
 #[test]
 fn test_vector_push_pop() { assert_snapshot!(run_aion_test("stdlib/vector_push_pop")); }
 #[test]
+fn test_vector_utils() { assert_snapshot!(run_aion_test("stdlib/vector_utils")); }
+#[test]
+fn test_vector_contains() { assert_snapshot!(run_aion_test("stdlib/vector_contains")); }
+#[test]
 fn test_hashmap_basic() { assert_snapshot!(run_aion_test("stdlib/hashmap_basic")); }
 #[test]
 fn test_hashmap_resize_hashset() { assert_snapshot!(run_aion_test("stdlib/hashmap_resize_hashset")); }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -150,6 +150,8 @@ fn test_vector_utils() { assert_snapshot!(run_aion_test("stdlib/vector_utils"));
 #[test]
 fn test_vector_contains() { assert_snapshot!(run_aion_test("stdlib/vector_contains")); }
 #[test]
+fn test_vector_edge() { assert_snapshot!(run_aion_test("stdlib/vector_edge")); }
+#[test]
 fn test_hashmap_basic() { assert_snapshot!(run_aion_test("stdlib/hashmap_basic")); }
 #[test]
 fn test_hashmap_resize_hashset() { assert_snapshot!(run_aion_test("stdlib/hashmap_resize_hashset")); }

--- a/tests/snapshots/integration__vector_contains.snap
+++ b/tests/snapshots/integration__vector_contains.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/vector_contains\")"
+---
+contains 20
+does not contain 99
+contains beta
+does not contain zzz

--- a/tests/snapshots/integration__vector_edge.snap
+++ b/tests/snapshots/integration__vector_edge.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/vector_edge\")"
+---
+first on empty: None
+last on empty: None
+remove on empty: None
+contains on empty: false
+5
+10
+20
+30
+99
+99
+4
+5
+5
+5
+remove OOB: None
+alpha
+beta
+gamma
+alpha
+beta

--- a/tests/snapshots/integration__vector_utils.snap
+++ b/tests/snapshots/integration__vector_utils.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/vector_utils\")"
+---
+empty at start
+not empty after push
+3
+10
+30
+20
+99
+30
+10
+30
+55
+99
+4
+30
+55
+3
+0
+empty after clear


### PR DESCRIPTION
## Summary
Adds 9 utility methods to `Vector<T>`, partially closing #35. `map`/`filter`/`fold` are blocked by lack of closures (new issue #84).

## Changes

### Stdlib
`stdlib/std/collections/vector.ai` — added 9 methods to `impl Vector<T>`:
- `is_empty()` — returns `true` if `len == 0`
- `first()` — returns `Option<T>` (first element or None)
- `last()` — returns `Option<T>` (last element or None)
- `contains(value: T)` — linear scan with `==`, works on `i64` and `String`
- `clear()` — sets `len = 0` (keeps allocation)
- `swap(i, j)` — swaps two elements in-place
- `insert(index, value)` — shifts elements right, inserts at index
- `remove(index)` — shifts elements left, returns removed element as `Option<T>`
- `set(index, value)` — overwrites element at index

### Docs
`docs/STDLIB.md` — updated vector status: removed "Missing iter, map, filter, fold (tracked by issue #35)", now lists all implemented methods + notes that map/filter/fold are blocked by lack of closures.

## Tests
- [x] Fixture added: `tests/fixtures/stdlib/vector_utils.ai` — all 9 methods (is_empty, first, last, get, set, swap, insert, remove, clear)
- [x] Fixture added: `tests/fixtures/stdlib/vector_contains.ai` — contains on `Vector<i64>` and `Vector<String>`
- [x] All 75 tests pass
- [x] Snapshots reviewed — deterministic output (no heap addresses)

## Docs
- [x] `docs/STDLIB.md` updated — vector status marker reflects new methods

## Notes
`map`/`filter`/`fold`/`find`/`iter` are **not** included — they require closures or function-as-value, which Aion does not support yet. Opened issue #84 to track function pointer support. Commented on #35 with details.

Closes #35 (partially — map/filter/fold deferred to #84)
