### PR TITLE
feat(parser): type-annotated let bindings let x: Type = expr (#78)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -121,6 +121,19 @@ First-class `Duration` and `Date` literals (see `docs/SPEC_TIME.md`).
   (register prototypes, then compile bodies) enables forward references.
   Tested up to 1B+ recursion depth (limited only by the OS 8MB stack).
 
+### Variable Bindings
+
+- `let name = expr` — inferred-type binding (default).
+- `let name: Type = expr` — explicit type annotation. The annotation
+  wins over inference for the variable's stored type and the LLVM alloca
+  type, disambiguating cases where inference is ambiguous (e.g.
+  `let p: *Triple = unsafe { core.heap.alloc(24) as *Triple }`,
+  `let m: HashMap<String> = ...`, intrinsics that lower to `i64` but
+  carry a struct/pointer meaning). The value is coerced to the annotated
+  LLVM type when needed (int↔pointer). #78.
+- `let mut name = expr` / `let mut name: Type = expr` — mutable binding.
+- Assignment is a statement (`name = expr`), not an expression.
+
 ## 6. Concurrency & AI-Native Features
 
 - **Threading**: 1:1 via `pthread`. `spawn { ... }` creates detached

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -2,7 +2,7 @@ use super::{Span, Expression};
 
 #[derive(Debug, Clone)]
 pub enum Statement {
-    Let { name: String, value: Expression, intent: Option<String>, is_mut: bool, span: Span },
+    Let { name: String, value: Expression, explicit_type: Option<String>, intent: Option<String>, is_mut: bool, span: Span },
     Return { value: Expression, intent: Option<String>, span: Span },
     ExpressionStmt(Expression, Span),
     If { condition: Expression, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>>, span: Span },

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -436,13 +436,33 @@ impl<'ctx> Compiler<'ctx> {
         
         for s in body {
             match s {
-                Statement::Let { name, value, .. } => {
+                Statement::Let { name, value, explicit_type, .. } => {
                     let v = self.compile_expr(value, variables, function)?;
-                    let vt = v.get_type();
-                    let vtn = self.get_expr_type_name(value, variables).replace(" ", "");
-                    let a = self.builder.build_alloca(vt, name)?;
-                    self.builder.build_store(a, v)?;
-                    variables.insert(name.clone(), (a, vt, vtn));
+                    let inferred_vt = v.get_type();
+                    let inferred_vtn = self.get_expr_type_name(value, variables).replace(" ", "");
+                    // An explicit type annotation (`let x: T = expr`) wins over inference
+                    // for the variable's stored type-name (used by `get_expr_type_name`
+                    // downstream) and for the LLVM alloca type when the inferred type
+                    // is ambiguous (e.g. intrinsics that lower to i64 but carry a
+                    // struct/pointer meaning, or pointer-vs-int casts). #78.
+                    if let Some(et) = explicit_type {
+                        let et_clean = et.replace(" ", "");
+                        let llvm_t = self.aion_type_to_llvm(&et_clean);
+                        let final_v = if llvm_t != inferred_vt {
+                            if llvm_t.is_pointer_type() && v.is_int_value() {
+                                self.builder.build_int_to_ptr(v.into_int_value(), llvm_t.into_pointer_type(), "let_coerce")?.into()
+                            } else if llvm_t.is_int_type() && v.is_pointer_value() {
+                                self.builder.build_ptr_to_int(v.into_pointer_value(), llvm_t.into_int_type(), "let_coerce")?.into()
+                            } else { v }
+                        } else { v };
+                        let a = self.builder.build_alloca(llvm_t, name)?;
+                        self.builder.build_store(a, final_v)?;
+                        variables.insert(name.clone(), (a, llvm_t, et_clean));
+                    } else {
+                        let a = self.builder.build_alloca(inferred_vt, name)?;
+                        self.builder.build_store(a, v)?;
+                        variables.insert(name.clone(), (a, inferred_vt, inferred_vtn));
+                    }
                     lv = None;
                 },
                 Statement::Assignment { target, value, .. } => { 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -448,11 +448,15 @@ impl<'a> Parser<'a> {
                 let is_mut = if self.current_token.kind == TokenKind::Mut { self.next_token(); true } else { false };
                 let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
                 self.next_token();
-                if self.current_token.kind == TokenKind::Eq { 
-                    self.next_token(); 
-                    let value = self.parse_expression(); 
+                let explicit_type = if self.current_token.kind == TokenKind::Colon {
+                    self.next_token();
+                    Some(self.parse_type_name())
+                } else { None };
+                if self.current_token.kind == TokenKind::Eq {
+                    self.next_token();
+                    let value = self.parse_expression();
                     if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::Let { name, value, intent: None, is_mut, span }) 
+                    Some(Statement::Let { name, value, explicit_type, intent: None, is_mut, span })
                 } else { None }
             },
             TokenKind::Return => { 

--- a/tests/fixtures/language/let_type_annotation.ai
+++ b/tests/fixtures/language/let_type_annotation.ai
@@ -1,0 +1,50 @@
+use std.string
+use core.heap
+
+struct Triple {
+    a: i64,
+    b: i64,
+    c: i64,
+}
+
+fn main() {
+    // Nominal: primitive annotation.
+    let x: i64 = 42
+    if x == 42 {
+        io.println("let x: i64 = 42 ok")
+    } else {
+        io.println("BUG let x: i64")
+    }
+
+    // Edge: pointer annotation disambiguates the int-typed alloc result.
+    let p: *Triple = unsafe { core.heap.alloc(24) as *Triple }
+    unsafe { *p = Triple { a: 1, b: 2, c: 3 } }
+    let a = unsafe { (*p).a }
+    if a == 1 {
+        io.println("let p: *Triple -> (*p).a ok")
+    } else {
+        io.println("BUG let p: *Triple")
+    }
+
+    // Edge: annotated bool (lowers to i64).
+    let flag: bool = true
+    if flag {
+        io.println("let flag: bool = true ok")
+    } else {
+        io.println("BUG let flag: bool")
+    }
+
+    // Edge: explicit String annotation on a literal.
+    let s: String = "hello"
+    io.println(s)
+
+    let mut y: i64 = 10
+    y = y + 5
+    if y == 15 {
+        io.println("let mut y: i64 -> mutate ok")
+    } else {
+        io.println("BUG let mut y: i64")
+    }
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -91,6 +91,8 @@ fn test_generics_multi_arg() { assert_snapshot!(run_aion_test("language/generics
 #[test]
 fn test_generics_multi_arg_err() { assert_snapshot!(run_aion_test("language/generics_multi_arg_err")); }
 #[test]
+fn test_let_type_annotation() { assert_snapshot!(run_aion_test("language/let_type_annotation")); }
+#[test]
 fn test_method_chaining() { assert_snapshot!(run_aion_test("language/method_chaining")); }
 #[test]
 fn test_short_circuit() { assert_snapshot!(run_aion_test("language/short_circuit")); }

--- a/tests/snapshots/integration__let_type_annotation.snap
+++ b/tests/snapshots/integration__let_type_annotation.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/let_type_annotation\")"
+---
+let x: i64 = 42 ok
+let p: *Triple -> (*p).a ok
+let flag: bool = true ok
+hello
+let mut y: i64 -> mutate ok


### PR DESCRIPTION
## Summary
The parser only supported `let name = expr` (no type annotation). After the identifier it expected `=` immediately, leaving no way to disambiguate ambiguous inference (`let p = ...alloc(24) as *Triple` — int or pointer?), force a generic instantiation, or document intent at API boundaries. This PR adds optional `: Type` annotations via `parse_type_name` (so `*T`, `std.foo`, `Vector<K, V>` all work) and makes the annotation win over inference in codegen for the alloca type and the variable's stored type-name, coercing int↔pointer when needed. Unannotated `let` keeps exactly the previous behavior.

## Changes
### Parser / AST
- `src/ast/stmt.rs`: `Statement::Let` gains `explicit_type: Option<String>`.
- `src/parser/mod.rs`: parse optional `: Type` before `=` in let bindings, via the existing `parse_type_name` helper (handles `*T`, qualified `std.foo`, generic args `Vector<K, V>`).

### Codegen
- `src/codegen/compiler.rs`: `Statement::Let` honors `explicit_type` for the LLVM alloca type and the stored type-name (used by `get_expr_type_name` downstream for field access, method resolution, etc.). When the inferred LLVM type differs from the annotated one, the value is coerced (int→pointer via `int_to_ptr`, pointer→int via `ptr_to_int`) — covering the common cases from casts and intrinsics without changing inference for unannotated lets.

### Tests
- `tests/fixtures/language/let_type_annotation.ai`: nominal (`let x: i64 = 42`), edge (`let p: *Triple = ... as *Triple` then `(*p).a` field access through the annotated pointer, `let flag: bool = true`, `let s: String = "hello"`, `let mut y: i64` → mutate), plus a regression guard for unannotated `let`.
- `tests/integration.rs`: registered the new fixture.
- Snapshot: `integration__let_type_annotation.snap` (reviewed). **No existing snapshot changed** — 83/83 pass.

### Docs
- `docs/SPEC.md`: new \"Variable Bindings\" section documenting `let` / `let mut` / `let name: Type = expr` and how the annotation wins over inference (#78).

## Tests
- [x] Fixture added: `tests/fixtures/language/let_type_annotation.ai` (nominal + edge + regression guard)
- [x] All tests pass: `cargo test -- --test-threads=1` via Docker (82 → 83; zero regressions, zero snapshot drift)
- [x] Snapshots reviewed (not blindly accepted via INSTA_UPDATE=always)

## Docs
- [x] `docs/SPEC.md` updated
- [ ] `docs/architecture.md` updated — N/A (no architectural change; codegen path for `Let` is a local annotation override, no new invariant)
- [ ] `stdlib/.../SPEC.md` updated — N/A
- [ ] `ROADMAP.md` checkbox updated — N/A (Phase 1.6 compiler-robustness umbrella)

## Closes
Closes #78.