### PR TITLE
docs: require edge cases + error cases in test coverage rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,9 +34,13 @@ Checklist of conditions that must be true for the issue to be closed.
 
 ## Tests required
 <!--
-Per AGENTS.md Test Coverage rule: every behavior change needs a fixture.
+Per AGENTS.md Test Coverage rule: every behavior change needs fixtures
+covering nominal + edge + error cases.
 Describe the test(s) to add under tests/fixtures/.
-- [ ] ...
+- [ ] Nominal: ...
+- [ ] Edge cases: empty inputs, boundary indices (0, len-1, len),
+      out-of-bounds, type variations, no-op conditions.
+- [ ] Error cases: invalid inputs produce documented errors, not crashes.
 -->
 
 ## Related

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,9 +27,14 @@ Checklist of conditions that must be true for the issue to be closed.
 
 ## Tests required
 <!--
-Per AGENTS.md Test Coverage rule: every new feature needs fixtures.
-Describe the test(s) to add under tests/fixtures/ (nominal + edge cases).
-- [ ] ...
+Per AGENTS.md Test Coverage rule: every new feature needs fixtures
+covering nominal + edge + error cases.
+Describe the test(s) to add under tests/fixtures/.
+- [ ] Nominal: the happy path — normal inputs producing expected output.
+- [ ] Edge cases: empty inputs, boundary indices (0, len-1, len),
+      out-of-bounds, type variations (i64 vs String vs struct),
+      no-op conditions, overflow/truncation.
+- [ ] Error cases: invalid inputs produce documented errors, not crashes.
 -->
 
 ## Related

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@
 - **Strict Conciseness**: Respond directly and without unnecessary politeness to save output tokens. Get straight to the point (no "hello", "I will do it", or "here is").
 - **Quiet Shell Commands**: Always use quiet flags (`-q`, `--quiet`, or `> /dev/null`) for shell commands when detailed output is not needed (e.g. dependency installation, successful builds).
 - **Doc Freshness**: When modifying code behavior, architecture, or workflow, update the corresponding `docs/*.md` file in the same commit. Never leave stale docs — they will mislead future sessions.
-- **Test Coverage**: When adding or changing compiler/lexer/parser/codegen behavior, add or update test fixtures under `tests/fixtures/` covering the new behavior (nominal case + edge cases). Run `INSTA_UPDATE=always cargo test` to generate snapshots, then verify their content before committing. Never ship a behavior change without an accompanying test.
+- **Test Coverage**: When adding or changing compiler/lexer/parser/codegen behavior, add or update test fixtures under `tests/fixtures/` covering the new behavior. Run `INSTA_UPDATE=always cargo test` to generate snapshots, then verify their content before committing. Never ship a behavior change without an accompanying test. Each fixture must cover:
+  - **Nominal case**: the happy path — normal inputs producing expected output.
+  - **Edge cases**: empty inputs, boundary indices (0, len-1, len), out-of-bounds, type variations (i64 vs String vs struct), no-op conditions (e.g. `swap(i, i)`), and any overflow/truncation scenarios relevant to the feature.
+  - **Error cases**: where applicable — invalid inputs should produce the documented error, not a crash. Snapshot the stderr for expected-failure tests.
 - **Never run git add, commit, or push without explicit user approval**.
 
 ## Project Overview


### PR DESCRIPTION
## Summary
Formalizes the test coverage rule to explicitly require nominal + edge + error cases, not just the happy path.

## Changes

### AGENTS.md
Test Coverage rule expanded from "nominal case + edge cases" to explicitly list:
- **Nominal case**: happy path — normal inputs producing expected output
- **Edge cases**: empty inputs, boundary indices (0, len-1, len), out-of-bounds, type variations (i64 vs String vs struct), no-op conditions (e.g. `swap(i, i)`), overflow/truncation
- **Error cases**: invalid inputs produce documented errors, not crashes. Snapshot stderr for expected-failure tests.

### Issue templates
`bug_report.md` and `feature_request.md` — "Tests required" section now has 3 checkboxes (nominal, edge, error) with guidance comments.

## Motivation
PR #85 (Vector utils) initially shipped with only nominal tests. Edge cases (empty vector, insert at front/end, OOB, String vs i64 pointer shift, swap no-op) were added only when explicitly prompted. Formalizing the rule ensures future PRs include edge cases from the start, reducing back-and-forth during review.

## Tests
- [x] No code changes — docs/templates only
- [x] Verified templates render correctly on GitHub

## Docs
- [x] `AGENTS.md` updated — Test Coverage rule expanded
- [x] `.github/ISSUE_TEMPLATE/bug_report.md` updated
- [x] `.github/ISSUE_TEMPLATE/feature_request.md` updated

## Closes
N/A
