### PR TITLE
fix(parser): allow multi-arg generic calls foo<A, B>(...) (#91)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -49,8 +49,12 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
 - **Enums** compile as `{ i64, [64 x i8] }` — index 0 = Tag, index 1 =
   Payload (64 bytes). Tags: `Some/Ok = 0`, `None/Err = 1`.
 - **Generics**: monomorphization at compile time. Full type substitution
-  before LLVM generation. Generic params are substituted via
-  `<Param>`-pattern matching to avoid corrupting nested type names.
+  before LLVM generation. Generic params are substituted via token-aware
+  identifier matching (`substitute_type_string`) to avoid corrupting
+  nested type names (param `T` no longer clobbers `Tensor`). Explicit
+  instantiation supports single- and multi-arg calls (`foo<A, B>(...)`)
+  and nested arg lists (`Vector<HashMap<K, V>>`); the comma separating
+  args is recognized inside the angle list.
 - **Pointers**: `*T` for explicit pointer types. All complex types are
   passed by reference. Dereferencing `*T` yields `T` in the type checker,
   so `(*p).field` works for `p: *Struct` (member access also resolves when

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -754,9 +754,15 @@ impl<'a> Parser<'a> {
             while angle_count > 0 {
                 let tok = self.peek_at(i);
                 match tok.kind {
+                    // Tokens that cannot appear inside a generic-argument list but do
+                    // appear in a less-than comparison context. Comma is intentionally
+                    // NOT here: Aion has no comma operator at the expression level, and
+                    // `foo<A, B>(...)` needs the comma to keep scanning. Less-than inside
+                    // call/struct/aggregate args is still rejected because RParen/LBrace
+                    // abort the scan before the angles can balance.
                     TokenKind::EOF | TokenKind::LBrace | TokenKind::Semicolon | TokenKind::Eq | 
                     TokenKind::Or | TokenKind::And | TokenKind::Plus | TokenKind::Minus | 
-                    TokenKind::RParen | TokenKind::Comma => return false,
+                    TokenKind::RParen => return false,
                     TokenKind::Lt => angle_count += 1,
                     TokenKind::Gt => angle_count -= 1,
                     _ => {}

--- a/tests/fixtures/language/generics_multi_arg.ai
+++ b/tests/fixtures/language/generics_multi_arg.ai
@@ -1,0 +1,80 @@
+use std.string
+
+// Two-parameter generics: explicit instantiation `foo<A, B>(...)` previously
+// failed to parse because is_generic_args_ahead aborted on Comma (#91).
+fn first<K, V>(k: K, v: V) -> K {
+    return k
+}
+
+fn second<K, V>(k: K, v: V) -> V {
+    return v
+}
+
+fn both<K, V>(k: K, v: V) -> i64 {
+    let _ = k
+    let _ = v
+    return 42
+}
+
+// Three-parameter generic — boundary for the comma scan.
+fn pick3<A, B, C>(a: A, b: B, c: C) -> B {
+    return b
+}
+
+// Single-param generic — regression guard for the comma-free path.
+fn identity<T>(x: T) -> T {
+    return x
+}
+
+// Helper whose call args use `<` separated by commas — the parser must treat
+// these as less-than comparisons, NOT as a generic-args list (RParen aborts the
+// generic scan, so removing Comma from the abort set must not regress this).
+fn max(a: i64, b: i64) -> i64 {
+    if a > b { return a }
+    return b
+}
+
+fn main() {
+    // Nominal: 2-param explicit instantiation.
+    let a = first<i64, String>(11, "hi")
+    if a == 11 {
+        io.println("first<i64, String>: 11")
+    } else {
+        io.println("BUG first")
+    }
+
+    let b = second<i64, String>(11, "hi")
+    io.println(b)
+
+    let r = both<i64, String>(11, "hi")
+    if r == 42 {
+        io.println("both<i64, String>: 42")
+    } else {
+        io.println("BUG both")
+    }
+
+    // Edge: 3-param explicit instantiation (boundary for the comma scan).
+    let p = pick3<i64, String, bool>(1, "middle", false)
+    io.println(p)
+
+    // Edge: single-arg generic still parses (comma-free).
+    let id = identity<i64>(99)
+    if id == 99 {
+        io.println("identity<i64>(99): 99")
+    } else {
+        io.println("BUG identity regression")
+    }
+
+    // Regression: less-than inside comma-separated call args parses as comparison.
+    if 3 < 5 {
+        io.println("lt: 3 < 5")
+    }
+    let m = max(1 < 2, 9 < 3)
+    if m == 1 {
+        io.println("lt-in-call-args: max(true, false) == 1")
+    } else {
+        io.println("BUG lt-in-call-args")
+    }
+
+    return 0
+}

--- a/tests/fixtures/language/generics_multi_arg_err.ai
+++ b/tests/fixtures/language/generics_multi_arg_err.ai
@@ -1,0 +1,9 @@
+fn make<K, V>(k: K) -> K { return k }
+
+// Unterminated generic-args list (no closing `>` before end of expression):
+// is_generic_args_ahead aborts on EOF/Semicolon and treats `<` as less-than,
+// yielding a clean type-checker error rather than a crash.
+fn main() {
+    let z = make<i64,
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -87,6 +87,10 @@ fn test_generics_local() { assert_snapshot!(run_aion_test("language/generics_loc
 #[test]
 fn test_generics_substring() { assert_snapshot!(run_aion_test("language/generics_substring")); }
 #[test]
+fn test_generics_multi_arg() { assert_snapshot!(run_aion_test("language/generics_multi_arg")); }
+#[test]
+fn test_generics_multi_arg_err() { assert_snapshot!(run_aion_test("language/generics_multi_arg_err")); }
+#[test]
 fn test_method_chaining() { assert_snapshot!(run_aion_test("language/method_chaining")); }
 #[test]
 fn test_short_circuit() { assert_snapshot!(run_aion_test("language/short_circuit")); }

--- a/tests/snapshots/integration__generics_multi_arg.snap
+++ b/tests/snapshots/integration__generics_multi_arg.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/generics_multi_arg\")"
+---
+first<i64, String>: 11
+hi
+both<i64, String>: 42
+middle
+identity<i64>(99): 99
+lt: 3 < 5
+lt-in-call-args: max(true, false) == 1

--- a/tests/snapshots/integration__generics_multi_arg_err.snap
+++ b/tests/snapshots/integration__generics_multi_arg_err.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/generics_multi_arg_err\")"
+---
+Incompatible operator Lt for types Function { is_unsafe: false, params: [Placeholder("K")], return_type: Placeholder("K") } and Unknown


### PR DESCRIPTION
## Summary
`is_generic_args_ahead` aborted the angle scan as soon as it saw a `TokenKind::Comma`, so multi-parameter explicit instantiations (`make_pair<i64, String>(...)`, `Vector<HashMap<K, V>>.new()`) failed to parse: the parser fell back to treating `<` as less-than and the checker reported `Incompatible operator Lt for types Function ... and Unknown`. Single-arg calls parsed fine because no comma appears before `>`. This PR removes `Comma` from the early-return set. Safe because Aion has no comma operator at the expression level — commas in expression positions only appear inside `()` / `{}` / `[]`, and `RParen`/`LBrace` remain in the abort set, so less-than comparisons inside call/struct args (`max(1 < 2, 9 < 3)`) still abort the scan before the angles can balance. Nested generic arg lists (`Vector<HashMap<i64, i64>>`) benefit too: a comma at `angle_count > 1` now passes through instead of aborting.

## Changes
### Parser
- `src/parser/mod.rs`: drop `TokenKind::Comma` from `is_generic_args_ahead`'s early-return set; comment added explaining why `Comma` is excluded while `RParen`/`LBrace`/arithmetic/logic tokens remain.

### Tests
- `tests/fixtures/language/generics_multi_arg.ai`: nominal (2-param `first`/`second`/`both`), edge (3-param `pick3`, single-arg `identity` regression guard, less-than inside comma-separated call args via `max(1 < 2, 9 < 3) == 1`).
- `tests/fixtures/language/generics_multi_arg_err.ai`: error case — unterminated generic list (`make<i64,`) produces a clean type-checker error (`Lt vs Function`), no crash.
- `tests/integration.rs`: registered both fixtures.
- Snapshots: `integration__generics_multi_arg.snap`, `integration__generics_multi_arg_err.snap` (reviewed). **No existing snapshot changed** — 82/82 pass.

### Docs
- `docs/SPEC.md`: documented multi-arg + nested generic call instantiation and the token-aware substitution that guards type-name corruption.

## Tests
- [x] Fixture added: `tests/fixtures/language/generics_multi_arg.ai` (nominal + edge), `tests/fixtures/language/generics_multi_arg_err.ai` (error)
- [x] All tests pass: `cargo test -- --test-threads=1` via Docker (80 → 82; zero regressions, zero snapshot drift)
- [x] Snapshots reviewed (not blindly accepted via INSTA_UPDATE=always)
- [x] Regression guard: `max(1 < 2, 9 < 3)` still parses `<` as less-than (RParen aborts the generic scan)

## Docs
- [x] `docs/SPEC.md` updated
- [ ] `docs/architecture.md` updated — N/A (no architectural change; the existing \"String-based type resolution\" pitfall already covers the codegen side, and this is purely a parser disambiguation heuristic)
- [ ] `stdlib/.../SPEC.md` updated — N/A
- [ ] `ROADMAP.md` checkbox updated — N/A (Phase 1.6 compiler-robustness umbrella)

## Closes
Closes #91.