### PR TITLE
refactor(compiler): structured errors + did-you-mean suggestions (#40)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -108,7 +108,23 @@ First-class `Duration` and `Date` literals (see `docs/SPEC_TIME.md`).
 - **Error handling**: zero `unwrap()` in production paths. All compiler
   stages return `Result<T, CompileError>` with typed variants: `Type`,
   `Unsafe`, `NotFound`, `NotFunction`, `InvalidOperator`, `Inkwell`,
-  `Io`, `Import`, `Internal`.
+  `Io`, `Import`, `Internal`, `Warning`. Every variant carries `line`,
+  `col`, and `snippet` (snippets are populated when the location is
+  known; `Inkwell`/`Io`/`Import` location-default to `0`/`None` when the
+  error has no source position — e.g. a file-read failure). #40.
+- **`internal compiler error:` prefix**: the `Internal` variant renders
+  its message with a leading `internal compiler error: ` so user-facing
+  type errors are visually distinct from compiler bugs. #40.
+- **"Did you mean X?" suggestions**: undefined-function, -field, and
+  -method errors (via the `NotFound` variant) carry a Levenshtein-closest
+  suggestion from the candidate symbols in scope ("Not Found: function
+  'greet_word' is not defined (did you mean 'greet_world'?)"). Suggestion
+  is only surfaced when the closest candidate is within 3 edits AND within
+  `max(1, len/3)` of the typed name, so short typos do not match unrelated
+  short names. #40.
+- **`Warning` variant**: a non-fatal variant (renders `warning: ...`) for
+  future passes (unused-var, dead-code, ...). `CompileError::is_warning()`
+  lets the driver print to stderr without halting compilation. #40.
 - **Block termination**: every LLVM basic block is guaranteed to be
   terminated. The compiler injects `ret` or `unreachable` when
   `get_terminator().is_none()`.
@@ -116,7 +132,7 @@ First-class `Duration` and `Date` literals (see `docs/SPEC_TIME.md`).
   are explicit and validated.
 - **Debug hygiene**: no `println!`/`eprintln!` in production builds.
 - **Span tracking**: all AST nodes carry `Span` (line, col) for precise
-  error reporting. Quality of error messages is tracked by issue #40.
+  error reporting.
 - **Recursion**: full self- and mutual-recursion. Two-pass compilation
   (register prototypes, then compile bodies) enables forward references.
   Tested up to 1B+ recursion depth (limited only by the OS 8MB stack).

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -1,8 +1,8 @@
-use crate::ast::{Span, Statement, Expression, Program, Declaration};
-use super::types::Type;
 use super::environment::Environment;
+use super::types::Type;
+use crate::ast::{Declaration, Expression, Program, Span, Statement};
+use crate::error::{CompileError, suggest_closest};
 use crate::lexer::token::{Token, TokenKind};
-use crate::error::CompileError;
 
 use std::collections::HashMap;
 
@@ -27,8 +27,8 @@ impl TypeChecker {
     }
 
     pub fn with_source(source: &str) -> Self {
-        let mut checker = Self { 
-            env: Environment::new(), 
+        let mut checker = Self {
+            env: Environment::new(),
             type_params: HashMap::new(),
             decls: HashMap::new(),
             current_module: None,
@@ -44,44 +44,241 @@ impl TypeChecker {
         CompileError::new(msg, span.line, span.col).with_snippet(&self.source)
     }
 
+    /// "Did you mean X?" suggestion for an undefined function name. Candidate
+    /// source is the simple (rightmost-segment) name of every Function
+    /// declaration in scope. Returns `None` when nothing is close enough. #40.
+    fn suggest_function(&self, typed: &str) -> Option<String> {
+        let fns: Vec<String> = self
+            .decls
+            .iter()
+            .filter_map(|(k, v)| match v {
+                Declaration::Function(_) => Some(k.rsplit('.').next().unwrap_or(k).to_string()),
+                _ => None,
+            })
+            .collect();
+        suggest_closest(typed, &fns)
+    }
+
+    /// "Did you mean X?" suggestion for an undefined struct field. Candidates
+    /// are the declared field names of `struct_name` (looked up fuzzily among
+    /// self.decls since the user may have used the short name). #40.
+    fn suggest_field(&self, struct_name: &str, typed: &str) -> Option<String> {
+        let full = self
+            .resolve_fuzzy_name(&self.decls, struct_name)
+            .unwrap_or_else(|| struct_name.to_string());
+        let fields: Vec<String> = match self.decls.get(&full) {
+            Some(Declaration::Struct(s)) => s.fields.iter().map(|(n, _)| n.clone()).collect(),
+            _ => return None,
+        };
+        suggest_closest(typed, &fields)
+    }
+
+    /// "Did you mean X?" suggestion for an undefined method. Candidates are the
+    /// method suffixes declared on `type_name` — declared via `impl` blocks as
+    /// `Type::method` entries in `self.decls` (and the env). #40.
+    fn suggest_method(&self, type_name: &str, typed: &str) -> Option<String> {
+        let full = self
+            .resolve_fuzzy_name(&self.decls, type_name)
+            .unwrap_or_else(|| type_name.to_string());
+        let prefix_dot = format!("{}.", full);
+        let prefix_colon = format!("{}::", full);
+        let methods: Vec<String> = self
+            .decls
+            .keys()
+            .filter_map(|k| {
+                k.strip_prefix(&prefix_dot)
+                    .or_else(|| k.strip_prefix(&prefix_colon))
+                    .map(|s| s.to_string())
+            })
+            .collect();
+        suggest_closest(typed, &methods)
+    }
+
     fn resolve_type(&self, name: &str) -> Type {
         if let Some(t) = self.type_params.get(name) {
             return t.clone();
         }
         let trimmed = name.trim();
-        if let Some(t) = self.env.get(trimmed) { return t; }
+        if let Some(t) = self.env.get(trimmed) {
+            return t;
+        }
         if let Some(ref module) = self.current_module {
             let full_name = format!("{}.{}", module, trimmed);
-            if let Some(t) = self.env.get(&full_name) { return t; }
+            if let Some(t) = self.env.get(&full_name) {
+                return t;
+            }
         }
         Type::from_str(trimmed)
     }
 
     fn register_builtins(&mut self) {
-        self.env.set("aion_read_file".to_string(), Type::Function { is_unsafe: true, params: vec![Type::String], return_type: Box::new(Type::String) });
-        self.env.set("aion_write_file".to_string(), Type::Function { is_unsafe: true, params: vec![Type::String, Type::String], return_type: Box::new(Type::Integer) });
-        self.env.set("aion_get_argc".to_string(), Type::Function { is_unsafe: true, params: vec![], return_type: Box::new(Type::Integer) });
-        self.env.set("aion_get_argv_index".to_string(), Type::Function { is_unsafe: true, params: vec![Type::Integer], return_type: Box::new(Type::String) });
-        self.env.set("aion_str_ptr".to_string(), Type::Function { is_unsafe: true, params: vec![Type::String], return_type: Box::new(Type::Pointer(Box::new(Type::Integer))) });
-        self.env.set("exit".to_string(), Type::Function { is_unsafe: true, params: vec![Type::Integer], return_type: Box::new(Type::Unit) });
-        self.env.set("aion_exit".to_string(), Type::Function { is_unsafe: true, params: vec![Type::Integer], return_type: Box::new(Type::Unit) });
+        self.env.set(
+            "aion_read_file".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        self.env.set(
+            "aion_write_file".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "aion_get_argc".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "aion_get_argv_index".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::Integer],
+                return_type: Box::new(Type::String),
+            },
+        );
+        self.env.set(
+            "aion_str_ptr".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Pointer(Box::new(Type::Integer))),
+            },
+        );
+        self.env.set(
+            "exit".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::Integer],
+                return_type: Box::new(Type::Unit),
+            },
+        );
+        self.env.set(
+            "aion_exit".to_string(),
+            Type::Function {
+                is_unsafe: true,
+                params: vec![Type::Integer],
+                return_type: Box::new(Type::Unit),
+            },
+        );
 
-        self.env.set("io.println".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::Unit) });
-        self.env.set("io.print".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::Unit) });
-        self.env.set("env.var".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::GenericInstance("Option".to_string(), vec![Type::String])) });
-        self.env.set("mem.is_null".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Pointer(Box::new(Type::Unknown))], return_type: Box::new(Type::Boolean) });
-        self.env.set("string.len".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::Integer) });
-        self.env.set("String.len".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::Integer) });
-        self.env.set("string.concat".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String, Type::String], return_type: Box::new(Type::String) });
-        self.env.set("string.from_int".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Integer], return_type: Box::new(Type::String) });
-        self.env.set("string.from_float".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Float], return_type: Box::new(Type::String) });
-        self.env.set("string.to_float".to_string(), Type::Function { is_unsafe: false, params: vec![Type::String], return_type: Box::new(Type::Float) });
-        
+        self.env.set(
+            "io.println".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Unit),
+            },
+        );
+        self.env.set(
+            "io.print".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Unit),
+            },
+        );
+        self.env.set(
+            "env.var".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::GenericInstance(
+                    "Option".to_string(),
+                    vec![Type::String],
+                )),
+            },
+        );
+        self.env.set(
+            "mem.is_null".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Pointer(Box::new(Type::Unknown))],
+                return_type: Box::new(Type::Boolean),
+            },
+        );
+        self.env.set(
+            "string.len".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "String.len".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "string.concat".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String, Type::String],
+                return_type: Box::new(Type::String),
+            },
+        );
+        self.env.set(
+            "string.from_int".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Integer],
+                return_type: Box::new(Type::String),
+            },
+        );
+        self.env.set(
+            "string.from_float".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Float],
+                return_type: Box::new(Type::String),
+            },
+        );
+        self.env.set(
+            "string.to_float".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::String],
+                return_type: Box::new(Type::Float),
+            },
+        );
+
         // i64 methods as functions
-        self.env.set("i64.abs".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Integer], return_type: Box::new(Type::Integer) });
-        self.env.set("i64.max".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Integer, Type::Integer], return_type: Box::new(Type::Integer) });
-        self.env.set("i64.min".to_string(), Type::Function { is_unsafe: false, params: vec![Type::Integer, Type::Integer], return_type: Box::new(Type::Integer) });
-        
+        self.env.set(
+            "i64.abs".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Integer],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "i64.max".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Integer, Type::Integer],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+        self.env.set(
+            "i64.min".to_string(),
+            Type::Function {
+                is_unsafe: false,
+                params: vec![Type::Integer, Type::Integer],
+                return_type: Box::new(Type::Integer),
+            },
+        );
+
         self.env.set("argc".to_string(), Type::Integer);
         self.env.set("argv".to_string(), Type::String);
     }
@@ -94,39 +291,83 @@ impl TypeChecker {
                     self.decls.insert(f.name.clone(), decl.clone());
                     let is_unsafe = f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe);
                     let ret_type = self.resolve_type(&f.return_type);
-                    let param_types: Vec<Type> = f.params.iter().map(|(_, pt, _)| self.resolve_type(pt)).collect();
-                    self.env.set(f.name.clone(), Type::Function { is_unsafe, params: param_types, return_type: Box::new(ret_type) });
-                },
+                    let param_types: Vec<Type> = f
+                        .params
+                        .iter()
+                        .map(|(_, pt, _)| self.resolve_type(pt))
+                        .collect();
+                    self.env.set(
+                        f.name.clone(),
+                        Type::Function {
+                            is_unsafe,
+                            params: param_types,
+                            return_type: Box::new(ret_type),
+                        },
+                    );
+                }
                 Declaration::Enum(e) => {
                     self.decls.insert(e.name.clone(), decl.clone());
-                    self.env.set(e.name.clone(), Type::Enum { name: e.name.clone() });
-                },
+                    self.env.set(
+                        e.name.clone(),
+                        Type::Enum {
+                            name: e.name.clone(),
+                        },
+                    );
+                }
                 Declaration::Struct(s) => {
                     self.decls.insert(s.name.clone(), decl.clone());
-                    self.env.set(s.name.clone(), Type::Struct { name: s.name.clone() });
+                    self.env.set(
+                        s.name.clone(),
+                        Type::Struct {
+                            name: s.name.clone(),
+                        },
+                    );
                     for (f_name, f_type) in &s.fields {
-                        self.env.set(format!("{}.{}", s.name, f_name), self.resolve_type(f_type));
+                        self.env
+                            .set(format!("{}.{}", s.name, f_name), self.resolve_type(f_type));
                     }
-                },
+                }
                 Declaration::Impl(i) => {
                     let mut full_target = i.target_name.clone();
-                    if !i.generic_params.is_empty() { full_target = format!("{}<{}>", i.target_name, i.generic_params.join(", ")); }
-                    let base_target = if i.target_name.contains('<') { i.target_name.split('<').next().unwrap_or(&i.target_name) } else { &i.target_name };
+                    if !i.generic_params.is_empty() {
+                        full_target = format!("{}<{}>", i.target_name, i.generic_params.join(", "));
+                    }
+                    let base_target = if i.target_name.contains('<') {
+                        i.target_name.split('<').next().unwrap_or(&i.target_name)
+                    } else {
+                        &i.target_name
+                    };
                     for f in &i.functions {
                         let name = format!("{}::{}", base_target, f.name);
-                        self.decls.insert(name.clone(), Declaration::Function(f.clone()));
+                        self.decls
+                            .insert(name.clone(), Declaration::Function(f.clone()));
                         let is_unsafe = f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe);
                         let mut ret_name = f.return_type.clone();
-                        if ret_name == "Self" { ret_name = full_target.clone(); }
+                        if ret_name == "Self" {
+                            ret_name = full_target.clone();
+                        }
                         let ret_type = self.resolve_type(&ret_name);
-                        let param_types: Vec<Type> = f.params.iter().map(|(_, pt, _)| {
-                            let mut pt = pt.clone();
-                            if pt == "Self" { pt = full_target.clone(); }
-                            self.resolve_type(&pt)
-                        }).collect();
-                        self.env.set(name, Type::Function { is_unsafe, params: param_types, return_type: Box::new(ret_type) });
+                        let param_types: Vec<Type> = f
+                            .params
+                            .iter()
+                            .map(|(_, pt, _)| {
+                                let mut pt = pt.clone();
+                                if pt == "Self" {
+                                    pt = full_target.clone();
+                                }
+                                self.resolve_type(&pt)
+                            })
+                            .collect();
+                        self.env.set(
+                            name,
+                            Type::Function {
+                                is_unsafe,
+                                params: param_types,
+                                return_type: Box::new(ret_type),
+                            },
+                        );
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -136,33 +377,45 @@ impl TypeChecker {
                 Declaration::Function(f) => {
                     if let Some(body) = &f.body {
                         let was_unsafe = self.in_unsafe_context;
-                        if f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe) { self.in_unsafe_context = true; }
+                        if f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe) {
+                            self.in_unsafe_context = true;
+                        }
                         let enclosed = Environment::new_enclosed(self.env.clone());
                         let old_env = std::mem::replace(&mut self.env, enclosed);
-                        for (p_name, p_type, _) in &f.params { self.env.set(p_name.clone(), self.resolve_type(p_type)); }
-                        for stmt in body { self.check_statement(stmt)?; }
+                        for (p_name, p_type, _) in &f.params {
+                            self.env.set(p_name.clone(), self.resolve_type(p_type));
+                        }
+                        for stmt in body {
+                            self.check_statement(stmt)?;
+                        }
                         self.env = old_env;
                         self.in_unsafe_context = was_unsafe;
                     }
-                },
+                }
                 Declaration::Impl(i) => {
                     for f in &i.functions {
                         if let Some(body) = &f.body {
                             let was_unsafe = self.in_unsafe_context;
-                            if f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe) { self.in_unsafe_context = true; }
+                            if f.modifiers.iter().any(|m| m.kind == TokenKind::Unsafe) {
+                                self.in_unsafe_context = true;
+                            }
                             let enclosed = Environment::new_enclosed(self.env.clone());
                             let old_env = std::mem::replace(&mut self.env, enclosed);
                             for (p_name, p_type, _) in &f.params {
                                 let mut pt = p_type.clone();
-                                if pt == "Self" { pt = i.target_name.clone(); }
+                                if pt == "Self" {
+                                    pt = i.target_name.clone();
+                                }
                                 self.env.set(p_name.clone(), self.resolve_type(&pt));
                             }
-                            for stmt in body { self.check_statement(stmt)?; }
+                            for stmt in body {
+                                self.check_statement(stmt)?;
+                            }
                             self.env = old_env;
                             self.in_unsafe_context = was_unsafe;
                         }
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -175,33 +428,57 @@ impl TypeChecker {
                 let val_type = self.check_expression(value)?;
                 self.env.set(name.clone(), val_type);
                 Ok(Type::Unit)
-            },
+            }
             Statement::Assignment { target, value, .. } => {
                 self.check_expression(target)?;
                 self.check_expression(value)?;
                 Ok(Type::Unit)
-            },
-            Statement::Return { value, .. } => { self.check_expression(value)?; Ok(Type::Unit) },
+            }
+            Statement::Return { value, .. } => {
+                self.check_expression(value)?;
+                Ok(Type::Unit)
+            }
             Statement::ExpressionStmt(expr, _) => self.check_expression(expr),
-            Statement::If { condition, then_branch, else_branch, .. } => {
+            Statement::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 self.check_expression(condition)?;
-                for s in then_branch { self.check_statement(s)?; }
-                if let Some(eb) = else_branch { for s in eb { self.check_statement(s)?; } }
+                for s in then_branch {
+                    self.check_statement(s)?;
+                }
+                if let Some(eb) = else_branch {
+                    for s in eb {
+                        self.check_statement(s)?;
+                    }
+                }
                 Ok(Type::Unit)
-            },
-            Statement::While { condition, body, .. } => {
+            }
+            Statement::While {
+                condition, body, ..
+            } => {
                 self.check_expression(condition)?;
-                for s in body { self.check_statement(s)?; }
+                for s in body {
+                    self.check_statement(s)?;
+                }
                 Ok(Type::Unit)
-            },
+            }
             Statement::Break(_) => Ok(Type::Unit),
             Statement::Continue(_) => Ok(Type::Unit),
             Statement::UnsafeBlock(body, _) => {
-                let was = self.in_unsafe_context; self.in_unsafe_context = true;
-                for s in body { self.check_statement(s)?; }
-                self.in_unsafe_context = was; Ok(Type::Unit)
-            },
-            Statement::Match { condition, arms, .. } => {
+                let was = self.in_unsafe_context;
+                self.in_unsafe_context = true;
+                for s in body {
+                    self.check_statement(s)?;
+                }
+                self.in_unsafe_context = was;
+                Ok(Type::Unit)
+            }
+            Statement::Match {
+                condition, arms, ..
+            } => {
                 let cond_type = self.check_expression(condition)?;
                 let cond_name = match &cond_type {
                     Type::Enum { name } => name.clone(),
@@ -213,29 +490,35 @@ impl TypeChecker {
                 };
                 for arm in arms {
                     let old_env = self.env.clone();
-                    
+
                     // Get all patterns
                     let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                         vec![arm.pattern.clone()]
                     } else {
                         arm.patterns.clone()
                     };
-                    
+
                     // Check if this is a binding variable pattern (lowercase identifier that should bind)
-                    let _is_binding_pattern = arm.params.len() > 0 && all_patterns.iter().all(|p| {
-                        !p.parse::<i64>().is_ok() && !p.starts_with('"')
-                    });
-                    
+                    let _is_binding_pattern = arm.params.len() > 0
+                        && all_patterns
+                            .iter()
+                            .all(|p| !p.parse::<i64>().is_ok() && !p.starts_with('"'));
+
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
                         let mut payload = Type::Integer;
-                        
+
                         // Check patterns for enum type
                         if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
                             for pat in &all_patterns {
                                 for v in &e.variants {
-                                    if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
-                                        if !v.data_types.is_empty() { payload = self.resolve_type(&v.data_types[0]); }
+                                    if pat == &v.name
+                                        || pat.ends_with(&format!(".{}", v.name))
+                                        || pat.ends_with(&format!("::{}", v.name))
+                                    {
+                                        if !v.data_types.is_empty() {
+                                            payload = self.resolve_type(&v.data_types[0]);
+                                        }
                                         break;
                                     }
                                 }
@@ -245,27 +528,32 @@ impl TypeChecker {
                         } else if cond_name == "String" {
                             payload = Type::String;
                         } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
-                            payload = Type::Struct { name: cond_name.clone() };
+                            payload = Type::Struct {
+                                name: cond_name.clone(),
+                            };
                             // Add struct fields to environment
                             for (field_name, field_type_str) in &s.fields {
                                 let field_type = self.resolve_type(field_type_str);
-                                self.env.set(format!("{}.{}", arm.params[0], field_name), field_type);
+                                self.env
+                                    .set(format!("{}.{}", arm.params[0], field_name), field_type);
                             }
                         }
-                        
+
                         self.env.set(arm.params[0].clone(), payload);
                     }
-                    
+
                     // Evaluate guard if present
                     if let Some(guard_expr) = &arm.guard {
                         self.check_expression(guard_expr)?;
                     }
-                    
-                    for s in &arm.body { self.check_statement(s)?; }
+
+                    for s in &arm.body {
+                        self.check_statement(s)?;
+                    }
                     self.env = old_env;
                 }
                 Ok(Type::Unit)
-            },
+            }
             _ => Ok(Type::Unit),
         }
     }
@@ -279,168 +567,344 @@ impl TypeChecker {
             Expression::String(..) => Ok(Type::String),
             Expression::Duration(..) => Ok(Type::Duration),
             Expression::Date(..) => Ok(Type::Date),
-            Expression::TypeRef { name, generic_args, .. } => {
+            Expression::TypeRef {
+                name, generic_args, ..
+            } => {
                 let mut ga = Vec::new();
-                for arg in generic_args { ga.push(self.env.get(arg).unwrap_or(Type::Unknown)); }
+                for arg in generic_args {
+                    ga.push(self.env.get(arg).unwrap_or(Type::Unknown));
+                }
                 Ok(Type::GenericInstance(name.clone(), ga))
-            },
+            }
             Expression::Identifier(name, _) => {
-                if let Some(t) = self.env.get(name) { return Ok(t); }
+                if let Some(t) = self.env.get(name) {
+                    return Ok(t);
+                }
                 if let Some((var, field)) = name.split_once('.')
-                    && let Ok(rt) = self.check_expression(&Expression::Identifier(var.to_string(), Span::zero())) {
-                        let tn = match rt { Type::GenericInstance(n, _) | Type::Struct { name: n } => n, _ => "".to_string() };
-                        if !tn.is_empty() {
-                            let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
-                            if let Some(t) = self.env.get(&format!("{}.{}", full, field)) { return Ok(t); }
+                    && let Ok(rt) = self
+                        .check_expression(&Expression::Identifier(var.to_string(), Span::zero()))
+                {
+                    let tn = match rt {
+                        Type::GenericInstance(n, _) | Type::Struct { name: n } => n,
+                        _ => "".to_string(),
+                    };
+                    if !tn.is_empty() {
+                        let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
+                        if let Some(t) = self.env.get(&format!("{}.{}", full, field)) {
+                            return Ok(t);
                         }
                     }
+                }
                 Ok(Type::Unknown)
-            },
-            Expression::Infix { left, operator, right, .. } => {
+            }
+            Expression::Infix {
+                left,
+                operator,
+                right,
+                ..
+            } => {
                 let t1 = self.check_expression(left)?;
                 let t2 = self.check_expression(right)?;
                 self.check_compatibility(t1, t2, operator)
-            },
-            Expression::Call { function, arguments, .. } => {
+            }
+            Expression::Call {
+                function,
+                arguments,
+                ..
+            } => {
                 let span = expr.span();
-                let call_expr = Expression::Call { function: function.clone(), generic_args: vec![], arguments: arguments.clone(), span };
+                let call_expr = Expression::Call {
+                    function: function.clone(),
+                    generic_args: vec![],
+                    arguments: arguments.clone(),
+                    span,
+                };
                 if let Some((receiver_name, method_name)) = function.rsplit_once('.') {
-                    let receiver_expr = Expression::Identifier(receiver_name.to_string(), Span::zero());
+                    let receiver_expr =
+                        Expression::Identifier(receiver_name.to_string(), Span::zero());
                     if let Ok(rt) = self.check_expression(&receiver_expr) {
                         let mut is_ptr = false;
-                        if let Type::Pointer(_) = rt { is_ptr = true; }
+                        if let Type::Pointer(_) = rt {
+                            is_ptr = true;
+                        }
                         if is_ptr && method_name == "offset" {
-                            for arg in arguments { self.check_expression(arg)?; }
+                            for arg in arguments {
+                                self.check_expression(arg)?;
+                            }
                             return Ok(rt.clone());
                         }
                         if rt != Type::Unknown {
                             let tn = match rt {
-                                Type::GenericInstance(ref n, _) | Type::Struct { name: ref n } | Type::Enum { name: ref n } => n.clone(),
+                                Type::GenericInstance(ref n, _)
+                                | Type::Struct { name: ref n }
+                                | Type::Enum { name: ref n } => n.clone(),
                                 Type::Integer => "i64".to_string(),
                                 Type::String => "String".to_string(),
-                                _ => "".to_string()
+                                _ => "".to_string(),
                             };
                             if !tn.is_empty() {
                                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
                                 // Try both :: and . formats for method lookup
                                 let cand_colon = format!("{}::{}", full, method_name);
                                 let cand_dot = format!("{}.{}", full, method_name);
-                                let ft = self.env.get(&cand_colon).or_else(|| self.env.get(&cand_dot));
-                                if let Some(Type::Function { is_unsafe, ref return_type, .. }) = ft {
+                                let ft = self
+                                    .env
+                                    .get(&cand_colon)
+                                    .or_else(|| self.env.get(&cand_dot));
+                                if let Some(Type::Function {
+                                    is_unsafe,
+                                    ref return_type,
+                                    ..
+                                }) = ft
+                                {
                                     if is_unsafe && !self.in_unsafe_context {
-                                        return Err(self.err(format!("unsafe method call '{}'", method_name), &call_expr));
+                                        return Err(self.err(
+                                            format!("unsafe method call '{}'", method_name),
+                                            &call_expr,
+                                        ));
                                     }
-                                    for arg in arguments { self.check_expression(arg)?; }
+                                    for arg in arguments {
+                                        self.check_expression(arg)?;
+                                    }
                                     return Ok(*return_type.clone());
                                 }
                             }
                         }
                     }
                 }
-                let ft = if let Some(t) = self.env.get(function) { t }
-                         else if self.in_unsafe_context && function.starts_with("aion_") { Type::Function { is_unsafe: true, params: vec![], return_type: Box::new(Type::Unknown) } }
-                         else { return Err(self.err(format!("function '{}' not defined", function), &call_expr)); };
-                if let Type::Function { is_unsafe, ref return_type, .. } = ft {
-                    if is_unsafe && !self.in_unsafe_context {
-                        return Err(self.err(format!("call to unsafe function '{}' requires unsafe block", function), &call_expr));
+                let ft = if let Some(t) = self.env.get(function) {
+                    t
+                } else if self.in_unsafe_context && function.starts_with("aion_") {
+                    Type::Function {
+                        is_unsafe: true,
+                        params: vec![],
+                        return_type: Box::new(Type::Unknown),
                     }
-                    for arg in arguments { self.check_expression(arg)?; }
+                } else {
+                    // Skip the suggestion path for FFI-style calls inside unsafe
+                    // blocks — the user accepts responsibility for external names.
+                    let span = call_expr.span();
+                    let suggestion = self.suggest_function(function).unwrap_or_default();
+                    return Err(CompileError::not_found(
+                        "function", function, suggestion, span.line, span.col,
+                    )
+                    .with_snippet(&self.source));
+                };
+                if let Type::Function {
+                    is_unsafe,
+                    ref return_type,
+                    ..
+                } = ft
+                {
+                    if is_unsafe && !self.in_unsafe_context {
+                        return Err(self.err(
+                            format!(
+                                "call to unsafe function '{}' requires unsafe block",
+                                function
+                            ),
+                            &call_expr,
+                        ));
+                    }
+                    for arg in arguments {
+                        self.check_expression(arg)?;
+                    }
                     Ok(*return_type.clone())
-                } else { Err(self.err(format!("'{}' is not a function", function), &call_expr)) }
-            },
-            Expression::MemberAccess { receiver, member, .. } => {
+                } else {
+                    Err(self.err(format!("'{}' is not a function", function), &call_expr))
+                }
+            }
+            Expression::MemberAccess {
+                receiver, member, ..
+            } => {
                 let rt = self.check_expression(receiver)?;
                 let span = receiver.span();
                 let tn = match rt {
-                    Type::GenericInstance(ref n, _) | Type::Struct { name: ref n } | Type::Placeholder(ref n) => n.clone(),
-                    _ => return Err(CompileError::new(format!("member access on {:?}", rt), span.line, span.col).with_snippet(&self.source)),
+                    Type::GenericInstance(ref n, _)
+                    | Type::Struct { name: ref n }
+                    | Type::Placeholder(ref n) => n.clone(),
+                    _ => {
+                        return Err(CompileError::new(
+                            format!("member access on {:?}", rt),
+                            span.line,
+                            span.col,
+                        )
+                        .with_snippet(&self.source));
+                    }
                 };
                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
-                self.env.get(&format!("{}.{}", full, member))
-                    .ok_or_else(|| CompileError::new(format!("field '{}' not found on struct '{}'", member, full), span.line, span.col).with_snippet(&self.source))
-            },
-            Expression::MethodCall { receiver, method, generic_args: _, arguments, .. } => {
-                let method_expr = Expression::MethodCall { receiver: receiver.clone(), method: method.clone(), generic_args: vec![], arguments: arguments.clone(), span: expr.span() };
+                let suggestion = self.suggest_field(&full, member).unwrap_or_default();
+                self.env
+                    .get(&format!("{}.{}", full, member))
+                    .ok_or_else(|| {
+                        CompileError::not_found("field", member, suggestion, span.line, span.col)
+                            .with_snippet(&self.source)
+                    })
+            }
+            Expression::MethodCall {
+                receiver,
+                method,
+                generic_args: _,
+                arguments,
+                ..
+            } => {
+                let method_expr = Expression::MethodCall {
+                    receiver: receiver.clone(),
+                    method: method.clone(),
+                    generic_args: vec![],
+                    arguments: arguments.clone(),
+                    span: expr.span(),
+                };
                 let rt = self.check_expression(receiver)?;
-                
+
                 // Special case for Pointer.offset()
                 if method == "offset"
-                    && let Type::Pointer(_) = rt {
-                        // Check argument is integer
-                        if !arguments.is_empty() {
-                            let arg_type = self.check_expression(&arguments[0])?;
-                            if arg_type != Type::Integer { return Err(self.err("offset argument must be an integer", &method_expr)); }
+                    && let Type::Pointer(_) = rt
+                {
+                    // Check argument is integer
+                    if !arguments.is_empty() {
+                        let arg_type = self.check_expression(&arguments[0])?;
+                        if arg_type != Type::Integer {
+                            return Err(
+                                self.err("offset argument must be an integer", &method_expr)
+                            );
                         }
-                        return Ok(rt); // offset returns same pointer type
                     }
+                    return Ok(rt); // offset returns same pointer type
+                }
 
-                let tn = match rt { 
-                    Type::GenericInstance(ref n, _) | Type::Struct { name: ref n } | Type::Enum { name: ref n } => n.clone(), 
+                let tn = match rt {
+                    Type::GenericInstance(ref n, _)
+                    | Type::Struct { name: ref n }
+                    | Type::Enum { name: ref n } => n.clone(),
                     Type::Integer => "i64".to_string(),
                     Type::String => "String".to_string(),
-                    _ => return Err(self.err(format!("method call on {:?}", rt), &method_expr)) 
+                    _ => return Err(self.err(format!("method call on {:?}", rt), &method_expr)),
                 };
 
                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
                 let cand_colon = format!("{}::{}", full, method);
                 let cand_dot = format!("{}.{}", full, method);
-                let ft = self.env.get(&cand_colon)
-                    .or_else(|| self.env.get(&cand_dot))
-                    .ok_or_else(|| self.err(format!("method '{}' not found on '{}'", method, full), &method_expr))?;
-                if let Type::Function { is_unsafe, ref return_type, .. } = ft {
-                    if is_unsafe && !self.in_unsafe_context {
-                        return Err(self.err(format!("unsafe method call '{}'", method), &method_expr));
+                let ft = self
+                    .env
+                    .get(&cand_colon)
+                    .or_else(|| self.env.get(&cand_dot));
+                let ft = match ft {
+                    Some(t) => t,
+                    None => {
+                        let span = method_expr.span();
+                        let suggestion = self.suggest_method(&full, method).unwrap_or_default();
+                        return Err(CompileError::not_found(
+                            "method", method, suggestion, span.line, span.col,
+                        )
+                        .with_snippet(&self.source));
                     }
-                    for arg in arguments { self.check_expression(arg)?; }
+                };
+                if let Type::Function {
+                    is_unsafe,
+                    ref return_type,
+                    ..
+                } = ft
+                {
+                    if is_unsafe && !self.in_unsafe_context {
+                        return Err(
+                            self.err(format!("unsafe method call '{}'", method), &method_expr)
+                        );
+                    }
+                    for arg in arguments {
+                        self.check_expression(arg)?;
+                    }
                     Ok(*return_type.clone())
-                } else { Err(self.err(format!("'{}' is not a function", cand_colon), &method_expr)) }
-            },
+                } else {
+                    Err(self.err(format!("'{}' is not a function", cand_colon), &method_expr))
+                }
+            }
             Expression::Cast { target, .. } => Ok(self.resolve_type(target)),
             Expression::StructInst { name, .. } => {
-                let full = self.resolve_fuzzy_name(&self.decls, name).unwrap_or(name.clone());
+                let full = self
+                    .resolve_fuzzy_name(&self.decls, name)
+                    .unwrap_or(name.clone());
                 Ok(Type::Struct { name: full })
-            },
-            Expression::EnumInst { name, variant, arguments, .. } => {
-                let full = self.resolve_fuzzy_name(&self.decls, name).unwrap_or(name.clone());
+            }
+            Expression::EnumInst {
+                name,
+                variant,
+                arguments,
+                ..
+            } => {
+                let full = self
+                    .resolve_fuzzy_name(&self.decls, name)
+                    .unwrap_or(name.clone());
                 // Try to infer generic type arguments from variant arguments
-                let has_generics = if let Some(Declaration::Enum(enum_decl)) = self.decls.get(&full) {
-                    enum_decl.variants.iter().find(|v| v.name == *variant).map_or(false, |v| !v.data_types.is_empty())
+                let has_generics = if let Some(Declaration::Enum(enum_decl)) = self.decls.get(&full)
+                {
+                    enum_decl
+                        .variants
+                        .iter()
+                        .find(|v| v.name == *variant)
+                        .map_or(false, |v| !v.data_types.is_empty())
                 } else {
                     false
                 };
                 if has_generics {
-                    let type_args: Vec<Type> = arguments.iter().map(|arg| {
-                        self.check_expression(arg).unwrap_or(Type::Unknown)
-                    }).collect();
+                    let type_args: Vec<Type> = arguments
+                        .iter()
+                        .map(|arg| self.check_expression(arg).unwrap_or(Type::Unknown))
+                        .collect();
                     if !type_args.is_empty() {
                         return Ok(Type::GenericInstance(full, type_args));
                     }
                 }
                 Ok(Type::Enum { name: full })
-            },
+            }
             Expression::Deref { expr, .. } => {
                 let rt = self.check_expression(expr)?;
-                if let Type::Pointer(t) = rt { Ok(*t) } else { Ok(Type::Integer) }
-            },
-            Expression::Intrinsic { name, arguments, .. } => {
+                if let Type::Pointer(t) = rt {
+                    Ok(*t)
+                } else {
+                    Ok(Type::Integer)
+                }
+            }
+            Expression::Intrinsic {
+                name, arguments, ..
+            } => {
                 let mut actual_name = name.clone();
                 let mut args = arguments.as_slice();
-                if name == "intrinsic" && !arguments.is_empty()
-                    && let Expression::String(s, _) = &arguments[0] {
-                        actual_name = s.clone();
-                        args = &arguments[1..];
-                    }
-                for arg in args { self.check_expression(arg)?; }
-                if actual_name == "str_len" || actual_name == "fs_exists" || actual_name == "fs_write" || actual_name == "fs_append" { Ok(Type::Integer) }
-                else if actual_name == "str_concat" || actual_name == "fs_read_to_string" || actual_name == "int_to_str" || actual_name == "float_to_str" || actual_name == "char_to_str" || actual_name == "str_substr" { Ok(Type::String) }
-                else if actual_name == "str_ptr" { Ok(Type::Pointer(Box::new(Type::Integer))) }
-                else if actual_name == "mem_is_null" { Ok(Type::Boolean) }
-                else if actual_name == "mem_zero" && !args.is_empty() {
+                if name == "intrinsic"
+                    && !arguments.is_empty()
+                    && let Expression::String(s, _) = &arguments[0]
+                {
+                    actual_name = s.clone();
+                    args = &arguments[1..];
+                }
+                for arg in args {
+                    self.check_expression(arg)?;
+                }
+                if actual_name == "str_len"
+                    || actual_name == "fs_exists"
+                    || actual_name == "fs_write"
+                    || actual_name == "fs_append"
+                {
+                    Ok(Type::Integer)
+                } else if actual_name == "str_concat"
+                    || actual_name == "fs_read_to_string"
+                    || actual_name == "int_to_str"
+                    || actual_name == "float_to_str"
+                    || actual_name == "char_to_str"
+                    || actual_name == "str_substr"
+                {
+                    Ok(Type::String)
+                } else if actual_name == "str_ptr" {
+                    Ok(Type::Pointer(Box::new(Type::Integer)))
+                } else if actual_name == "mem_is_null" {
+                    Ok(Type::Boolean)
+                } else if actual_name == "mem_zero" && !args.is_empty() {
                     // mem_zero(Type): return value uses the language's boxed struct/enum
                     // representation (matches StructInst/EnumInst), so the field-access path
                     // (*p).field stays consistent after *p = mem_zero(T).
                     let tnm = match &args[0] {
-                        Expression::Identifier(s, _) | Expression::TypeRef { name: s, .. } => s.clone(),
+                        Expression::Identifier(s, _) | Expression::TypeRef { name: s, .. } => {
+                            s.clone()
+                        }
                         _ => return Ok(Type::Integer),
                     };
                     let full = self.resolve_fuzzy_name(&self.decls, &tnm).unwrap_or(tnm);
@@ -449,26 +913,53 @@ impl TypeChecker {
                         Some(Declaration::Enum(_)) => Ok(Type::Enum { name: full }),
                         _ => Ok(Type::Integer),
                     }
+                } else if actual_name.starts_with("ai_tensor_") {
+                    Ok(Type::Struct {
+                        name: "std.ai.tensor.Tensor".to_string(),
+                    })
+                } else {
+                    Ok(Type::Integer)
                 }
-                else if actual_name.starts_with("ai_tensor_") { Ok(Type::Struct { name: "std.ai.tensor.Tensor".to_string() }) }
-                else { Ok(Type::Integer) }
-            },
-            Expression::If { condition, then_branch, else_branch, .. } => {
+            }
+            Expression::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 self.check_expression(condition)?;
                 let mut lt = Type::Unit;
-                for s in then_branch { lt = self.check_statement(s)?; }
-                if let Some(eb) = else_branch { for s in eb { self.check_statement(s)?; } }
+                for s in then_branch {
+                    lt = self.check_statement(s)?;
+                }
+                if let Some(eb) = else_branch {
+                    for s in eb {
+                        self.check_statement(s)?;
+                    }
+                }
                 Ok(lt)
-            },
-            Expression::Block { statements, is_unsafe, .. } => {
+            }
+            Expression::Block {
+                statements,
+                is_unsafe,
+                ..
+            } => {
                 let was = self.in_unsafe_context;
-                if *is_unsafe { self.in_unsafe_context = true; }
+                if *is_unsafe {
+                    self.in_unsafe_context = true;
+                }
                 let mut lt = Type::Unit;
-                for s in statements { lt = self.check_statement(s)?; }
-                if *is_unsafe { self.in_unsafe_context = was; }
+                for s in statements {
+                    lt = self.check_statement(s)?;
+                }
+                if *is_unsafe {
+                    self.in_unsafe_context = was;
+                }
                 Ok(lt)
-            },
-            Expression::Match { condition, arms, .. } => {
+            }
+            Expression::Match {
+                condition, arms, ..
+            } => {
                 let cond_type = self.check_expression(condition)?;
                 let cond_name = match &cond_type {
                     Type::Enum { name } => name.clone(),
@@ -481,22 +972,27 @@ impl TypeChecker {
                 let mut result_type = Type::Unit;
                 for arm in arms {
                     let old_env = self.env.clone();
-                    
+
                     let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                         vec![arm.pattern.clone()]
                     } else {
                         arm.patterns.clone()
                     };
-                    
+
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
                         let mut payload = Type::Integer;
-                        
+
                         if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
                             for pat in &all_patterns {
                                 for v in &e.variants {
-                                    if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
-                                        if !v.data_types.is_empty() { payload = self.resolve_type(&v.data_types[0]); }
+                                    if pat == &v.name
+                                        || pat.ends_with(&format!(".{}", v.name))
+                                        || pat.ends_with(&format!("::{}", v.name))
+                                    {
+                                        if !v.data_types.is_empty() {
+                                            payload = self.resolve_type(&v.data_types[0]);
+                                        }
                                         break;
                                     }
                                 }
@@ -506,28 +1002,34 @@ impl TypeChecker {
                         } else if cond_name == "String" {
                             payload = Type::String;
                         } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
-                            payload = Type::Struct { name: cond_name.clone() };
+                            payload = Type::Struct {
+                                name: cond_name.clone(),
+                            };
                             for (field_name, field_type_str) in &s.fields {
                                 let field_type = self.resolve_type(field_type_str);
-                                self.env.set(format!("{}.{}", arm.params[0], field_name), field_type);
+                                self.env
+                                    .set(format!("{}.{}", arm.params[0], field_name), field_type);
                             }
                         }
-                        
+
                         self.env.set(arm.params[0].clone(), payload);
                     }
-                    
+
                     if let Some(guard_expr) = &arm.guard {
                         self.check_expression(guard_expr)?;
                     }
-                    
+
                     for s in &arm.body {
                         result_type = self.check_statement(s)?;
                     }
                     self.env = old_env;
                 }
                 Ok(result_type)
-            },
-            _ => Err(CompileError::Internal(format!("Unsupported expression {:?}", expr))),
+            }
+            _ => Err(CompileError::internal(format!(
+                "Unsupported expression {:?}",
+                expr
+            ))),
         }
     }
 
@@ -535,43 +1037,91 @@ impl TypeChecker {
         match t1 {
             Type::Integer => {
                 if t2 == Type::Integer {
-                    if matches!(op.kind, TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::Slash | TokenKind::Percent | TokenKind::And | TokenKind::Or | TokenKind::Caret) { 
-                        return Ok(Type::Integer); 
+                    if matches!(
+                        op.kind,
+                        TokenKind::Plus
+                            | TokenKind::Minus
+                            | TokenKind::Star
+                            | TokenKind::Slash
+                            | TokenKind::Percent
+                            | TokenKind::And
+                            | TokenKind::Or
+                            | TokenKind::Caret
+                    ) {
+                        return Ok(Type::Integer);
                     }
-                    if matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq | TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq) { 
-                        return Ok(Type::Boolean); 
+                    if matches!(
+                        op.kind,
+                        TokenKind::EqEq
+                            | TokenKind::NotEq
+                            | TokenKind::Lt
+                            | TokenKind::Gt
+                            | TokenKind::LtEq
+                            | TokenKind::GtEq
+                    ) {
+                        return Ok(Type::Boolean);
                     }
                     return Ok(Type::Integer);
                 }
-            },
+            }
             Type::Float => {
                 if t2 == Type::Float {
-                    if matches!(op.kind, TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::Slash) { return Ok(Type::Float); }
-                    if matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq | TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq) { return Ok(Type::Boolean); }
+                    if matches!(
+                        op.kind,
+                        TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::Slash
+                    ) {
+                        return Ok(Type::Float);
+                    }
+                    if matches!(
+                        op.kind,
+                        TokenKind::EqEq
+                            | TokenKind::NotEq
+                            | TokenKind::Lt
+                            | TokenKind::Gt
+                            | TokenKind::LtEq
+                            | TokenKind::GtEq
+                    ) {
+                        return Ok(Type::Boolean);
+                    }
                     return Ok(Type::Float);
                 }
-            },
+            }
             Type::Boolean => {
                 if t2 == Type::Boolean {
-                    if matches!(op.kind, TokenKind::And | TokenKind::Or | TokenKind::EqEq | TokenKind::NotEq) { return Ok(Type::Boolean); }
+                    if matches!(
+                        op.kind,
+                        TokenKind::And | TokenKind::Or | TokenKind::EqEq | TokenKind::NotEq
+                    ) {
+                        return Ok(Type::Boolean);
+                    }
                     return Ok(Type::Boolean);
                 }
-            },
+            }
             Type::String => {
-                if (t2 == Type::String || t2 == Type::Integer)
-                    && op.kind == TokenKind::Plus { return Ok(Type::String); }
-                if t2 == Type::String
-                    && matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq) { return Ok(Type::Boolean); }
-            },
-            Type::Placeholder(_) => { return Ok(t1.clone()); },
+                if (t2 == Type::String || t2 == Type::Integer) && op.kind == TokenKind::Plus {
+                    return Ok(Type::String);
+                }
+                if t2 == Type::String && matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq) {
+                    return Ok(Type::Boolean);
+                }
+            }
+            Type::Placeholder(_) => {
+                return Ok(t1.clone());
+            }
             Type::Date => {
-                if t2 == Type::Duration && op.kind == TokenKind::Plus { return Ok(Type::Date); }
-            },
+                if t2 == Type::Duration && op.kind == TokenKind::Plus {
+                    return Ok(Type::Date);
+                }
+            }
             _ => {
-                if t1 == t2 && matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq) { return Ok(Type::Boolean); }
+                if t1 == t2 && matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq) {
+                    return Ok(Type::Boolean);
+                }
             }
         }
-        if let Type::Placeholder(_) = t2 { return Ok(t1.clone()); }
+        if let Type::Placeholder(_) = t2 {
+            return Ok(t1.clone());
+        }
         Err(CompileError::InvalidOperator {
             op: format!("{:?}", op.kind),
             left: format!("{:?}", t1),
@@ -583,9 +1133,13 @@ impl TypeChecker {
     }
 
     fn resolve_fuzzy_name<T>(&self, map: &HashMap<String, T>, name: &str) -> Option<String> {
-        if map.contains_key(name) { return Some(name.to_string()); }
+        if map.contains_key(name) {
+            return Some(name.to_string());
+        }
         for key in map.keys() {
-            if key.ends_with(name) && (key.len() == name.len() || key.as_bytes()[key.len() - name.len() - 1] == b'.') {
+            if key.ends_with(name)
+                && (key.len() == name.len() || key.as_bytes()[key.len() - name.len() - 1] == b'.')
+            {
                 return Some(key.clone());
             }
         }

--- a/src/analysis/environment.rs
+++ b/src/analysis/environment.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use super::types::Type;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct Environment {
@@ -15,25 +15,33 @@ impl Default for Environment {
 
 impl Environment {
     pub fn new() -> Self {
-        Self { store: HashMap::new(), outer: None }
+        Self {
+            store: HashMap::new(),
+            outer: None,
+        }
     }
-    
+
     pub fn new_enclosed(outer: Environment) -> Self {
-        Self { store: HashMap::new(), outer: Some(Box::new(outer)) }
+        Self {
+            store: HashMap::new(),
+            outer: Some(Box::new(outer)),
+        }
     }
 
     pub fn get(&self, name: &str) -> Option<Type> {
         if let Some(t) = self.store.get(name) {
             return Some(t.clone());
         }
-        
+
         // Fuzzy lookup: check if name matches a fully qualified name suffix
         for (key, val) in &self.store {
-            if key.ends_with(name) && (key.len() == name.len() || {
-                let sep_idx = key.len() - name.len() - 1;
-                let b = key.as_bytes()[sep_idx];
-                b == b'.' || (sep_idx >= 1 && key.as_bytes()[sep_idx - 1] == b':' && b == b':')
-            }) {
+            if key.ends_with(name)
+                && (key.len() == name.len() || {
+                    let sep_idx = key.len() - name.len() - 1;
+                    let b = key.as_bytes()[sep_idx];
+                    b == b'.' || (sep_idx >= 1 && key.as_bytes()[sep_idx - 1] == b':' && b == b':')
+                })
+            {
                 return Some(val.clone());
             }
         }
@@ -46,5 +54,26 @@ impl Environment {
 
     pub fn set(&mut self, name: String, val: Type) {
         self.store.insert(name, val);
+    }
+
+    /// Iterator over all visible names in this environment and its enclosing
+    /// scopes. Used by the type checker for "did you mean X?" suggestions. #40.
+    pub fn visible_names(&self) -> impl Iterator<Item = &String> {
+        // Build an explicit owned-vector chain to avoid lifetime gymnastics
+        // across the recursive `outer` boxes; scopes stay small.
+        let mut seen: std::collections::HashSet<&String> = std::collections::HashSet::new();
+        let mut chain: Vec<&Environment> = vec![self];
+        let mut idx = 0;
+        while idx < chain.len() {
+            let cur = chain[idx];
+            for k in cur.store.keys() {
+                seen.insert(k);
+            }
+            if let Some(o) = cur.outer.as_deref() {
+                chain.push(o);
+            }
+            idx += 1;
+        }
+        seen.into_iter()
     }
 }

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -9,9 +9,17 @@ pub enum Type {
     String,
     Duration,
     Date,
-    Function { is_unsafe: bool, params: Vec<Type>, return_type: Box<Type> },
-    Enum { name: String },
-    Struct { name: String },
+    Function {
+        is_unsafe: bool,
+        params: Vec<Type>,
+        return_type: Box<Type>,
+    },
+    Enum {
+        name: String,
+    },
+    Struct {
+        name: String,
+    },
     Placeholder(String),
     GenericInstance(String, Vec<Type>),
     Pointer(Box<Type>),
@@ -69,10 +77,14 @@ impl Type {
                 format!("{}<{}>", base, args_str.join(", "))
             }
             Type::Placeholder(name) => name.clone(),
-            Type::Function { params, return_type, .. } => {
+            Type::Function {
+                params,
+                return_type,
+                ..
+            } => {
                 let params_str: Vec<String> = params.iter().map(|p| p.name()).collect();
                 format!("fn({}) -> {}", params_str.join(", "), return_type.name())
-            },
+            }
             Type::Unknown => "unknown".to_string(),
         }
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,7 +1,7 @@
 use super::Span;
 use super::stmt::MatchArm;
-use crate::lexer::token::Token;
 use crate::ast::Statement;
+use crate::lexer::token::Token;
 
 #[derive(Debug, Clone)]
 pub enum Expression {
@@ -13,7 +13,12 @@ pub enum Expression {
     Date(i64, Span),
     Identifier(String, Span),
     Boolean(bool, Span),
-    Infix { left: Box<Expression>, operator: Token, right: Box<Expression>, span: Span },
+    Infix {
+        left: Box<Expression>,
+        operator: Token,
+        right: Box<Expression>,
+        span: Span,
+    },
     Call {
         function: String,
         generic_args: Vec<String>,
@@ -26,12 +31,36 @@ pub enum Expression {
         fields: Vec<(String, Expression)>,
         span: Span,
     },
-    Range { start: Box<Expression>, end: Box<Expression>, span: Span },
-    Block { statements: Vec<Statement>, is_unsafe: bool, span: Span },
-    If { condition: Box<Expression>, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>>, span: Span },
-    Deref { expr: Box<Expression>, span: Span },
-    Cast { expr: Box<Expression>, target: String, span: Span },
-    Intrinsic { name: String, arguments: Vec<Expression>, span: Span },
+    Range {
+        start: Box<Expression>,
+        end: Box<Expression>,
+        span: Span,
+    },
+    Block {
+        statements: Vec<Statement>,
+        is_unsafe: bool,
+        span: Span,
+    },
+    If {
+        condition: Box<Expression>,
+        then_branch: Vec<Statement>,
+        else_branch: Option<Vec<Statement>>,
+        span: Span,
+    },
+    Deref {
+        expr: Box<Expression>,
+        span: Span,
+    },
+    Cast {
+        expr: Box<Expression>,
+        target: String,
+        span: Span,
+    },
+    Intrinsic {
+        name: String,
+        arguments: Vec<Expression>,
+        span: Span,
+    },
     EnumInst {
         name: String,
         variant: String,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,10 +1,10 @@
+pub mod decl;
 pub mod expr;
 pub mod stmt;
-pub mod decl;
 
+pub use decl::*;
 pub use expr::*;
 pub use stmt::*;
-pub use decl::*;
 
 use crate::lexer::token::Token;
 
@@ -20,6 +20,9 @@ impl Span {
     }
 
     pub fn from_token(tok: &Token) -> Self {
-        Self { line: tok.line, col: tok.col }
+        Self {
+            line: tok.line,
+            col: tok.col,
+        }
     }
 }

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -1,16 +1,49 @@
-use super::{Span, Expression};
+use super::{Expression, Span};
 
 #[derive(Debug, Clone)]
 pub enum Statement {
-    Let { name: String, value: Expression, explicit_type: Option<String>, intent: Option<String>, is_mut: bool, span: Span },
-    Return { value: Expression, intent: Option<String>, span: Span },
+    Let {
+        name: String,
+        value: Expression,
+        explicit_type: Option<String>,
+        intent: Option<String>,
+        is_mut: bool,
+        span: Span,
+    },
+    Return {
+        value: Expression,
+        intent: Option<String>,
+        span: Span,
+    },
     ExpressionStmt(Expression, Span),
-    If { condition: Expression, then_branch: Vec<Statement>, else_branch: Option<Vec<Statement>>, span: Span },
-    Assignment { target: Expression, value: Expression, span: Span },
-    While { condition: Expression, body: Vec<Statement>, span: Span },
-    For { var: String, range: Expression, body: Vec<Statement>, span: Span },
+    If {
+        condition: Expression,
+        then_branch: Vec<Statement>,
+        else_branch: Option<Vec<Statement>>,
+        span: Span,
+    },
+    Assignment {
+        target: Expression,
+        value: Expression,
+        span: Span,
+    },
+    While {
+        condition: Expression,
+        body: Vec<Statement>,
+        span: Span,
+    },
+    For {
+        var: String,
+        range: Expression,
+        body: Vec<Statement>,
+        span: Span,
+    },
     Spawn(Vec<Statement>, Span),
-    Match { condition: Expression, arms: Vec<MatchArm>, span: Span },
+    Match {
+        condition: Expression,
+        arms: Vec<MatchArm>,
+        span: Span,
+    },
     UnsafeBlock(Vec<Statement>, Span),
     Break(Span),
     Continue(Span),

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -1,17 +1,17 @@
-use std::path::Path;
-use std::collections::{HashMap, HashSet};
-use inkwell::basic_block::BasicBlock;
-use inkwell::context::Context;
-use inkwell::builder::Builder;
-use inkwell::module::Module;
-use inkwell::values::{BasicValueEnum, PointerValue, FunctionValue, ValueKind, BasicValue};
-use inkwell::types::{StructType, BasicTypeEnum, BasicType};
-use inkwell::{AddressSpace, IntPredicate};
-use inkwell::passes::{PassManager, PassManagerBuilder};
-use inkwell::OptimizationLevel;
 use crate::ast::*;
-use crate::lexer::token::TokenKind;
 use crate::error::CompileError;
+use crate::lexer::token::TokenKind;
+use inkwell::OptimizationLevel;
+use inkwell::basic_block::BasicBlock;
+use inkwell::builder::Builder;
+use inkwell::context::Context;
+use inkwell::module::Module;
+use inkwell::passes::{PassManager, PassManagerBuilder};
+use inkwell::types::{BasicType, BasicTypeEnum, StructType};
+use inkwell::values::{BasicValue, BasicValueEnum, FunctionValue, PointerValue, ValueKind};
+use inkwell::{AddressSpace, IntPredicate};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 pub struct Compiler<'ctx> {
     pub context: &'ctx Context,
@@ -35,14 +35,14 @@ impl<'ctx> Compiler<'ctx> {
     pub fn with_source(context: &'ctx Context, module_name: &str, source: &str) -> Self {
         let module = context.create_module(module_name);
         let builder = context.create_builder();
-        let mut compiler = Self { 
-            context, 
-            module, 
-            builder, 
-            struct_types: HashMap::new(), 
-            struct_fields: HashMap::new(), 
-            enum_types: HashMap::new(), 
-            decls: HashMap::new(), 
+        let mut compiler = Self {
+            context,
+            module,
+            builder,
+            struct_types: HashMap::new(),
+            struct_fields: HashMap::new(),
+            enum_types: HashMap::new(),
+            decls: HashMap::new(),
             compiled_instances: HashSet::new(),
             source: source.to_string(),
             loop_exit_blocks: Vec::new(),
@@ -59,28 +59,63 @@ impl<'ctx> Compiler<'ctx> {
 
     fn register_builtins(&mut self) {
         let builtins = vec![
-            ("io.println", "aion_io_println", "void", false), ("io.print", "aion_io_print", "void", false), ("io.read_line", "aion_io_read_line", "String", false),
-            ("string.from_int", "aion_int_to_str", "String", false), ("string.from_float", "aion_float_to_str", "String", false),
+            ("io.println", "aion_io_println", "void", false),
+            ("io.print", "aion_io_print", "void", false),
+            ("io.read_line", "aion_io_read_line", "String", false),
+            ("string.from_int", "aion_int_to_str", "String", false),
+            ("string.from_float", "aion_float_to_str", "String", false),
             ("string.to_float", "aion_str_to_float", "f64", false),
-            ("fs_read_to_string", "aion_read_file", "String", false), ("fs_write", "aion_write_file", "i32", false), ("fs_exists", "aion_fs_exists", "i64", false), ("fs_append", "aion_append_file", "i32", false),
-            ("aion_getenv", "aion_getenv", "String", false), ("aion_get_argc", "aion_get_argc", "i64", false), ("aion_get_argv_index", "aion_get_argv_index", "String", false),
-            ("aion_exit", "exit", "void", false), ("exit", "exit", "void", false), ("aion_malloc", "aion_malloc", "ptr", false), ("aion_realloc", "aion_realloc", "ptr", false), ("aion_free", "aion_free", "void", false),
-            ("aion_str_at", "aion_str_at", "i64", false), ("aion_str_substr", "aion_str_substr", "String", false), ("aion_char_to_str", "aion_char_to_str", "String", false),
-            ("ai.tensor_zeros", "aion_ai_tensor_zeros", "ptr", false), ("ai.tensor_ones", "aion_ai_tensor_ones", "ptr", false), ("ai.tensor_rand", "aion_ai_tensor_rand", "ptr", false),
-            ("ai.tensor_backward", "aion_ai_tensor_backward", "void", false), ("ai.tensor_matmul", "aion_ai_tensor_matmul", "ptr", false), ("ai.tensor_add", "aion_ai_tensor_add", "ptr", false),
+            ("fs_read_to_string", "aion_read_file", "String", false),
+            ("fs_write", "aion_write_file", "i32", false),
+            ("fs_exists", "aion_fs_exists", "i64", false),
+            ("fs_append", "aion_append_file", "i32", false),
+            ("aion_getenv", "aion_getenv", "String", false),
+            ("aion_get_argc", "aion_get_argc", "i64", false),
+            (
+                "aion_get_argv_index",
+                "aion_get_argv_index",
+                "String",
+                false,
+            ),
+            ("aion_exit", "exit", "void", false),
+            ("exit", "exit", "void", false),
+            ("aion_malloc", "aion_malloc", "ptr", false),
+            ("aion_realloc", "aion_realloc", "ptr", false),
+            ("aion_free", "aion_free", "void", false),
+            ("aion_str_at", "aion_str_at", "i64", false),
+            ("aion_str_substr", "aion_str_substr", "String", false),
+            ("aion_char_to_str", "aion_char_to_str", "String", false),
+            ("ai.tensor_zeros", "aion_ai_tensor_zeros", "ptr", false),
+            ("ai.tensor_ones", "aion_ai_tensor_ones", "ptr", false),
+            ("ai.tensor_rand", "aion_ai_tensor_rand", "ptr", false),
+            (
+                "ai.tensor_backward",
+                "aion_ai_tensor_backward",
+                "void",
+                false,
+            ),
+            ("ai.tensor_matmul", "aion_ai_tensor_matmul", "ptr", false),
+            ("ai.tensor_add", "aion_ai_tensor_add", "ptr", false),
             ("ai.tensor_move", "aion_ai_tensor_move", "ptr", false),
-            ("i64.abs", "aion_i64_abs", "i64", true), ("i64.max", "aion_i64_max", "i64", true), ("i64.min", "aion_i64_min", "i64", true),
-            ("string.len", "aion_string_len", "i64", true), ("String.len", "aion_string_len", "i64", true)
+            ("i64.abs", "aion_i64_abs", "i64", true),
+            ("i64.max", "aion_i64_max", "i64", true),
+            ("i64.min", "aion_i64_min", "i64", true),
+            ("string.len", "aion_string_len", "i64", true),
+            ("String.len", "aion_string_len", "i64", true),
         ];
         for (an, ln, rt, is_method) in builtins {
-            let params = if is_method { vec![("self".to_string(), "i64".to_string(), None)] } else { vec![] };
-            let d = Declaration::Function(Function { 
-                name: an.to_string(), 
-                generic_params: vec![], 
+            let params = if is_method {
+                vec![("self".to_string(), "i64".to_string(), None)]
+            } else {
+                vec![]
+            };
+            let d = Declaration::Function(Function {
+                name: an.to_string(),
+                generic_params: vec![],
                 params,
-                return_type: rt.to_string(), 
-                body: None, 
-                modifiers: vec![], 
+                return_type: rt.to_string(),
+                body: None,
+                modifiers: vec![],
                 attributes: vec![("intrinsic".to_string(), ln.to_string())],
                 doc_comment: None,
             });
@@ -89,15 +124,21 @@ impl<'ctx> Compiler<'ctx> {
     }
 
     fn resolve_fuzzy_name<T>(&self, map: &HashMap<String, T>, name: &str) -> Option<String> {
-        let clean = name.replace(" ", ""); 
-        if map.contains_key(&clean) { return Some(clean); }
-        
-        let p: Vec<&str> = clean.split('.').collect(); 
-        let last = p.last()?.to_string(); 
-        if map.contains_key(&last) { return Some(last); }
-        
-        for k in map.keys() { 
-            if k.ends_with(&clean) || clean.ends_with(k) { return Some(k.clone()); } 
+        let clean = name.replace(" ", "");
+        if map.contains_key(&clean) {
+            return Some(clean);
+        }
+
+        let p: Vec<&str> = clean.split('.').collect();
+        let last = p.last()?.to_string();
+        if map.contains_key(&last) {
+            return Some(last);
+        }
+
+        for k in map.keys() {
+            if k.ends_with(&clean) || clean.ends_with(k) {
+                return Some(k.clone());
+            }
         }
         None
     }
@@ -109,11 +150,15 @@ impl<'ctx> Compiler<'ctx> {
     fn type_to_llvm(&self, ty: &crate::analysis::types::Type) -> BasicTypeEnum<'ctx> {
         use crate::analysis::types::Type;
         match ty {
-            Type::Integer | Type::Boolean | Type::Date | Type::Duration | Type::Unit => self.context.i64_type().into(),
-            Type::Float => self.context.f64_type().into(),
-            Type::String | Type::Pointer(_) | Type::Enum { .. } | Type::Struct { .. } | Type::GenericInstance(..) => {
-                self.context.ptr_type(AddressSpace::default()).into()
+            Type::Integer | Type::Boolean | Type::Date | Type::Duration | Type::Unit => {
+                self.context.i64_type().into()
             }
+            Type::Float => self.context.f64_type().into(),
+            Type::String
+            | Type::Pointer(_)
+            | Type::Enum { .. }
+            | Type::Struct { .. }
+            | Type::GenericInstance(..) => self.context.ptr_type(AddressSpace::default()).into(),
             _ => self.context.ptr_type(AddressSpace::default()).into(),
         }
     }
@@ -122,89 +167,158 @@ impl<'ctx> Compiler<'ctx> {
         for s in b.iter_mut() {
             match s {
                 Statement::Let { value, .. } => self.substitute_types_in_expr(value, ph, conc),
-                Statement::Assignment { target, value, .. } => { 
-                    self.substitute_types_in_expr(target, ph, conc); 
-                    self.substitute_types_in_expr(value, ph, conc); 
-                },
+                Statement::Assignment { target, value, .. } => {
+                    self.substitute_types_in_expr(target, ph, conc);
+                    self.substitute_types_in_expr(value, ph, conc);
+                }
                 Statement::Return { value, .. } => self.substitute_types_in_expr(value, ph, conc),
                 Statement::ExpressionStmt(e, _) => self.substitute_types_in_expr(e, ph, conc),
-                Statement::If { condition, then_branch, else_branch, .. } => { 
-                    self.substitute_types_in_expr(condition, ph, conc); 
-                    self.substitute_types_in_body(then_branch, ph, conc); 
-                    if let Some(eb) = else_branch { self.substitute_types_in_body(eb, ph, conc); } 
-                },
-                Statement::While { condition, body, .. } => { 
-                    self.substitute_types_in_expr(condition, ph, conc); 
-                    self.substitute_types_in_body(body, ph, conc); 
-                },
-                Statement::For { range, body, .. } => { 
-                    self.substitute_types_in_expr(range, ph, conc); 
-                    self.substitute_types_in_body(body, ph, conc); 
-                },
-                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => self.substitute_types_in_body(stmts, ph, conc),
-                Statement::Match { condition, arms, .. } => { 
-                    self.substitute_types_in_expr(condition, ph, conc); 
-                    for arm in arms { self.substitute_types_in_body(&mut arm.body, ph, conc); } 
-                },
-                _ => {},
+                Statement::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                    ..
+                } => {
+                    self.substitute_types_in_expr(condition, ph, conc);
+                    self.substitute_types_in_body(then_branch, ph, conc);
+                    if let Some(eb) = else_branch {
+                        self.substitute_types_in_body(eb, ph, conc);
+                    }
+                }
+                Statement::While {
+                    condition, body, ..
+                } => {
+                    self.substitute_types_in_expr(condition, ph, conc);
+                    self.substitute_types_in_body(body, ph, conc);
+                }
+                Statement::For { range, body, .. } => {
+                    self.substitute_types_in_expr(range, ph, conc);
+                    self.substitute_types_in_body(body, ph, conc);
+                }
+                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => {
+                    self.substitute_types_in_body(stmts, ph, conc)
+                }
+                Statement::Match {
+                    condition, arms, ..
+                } => {
+                    self.substitute_types_in_expr(condition, ph, conc);
+                    for arm in arms {
+                        self.substitute_types_in_body(&mut arm.body, ph, conc);
+                    }
+                }
+                _ => {}
             }
         }
     }
 
     fn substitute_types_in_expr(&self, e: &mut Expression, ph: &[String], conc: &[String]) {
         match e {
-            Expression::Infix { left, right, .. } => { 
-                self.substitute_types_in_expr(left, ph, conc); 
-                self.substitute_types_in_expr(right, ph, conc); 
-            },
-            Expression::Call { function, generic_args, arguments, .. } => {
+            Expression::Infix { left, right, .. } => {
+                self.substitute_types_in_expr(left, ph, conc);
+                self.substitute_types_in_expr(right, ph, conc);
+            }
+            Expression::Call {
+                function,
+                generic_args,
+                arguments,
+                ..
+            } => {
                 *function = Self::substitute_type_string(function, ph, conc);
-                for arg in generic_args.iter_mut() { *arg = Self::substitute_type_string(arg, ph, conc); }
-                for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); }
-            },
-            Expression::EnumInst { name, generic_args, arguments, .. } => {
+                for arg in generic_args.iter_mut() {
+                    *arg = Self::substitute_type_string(arg, ph, conc);
+                }
+                for arg in arguments {
+                    self.substitute_types_in_expr(arg, ph, conc);
+                }
+            }
+            Expression::EnumInst {
+                name,
+                generic_args,
+                arguments,
+                ..
+            } => {
                 *name = Self::substitute_type_string(name, ph, conc);
-                for arg in generic_args.iter_mut() { *arg = Self::substitute_type_string(arg, ph, conc); }
-                for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); }
-            },
-            Expression::StructInst { name, generic_args, fields, .. } => {
+                for arg in generic_args.iter_mut() {
+                    *arg = Self::substitute_type_string(arg, ph, conc);
+                }
+                for arg in arguments {
+                    self.substitute_types_in_expr(arg, ph, conc);
+                }
+            }
+            Expression::StructInst {
+                name,
+                generic_args,
+                fields,
+                ..
+            } => {
                 *name = Self::substitute_type_string(name, ph, conc);
-                for arg in generic_args.iter_mut() { *arg = Self::substitute_type_string(arg, ph, conc); }
-                for (_, val) in fields { self.substitute_types_in_expr(val, ph, conc); }
-            },
+                for arg in generic_args.iter_mut() {
+                    *arg = Self::substitute_type_string(arg, ph, conc);
+                }
+                for (_, val) in fields {
+                    self.substitute_types_in_expr(val, ph, conc);
+                }
+            }
             Expression::Cast { expr, target, .. } => {
                 self.substitute_types_in_expr(expr, ph, conc);
                 *target = Self::substitute_type_string(target, ph, conc);
-            },
+            }
             Expression::Deref { expr, .. } => self.substitute_types_in_expr(expr, ph, conc),
             Expression::Intrinsic { arguments, .. } => {
-                for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); }
-            },
-            Expression::Block { statements, .. } => self.substitute_types_in_body(statements, ph, conc),
+                for arg in arguments {
+                    self.substitute_types_in_expr(arg, ph, conc);
+                }
+            }
+            Expression::Block { statements, .. } => {
+                self.substitute_types_in_body(statements, ph, conc)
+            }
             Expression::Identifier(n, _) => {
                 *n = Self::substitute_type_string(n, ph, conc);
-            },
-            Expression::MemberAccess { receiver, .. } => self.substitute_types_in_expr(receiver, ph, conc),
-            Expression::MethodCall { receiver, generic_args, arguments, .. } => {
+            }
+            Expression::MemberAccess { receiver, .. } => {
+                self.substitute_types_in_expr(receiver, ph, conc)
+            }
+            Expression::MethodCall {
+                receiver,
+                generic_args,
+                arguments,
+                ..
+            } => {
                 self.substitute_types_in_expr(receiver, ph, conc);
-                for arg in generic_args { *arg = Self::substitute_type_string(arg, ph, conc); }
-                for arg in arguments { self.substitute_types_in_expr(arg, ph, conc); }
-            },
-            Expression::Match { condition, arms, .. } => {
+                for arg in generic_args {
+                    *arg = Self::substitute_type_string(arg, ph, conc);
+                }
+                for arg in arguments {
+                    self.substitute_types_in_expr(arg, ph, conc);
+                }
+            }
+            Expression::Match {
+                condition, arms, ..
+            } => {
                 self.substitute_types_in_expr(condition, ph, conc);
-                for arm in arms { self.substitute_types_in_body(&mut arm.body, ph, conc); }
-            },
+                for arm in arms {
+                    self.substitute_types_in_body(&mut arm.body, ph, conc);
+                }
+            }
             _ => {}
         }
     }
 
-    fn instantiate_function(&mut self, bn: &str, ga: &[String]) -> Result<FunctionValue<'ctx>, CompileError> {
-        let d = self.decls.get(bn).cloned().ok_or_else(|| CompileError::Internal(format!("Generic function '{}' not found", bn)))?;
+    fn instantiate_function(
+        &mut self,
+        bn: &str,
+        ga: &[String],
+    ) -> Result<FunctionValue<'ctx>, CompileError> {
+        let d = self.decls.get(bn).cloned().ok_or_else(|| {
+            CompileError::internal(format!("Generic function '{}' not found", bn))
+        })?;
         if let Declaration::Function(mut f) = d {
-            let ph = f.generic_params.clone(); 
+            let ph = f.generic_params.clone();
             let nn = format!("{}_{}", bn, ga.join("_"));
-            if let Some(e) = self.module.get_function(&nn) { return Ok(e); }
-            
+            if let Some(e) = self.module.get_function(&nn) {
+                return Ok(e);
+            }
+
             f.name = nn.clone();
             f.generic_params = vec![];
             let n = ph.len().min(ga.len());
@@ -212,231 +326,457 @@ impl<'ctx> Compiler<'ctx> {
                 *pt = Self::substitute_type_string(pt, &ph[..n], &ga[..n]);
             }
             f.return_type = Self::substitute_type_string(&f.return_type, &ph[..n], &ga[..n]);
-            if let Some(body) = &mut f.body { self.substitute_types_in_body(body, &ph[..n], &ga[..n]); }
-            
-            self.decls.insert(nn.clone(), Declaration::Function(f.clone()));
-            self.compiled_instances.insert(nn.clone()); 
+            if let Some(body) = &mut f.body {
+                self.substitute_types_in_body(body, &ph[..n], &ga[..n]);
+            }
+
+            self.decls
+                .insert(nn.clone(), Declaration::Function(f.clone()));
+            self.compiled_instances.insert(nn.clone());
             self.compile_function(&Declaration::Function(f))
-        } else { 
-            Err(CompileError::Internal(format!("'{}' is not a function", bn))) 
+        } else {
+            Err(CompileError::internal(format!(
+                "'{}' is not a function",
+                bn
+            )))
         }
     }
 
-    fn compile_function(&mut self, decl: &Declaration) -> Result<FunctionValue<'ctx>, CompileError> {
+    fn compile_function(
+        &mut self,
+        decl: &Declaration,
+    ) -> Result<FunctionValue<'ctx>, CompileError> {
         if let Declaration::Function(f) = decl {
-            let function = if let Some(e) = self.module.get_function(&f.name) { 
-                if e.get_first_basic_block().is_some() { return Ok(e); } 
-                e 
-            } else {
-                let mut pt = Vec::new(); 
-                let ptr_t = self.context.ptr_type(AddressSpace::default());
-                if f.name == "main" { 
-                    pt.push(self.context.i32_type().into()); 
-                    pt.push(ptr_t.into()); 
-                } else { 
-                    for (_, ptn, _) in &f.params { pt.push(self.aion_type_to_llvm(ptn).into()); } 
+            let function = if let Some(e) = self.module.get_function(&f.name) {
+                if e.get_first_basic_block().is_some() {
+                    return Ok(e);
                 }
-                self.module.add_function(&f.name, self.aion_type_to_llvm(&f.return_type).fn_type(&pt, false), None)
-            };
-            
-            if let Some(body) = &f.body {
-                let pb = self.builder.get_insert_block(); 
-                let bb = self.context.append_basic_block(function, "entry"); 
-                self.builder.position_at_end(bb);
-                let mut local_vars = HashMap::new(); 
-                let i64_t = self.context.i64_type();
-                
+                e
+            } else {
+                let mut pt = Vec::new();
+                let ptr_t = self.context.ptr_type(AddressSpace::default());
                 if f.name == "main" {
-                    let gc_init = self.module.get_function("GC_init").ok_or_else(|| CompileError::Internal("GC_init function not found".to_string()))?;
-                    self.builder.build_call(gc_init, &[], "")?;
-                    
-                    if let Some(argc) = function.get_nth_param(0) { 
-                        let av = self.builder.build_int_z_extend(argc.into_int_value(), i64_t, "argc_ext")?; 
-                        let a = self.builder.build_alloca(i64_t, "argc")?; 
-                        self.builder.build_store(a, av)?; 
-                        local_vars.insert("argc".to_string(), (a, i64_t.into(), "i64".to_string())); 
-                        if let Some(g) = self.module.get_global("aion_argc") { 
-                            self.builder.build_store(g.as_pointer_value(), av)?; 
-                        } 
+                    pt.push(self.context.i32_type().into());
+                    pt.push(ptr_t.into());
+                } else {
+                    for (_, ptn, _) in &f.params {
+                        pt.push(self.aion_type_to_llvm(ptn).into());
                     }
-                    if let Some(argv) = function.get_nth_param(1) { 
-                        let a = self.builder.build_alloca(self.context.ptr_type(AddressSpace::default()), "argv")?; 
-                        self.builder.build_store(a, argv)?; 
-                        local_vars.insert("argv".to_string(), (a, self.context.ptr_type(AddressSpace::default()).into(), "ptr".to_string())); 
-                        if let Some(g) = self.module.get_global("aion_argv") { 
-                            self.builder.build_store(g.as_pointer_value(), argv)?; 
-                        } 
+                }
+                self.module.add_function(
+                    &f.name,
+                    self.aion_type_to_llvm(&f.return_type).fn_type(&pt, false),
+                    None,
+                )
+            };
+
+            if let Some(body) = &f.body {
+                let pb = self.builder.get_insert_block();
+                let bb = self.context.append_basic_block(function, "entry");
+                self.builder.position_at_end(bb);
+                let mut local_vars = HashMap::new();
+                let i64_t = self.context.i64_type();
+
+                if f.name == "main" {
+                    let gc_init = self.module.get_function("GC_init").ok_or_else(|| {
+                        CompileError::internal("GC_init function not found".to_string())
+                    })?;
+                    self.builder.build_call(gc_init, &[], "")?;
+
+                    if let Some(argc) = function.get_nth_param(0) {
+                        let av = self.builder.build_int_z_extend(
+                            argc.into_int_value(),
+                            i64_t,
+                            "argc_ext",
+                        )?;
+                        let a = self.builder.build_alloca(i64_t, "argc")?;
+                        self.builder.build_store(a, av)?;
+                        local_vars.insert("argc".to_string(), (a, i64_t.into(), "i64".to_string()));
+                        if let Some(g) = self.module.get_global("aion_argc") {
+                            self.builder.build_store(g.as_pointer_value(), av)?;
+                        }
+                    }
+                    if let Some(argv) = function.get_nth_param(1) {
+                        let a = self
+                            .builder
+                            .build_alloca(self.context.ptr_type(AddressSpace::default()), "argv")?;
+                        self.builder.build_store(a, argv)?;
+                        local_vars.insert(
+                            "argv".to_string(),
+                            (
+                                a,
+                                self.context.ptr_type(AddressSpace::default()).into(),
+                                "ptr".to_string(),
+                            ),
+                        );
+                        if let Some(g) = self.module.get_global("aion_argv") {
+                            self.builder.build_store(g.as_pointer_value(), argv)?;
+                        }
                     }
                 } else {
-                    for (i, arg) in function.get_param_iter().enumerate() { 
-                        if i < f.params.len() { 
-                            let an = &f.params[i].0; 
-                            let atn = &f.params[i].1; 
+                    for (i, arg) in function.get_param_iter().enumerate() {
+                        if i < f.params.len() {
+                            let an = &f.params[i].0;
+                            let atn = &f.params[i].1;
                             let default_val = &f.params[i].2;
-                            arg.set_name(an); 
-                            let a = self.builder.build_alloca(arg.get_type(), an)?; 
-                            self.builder.build_store(a, arg)?; 
-                            local_vars.insert(an.clone(), (a, arg.get_type(), atn.replace(" ", ""))); 
-                            
+                            arg.set_name(an);
+                            let a = self.builder.build_alloca(arg.get_type(), an)?;
+                            self.builder.build_store(a, arg)?;
+                            local_vars
+                                .insert(an.clone(), (a, arg.get_type(), atn.replace(" ", "")));
+
                             // If there's a default value and the arg is zero-initialized, use the default
                             if default_val.is_some() {
                                 // For now, we'll handle defaults at call site
                             }
-                        } 
+                        }
                     }
                 }
-                
+
                 let lbv = self.compile_block(body, &mut local_vars, function)?;
                 if let Some(cb) = self.builder.get_insert_block() {
                     if cb.get_terminator().is_none() {
                         let rt = function.get_type().get_return_type();
                         if let Some(mut v) = lbv {
-                            if let Some(tt) = rt { 
-                                if v.get_type() != tt { 
-                                    if tt.is_pointer_type() && v.is_int_value() { 
-                                        v = self.builder.build_int_to_ptr(v.into_int_value(), self.context.ptr_type(AddressSpace::default()), "ret_ptr")?.into(); 
-                                    } else if tt.is_int_type() && v.is_pointer_value() { 
-                                        v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "ret_int")?.into(); 
-                                    } 
-                                } 
+                            if let Some(tt) = rt {
+                                if v.get_type() != tt {
+                                    if tt.is_pointer_type() && v.is_int_value() {
+                                        v = self
+                                            .builder
+                                            .build_int_to_ptr(
+                                                v.into_int_value(),
+                                                self.context.ptr_type(AddressSpace::default()),
+                                                "ret_ptr",
+                                            )?
+                                            .into();
+                                    } else if tt.is_int_type() && v.is_pointer_value() {
+                                        v = self
+                                            .builder
+                                            .build_ptr_to_int(
+                                                v.into_pointer_value(),
+                                                i64_t,
+                                                "ret_int",
+                                            )?
+                                            .into();
+                                    }
+                                }
                             }
                             self.builder.build_return(Some(&v))?;
-                        } else { 
-                            let def: BasicValueEnum = if rt.map_or(false, |t| t.is_pointer_type()) { 
-                                self.context.ptr_type(AddressSpace::default()).const_null().into() 
-                            } else { 
-                                i64_t.const_zero().into() 
-                            }; 
-                            self.builder.build_return(Some(&def))?; 
+                        } else {
+                            let def: BasicValueEnum = if rt.map_or(false, |t| t.is_pointer_type()) {
+                                self.context
+                                    .ptr_type(AddressSpace::default())
+                                    .const_null()
+                                    .into()
+                            } else {
+                                i64_t.const_zero().into()
+                            };
+                            self.builder.build_return(Some(&def))?;
                         }
                     }
                 }
-                if let Some(p) = pb { self.builder.position_at_end(p); }
+                if let Some(p) = pb {
+                    self.builder.position_at_end(p);
+                }
             }
             Ok(function)
-        } else { 
-            Err(CompileError::Internal("Not a function".to_string())) 
+        } else {
+            Err(CompileError::internal("Not a function".to_string()))
         }
     }
 
     pub fn compile(&mut self, program: &Program) -> Result<(), CompileError> {
         for d in &program.declarations {
             match d {
-                Declaration::Function(f) => { self.decls.insert(f.name.clone(), d.clone()); },
-                Declaration::Struct(s) => { self.decls.insert(s.name.clone(), d.clone()); },
-                Declaration::Enum(e) => { self.decls.insert(e.name.clone(), d.clone()); },
+                Declaration::Function(f) => {
+                    self.decls.insert(f.name.clone(), d.clone());
+                }
+                Declaration::Struct(s) => {
+                    self.decls.insert(s.name.clone(), d.clone());
+                }
+                Declaration::Enum(e) => {
+                    self.decls.insert(e.name.clone(), d.clone());
+                }
                 Declaration::Impl(i) => {
-                    let mut ftn = i.target_name.clone(); 
-                    if !i.generic_params.is_empty() { ftn = format!("{}<{}>", i.target_name, i.generic_params.join(",")); }
-                    let bt = if i.target_name.contains('<') { i.target_name.split('<').next().ok_or_else(|| CompileError::Internal("Invalid target name".to_string()))? } else { &i.target_name };
-                    for f in &i.functions { 
-                        let mut nf = f.clone(); 
-                        nf.name = format!("{}.{}", bt, f.name); 
-                        for (_, pt, _) in nf.params.iter_mut() { if pt == "Self" { *pt = ftn.clone(); } } 
-                        if nf.return_type == "Self" { nf.return_type = ftn.clone(); } 
-                        let mut cg = i.generic_params.clone(); 
-                        cg.extend(f.generic_params.clone()); 
-                        nf.generic_params = cg; 
-                        self.decls.insert(nf.name.clone(), Declaration::Function(nf)); 
+                    let mut ftn = i.target_name.clone();
+                    if !i.generic_params.is_empty() {
+                        ftn = format!("{}<{}>", i.target_name, i.generic_params.join(","));
                     }
-                },
+                    let bt = if i.target_name.contains('<') {
+                        i.target_name.split('<').next().ok_or_else(|| {
+                            CompileError::internal("Invalid target name".to_string())
+                        })?
+                    } else {
+                        &i.target_name
+                    };
+                    for f in &i.functions {
+                        let mut nf = f.clone();
+                        nf.name = format!("{}.{}", bt, f.name);
+                        for (_, pt, _) in nf.params.iter_mut() {
+                            if pt == "Self" {
+                                *pt = ftn.clone();
+                            }
+                        }
+                        if nf.return_type == "Self" {
+                            nf.return_type = ftn.clone();
+                        }
+                        let mut cg = i.generic_params.clone();
+                        cg.extend(f.generic_params.clone());
+                        nf.generic_params = cg;
+                        self.decls
+                            .insert(nf.name.clone(), Declaration::Function(nf));
+                    }
+                }
                 _ => {}
             }
         }
-        
-        let pt = self.context.ptr_type(AddressSpace::default()); 
+
+        let pt = self.context.ptr_type(AddressSpace::default());
         let i64_t = self.context.i64_type();
-        
-        self.module.add_function("printf", self.context.i32_type().fn_type(&[pt.into()], true), None); 
-        self.module.add_function("strlen", i64_t.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("exit", self.context.void_type().fn_type(&[self.context.i32_type().into()], false), None); 
-        self.module.add_function("malloc", pt.fn_type(&[i64_t.into()], false), None); 
-        self.module.add_function("realloc", pt.fn_type(&[pt.into(), i64_t.into()], false), None); 
-        self.module.add_function("free", self.context.void_type().fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_io_print", self.context.void_type().fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_io_println", self.context.void_type().fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_io_read_line", pt.fn_type(&[], false), None); 
-        self.module.add_function("GC_init", self.context.void_type().fn_type(&[], false), None); 
-        self.module.add_function("aion_str_eq", i64_t.fn_type(&[pt.into(), pt.into()], false), None); 
-        self.module.add_function("aion_str_concat", pt.fn_type(&[pt.into(), pt.into()], false), None); 
-        self.module.add_function("aion_int_to_str", pt.fn_type(&[i64_t.into()], false), None); 
-        self.module.add_function("aion_float_to_str", pt.fn_type(&[self.context.f64_type().into()], false), None); 
-        self.module.add_function("aion_str_to_float", self.context.f64_type().fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_read_file", pt.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_write_file", i64_t.fn_type(&[pt.into(), pt.into()], false), None); 
-        self.module.add_function("aion_append_file", i64_t.fn_type(&[pt.into(), pt.into()], false), None); 
-        self.module.add_function("aion_fs_exists", i64_t.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_getenv", pt.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_get_argc", i64_t.fn_type(&[], false), None); 
-        self.module.add_function("aion_get_argv_index", pt.fn_type(&[i64_t.into()], false), None); 
-        self.module.add_function("aion_malloc", pt.fn_type(&[i64_t.into()], false), None); 
-        self.module.add_function("aion_memzero", self.context.void_type().fn_type(&[pt.into(), i64_t.into()], false), None); 
-        self.module.add_function("aion_str_at", i64_t.fn_type(&[pt.into(), i64_t.into()], false), None); 
-        self.module.add_function("aion_str_substr", pt.fn_type(&[pt.into(), i64_t.into(), i64_t.into()], false), None); 
-        self.module.add_function("aion_char_to_str", pt.fn_type(&[i64_t.into()], false), None);
-        self.module.add_function("aion_ai_tensor_zeros", pt.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_ai_tensor_ones", pt.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_ai_tensor_rand", pt.fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_ai_tensor_backward", self.context.void_type().fn_type(&[pt.into()], false), None); 
-        self.module.add_function("aion_ai_tensor_move", pt.fn_type(&[pt.into(), pt.into()], false), None);
-        
-        self.module.add_global(i64_t, Some(AddressSpace::default()), "aion_argc").set_initializer(&i64_t.const_zero()); 
-        self.module.add_global(pt, Some(AddressSpace::default()), "aion_argv").set_initializer(&pt.const_null());
-        
-        for d in &program.declarations { 
-            match d { 
-                Declaration::Struct(s) => { self.struct_types.insert(s.name.clone(), self.context.opaque_struct_type(&s.name)); }, 
-                Declaration::Enum(e) => { self.enum_types.insert(e.name.clone(), self.context.struct_type(&[i64_t.into(), self.context.i8_type().array_type(512).into()], false)); }, 
-                _ => {} 
-            } 
+
+        self.module.add_function(
+            "printf",
+            self.context.i32_type().fn_type(&[pt.into()], true),
+            None,
+        );
+        self.module
+            .add_function("strlen", i64_t.fn_type(&[pt.into()], false), None);
+        self.module.add_function(
+            "exit",
+            self.context
+                .void_type()
+                .fn_type(&[self.context.i32_type().into()], false),
+            None,
+        );
+        self.module
+            .add_function("malloc", pt.fn_type(&[i64_t.into()], false), None);
+        self.module.add_function(
+            "realloc",
+            pt.fn_type(&[pt.into(), i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "free",
+            self.context.void_type().fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_io_print",
+            self.context.void_type().fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_io_println",
+            self.context.void_type().fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_io_read_line", pt.fn_type(&[], false), None);
+        self.module.add_function(
+            "GC_init",
+            self.context.void_type().fn_type(&[], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_str_eq",
+            i64_t.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_str_concat",
+            pt.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_int_to_str", pt.fn_type(&[i64_t.into()], false), None);
+        self.module.add_function(
+            "aion_float_to_str",
+            pt.fn_type(&[self.context.f64_type().into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_str_to_float",
+            self.context.f64_type().fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_read_file", pt.fn_type(&[pt.into()], false), None);
+        self.module.add_function(
+            "aion_write_file",
+            i64_t.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_append_file",
+            i64_t.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_fs_exists", i64_t.fn_type(&[pt.into()], false), None);
+        self.module
+            .add_function("aion_getenv", pt.fn_type(&[pt.into()], false), None);
+        self.module
+            .add_function("aion_get_argc", i64_t.fn_type(&[], false), None);
+        self.module.add_function(
+            "aion_get_argv_index",
+            pt.fn_type(&[i64_t.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_malloc", pt.fn_type(&[i64_t.into()], false), None);
+        self.module.add_function(
+            "aion_memzero",
+            self.context
+                .void_type()
+                .fn_type(&[pt.into(), i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_str_at",
+            i64_t.fn_type(&[pt.into(), i64_t.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_str_substr",
+            pt.fn_type(&[pt.into(), i64_t.into(), i64_t.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_char_to_str", pt.fn_type(&[i64_t.into()], false), None);
+        self.module.add_function(
+            "aion_ai_tensor_zeros",
+            pt.fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module
+            .add_function("aion_ai_tensor_ones", pt.fn_type(&[pt.into()], false), None);
+        self.module
+            .add_function("aion_ai_tensor_rand", pt.fn_type(&[pt.into()], false), None);
+        self.module.add_function(
+            "aion_ai_tensor_backward",
+            self.context.void_type().fn_type(&[pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_ai_tensor_move",
+            pt.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+
+        self.module
+            .add_global(i64_t, Some(AddressSpace::default()), "aion_argc")
+            .set_initializer(&i64_t.const_zero());
+        self.module
+            .add_global(pt, Some(AddressSpace::default()), "aion_argv")
+            .set_initializer(&pt.const_null());
+
+        for d in &program.declarations {
+            match d {
+                Declaration::Struct(s) => {
+                    self.struct_types
+                        .insert(s.name.clone(), self.context.opaque_struct_type(&s.name));
+                }
+                Declaration::Enum(e) => {
+                    self.enum_types.insert(
+                        e.name.clone(),
+                        self.context.struct_type(
+                            &[i64_t.into(), self.context.i8_type().array_type(512).into()],
+                            false,
+                        ),
+                    );
+                }
+                _ => {}
+            }
         }
-        
-        for d in &program.declarations { 
-            if let Declaration::Struct(s) = d { 
-                let mut fm = HashMap::new(); 
-                for (i, (n, _)) in s.fields.iter().enumerate() { fm.insert(n.clone(), i as u32); } 
-                self.struct_fields.insert(s.name.clone(), fm); 
-                let st = *self.struct_types.get(&s.name).ok_or_else(|| CompileError::Internal(format!("Struct type '{}' not found", s.name)))?; 
-                let mut ft_list = Vec::new(); 
-                for (_, tnm) in &s.fields { ft_list.push(self.aion_type_to_llvm(tnm)); } 
-                st.set_body(&ft_list, false); 
-            } 
+
+        for d in &program.declarations {
+            if let Declaration::Struct(s) = d {
+                let mut fm = HashMap::new();
+                for (i, (n, _)) in s.fields.iter().enumerate() {
+                    fm.insert(n.clone(), i as u32);
+                }
+                self.struct_fields.insert(s.name.clone(), fm);
+                let st = *self.struct_types.get(&s.name).ok_or_else(|| {
+                    CompileError::internal(format!("Struct type '{}' not found", s.name))
+                })?;
+                let mut ft_list = Vec::new();
+                for (_, tnm) in &s.fields {
+                    ft_list.push(self.aion_type_to_llvm(tnm));
+                }
+                st.set_body(&ft_list, false);
+            }
         }
-        
-        if self.resolve_fuzzy_name(&self.enum_types, "Option").is_none() { 
-            self.enum_types.insert("Option".to_string(), self.context.struct_type(&[i64_t.into(), self.context.i8_type().array_type(512).into()], false)); 
+
+        if self
+            .resolve_fuzzy_name(&self.enum_types, "Option")
+            .is_none()
+        {
+            self.enum_types.insert(
+                "Option".to_string(),
+                self.context.struct_type(
+                    &[i64_t.into(), self.context.i8_type().array_type(512).into()],
+                    false,
+                ),
+            );
         }
-        
+
         let ad: Vec<Declaration> = self.decls.values().cloned().collect();
-        for d in &ad { 
-            if let Declaration::Function(f) = d { 
-                if f.generic_params.is_empty() { 
-                    let mut pv = Vec::new(); 
-                    if f.name == "main" { pv.push(self.context.i32_type().into()); pv.push(pt.into()); } 
-                    else { for (_, ptn, _) in &f.params { pv.push(self.aion_type_to_llvm(ptn).into()); } } 
-                    let mut ln = f.name.clone(); 
-                    for (an, av) in &f.attributes { if an == "intrinsic" { ln = av.replace("libc.", ""); break; } } 
-                    self.module.add_function(&ln, self.aion_type_to_llvm(&f.return_type).fn_type(&pv, false), None); 
-                } 
-            } 
+        for d in &ad {
+            if let Declaration::Function(f) = d {
+                if f.generic_params.is_empty() {
+                    let mut pv = Vec::new();
+                    if f.name == "main" {
+                        pv.push(self.context.i32_type().into());
+                        pv.push(pt.into());
+                    } else {
+                        for (_, ptn, _) in &f.params {
+                            pv.push(self.aion_type_to_llvm(ptn).into());
+                        }
+                    }
+                    let mut ln = f.name.clone();
+                    for (an, av) in &f.attributes {
+                        if an == "intrinsic" {
+                            ln = av.replace("libc.", "");
+                            break;
+                        }
+                    }
+                    self.module.add_function(
+                        &ln,
+                        self.aion_type_to_llvm(&f.return_type).fn_type(&pv, false),
+                        None,
+                    );
+                }
+            }
         }
-        
-        for d in &ad { 
-            if let Declaration::Function(f) = d { 
-                if f.generic_params.is_empty() { self.compile_function(d)?; } 
-            } 
+
+        for d in &ad {
+            if let Declaration::Function(f) = d {
+                if f.generic_params.is_empty() {
+                    self.compile_function(d)?;
+                }
+            }
         }
         Ok(())
     }
 
-    fn compile_block(&mut self, body: &[Statement], variables: &mut HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>, function: FunctionValue<'ctx>) -> Result<Option<BasicValueEnum<'ctx>>, CompileError> {
-        let mut lv = None; 
-        let i64_t = self.context.i64_type(); 
+    fn compile_block(
+        &mut self,
+        body: &[Statement],
+        variables: &mut HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>,
+        function: FunctionValue<'ctx>,
+    ) -> Result<Option<BasicValueEnum<'ctx>>, CompileError> {
+        let mut lv = None;
+        let i64_t = self.context.i64_type();
         let pt = self.context.ptr_type(AddressSpace::default());
-        
+
         for s in body {
             match s {
-                Statement::Let { name, value, explicit_type, .. } => {
+                Statement::Let {
+                    name,
+                    value,
+                    explicit_type,
+                    ..
+                } => {
                     let v = self.compile_expr(value, variables, function)?;
                     let inferred_vt = v.get_type();
                     let inferred_vtn = self.get_expr_type_name(value, variables).replace(" ", "");
@@ -450,11 +790,27 @@ impl<'ctx> Compiler<'ctx> {
                         let llvm_t = self.aion_type_to_llvm(&et_clean);
                         let final_v = if llvm_t != inferred_vt {
                             if llvm_t.is_pointer_type() && v.is_int_value() {
-                                self.builder.build_int_to_ptr(v.into_int_value(), llvm_t.into_pointer_type(), "let_coerce")?.into()
+                                self.builder
+                                    .build_int_to_ptr(
+                                        v.into_int_value(),
+                                        llvm_t.into_pointer_type(),
+                                        "let_coerce",
+                                    )?
+                                    .into()
                             } else if llvm_t.is_int_type() && v.is_pointer_value() {
-                                self.builder.build_ptr_to_int(v.into_pointer_value(), llvm_t.into_int_type(), "let_coerce")?.into()
-                            } else { v }
-                        } else { v };
+                                self.builder
+                                    .build_ptr_to_int(
+                                        v.into_pointer_value(),
+                                        llvm_t.into_int_type(),
+                                        "let_coerce",
+                                    )?
+                                    .into()
+                            } else {
+                                v
+                            }
+                        } else {
+                            v
+                        };
                         let a = self.builder.build_alloca(llvm_t, name)?;
                         self.builder.build_store(a, final_v)?;
                         variables.insert(name.clone(), (a, llvm_t, et_clean));
@@ -464,169 +820,296 @@ impl<'ctx> Compiler<'ctx> {
                         variables.insert(name.clone(), (a, inferred_vt, inferred_vtn));
                     }
                     lv = None;
-                },
-                Statement::Assignment { target, value, .. } => { 
-                    let (ptr, tt) = self.compile_lvalue(target, variables, function)?; 
-                    let mut v = self.compile_expr(value, variables, function)?; 
-                    if tt.is_struct_type() && v.get_type().is_pointer_type() { 
-                        v = self.builder.build_load(tt, v.into_pointer_value(), "ld_assign")?; 
-                    } 
-                    self.builder.build_store(ptr, v)?; 
-                    lv = None; 
-                },
-                Statement::Return { value, .. } => { 
-                    let mut v = self.compile_expr(value, variables, function)?; 
-                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
+                }
+                Statement::Assignment { target, value, .. } => {
+                    let (ptr, tt) = self.compile_lvalue(target, variables, function)?;
+                    let mut v = self.compile_expr(value, variables, function)?;
+                    if tt.is_struct_type() && v.get_type().is_pointer_type() {
+                        v = self
+                            .builder
+                            .build_load(tt, v.into_pointer_value(), "ld_assign")?;
+                    }
+                    self.builder.build_store(ptr, v)?;
+                    lv = None;
+                }
+                Statement::Return { value, .. } => {
+                    let mut v = self.compile_expr(value, variables, function)?;
+                    if self
+                        .builder
+                        .get_insert_block()
+                        .ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?
+                        .get_terminator()
+                        .is_none()
+                    {
                         let rt = function.get_type().get_return_type();
-                        if let Some(tt) = rt { 
-                            if v.get_type() != tt { 
-                                if tt.is_pointer_type() && v.is_int_value() { 
-                                    v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "ret_ptr")?.into(); 
-                                } else if tt.is_int_type() && v.is_pointer_value() { 
-                                    v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "ret_int")?.into(); 
-                                } 
-                            } 
+                        if let Some(tt) = rt {
+                            if v.get_type() != tt {
+                                if tt.is_pointer_type() && v.is_int_value() {
+                                    v = self
+                                        .builder
+                                        .build_int_to_ptr(v.into_int_value(), pt, "ret_ptr")?
+                                        .into();
+                                } else if tt.is_int_type() && v.is_pointer_value() {
+                                    v = self
+                                        .builder
+                                        .build_ptr_to_int(v.into_pointer_value(), i64_t, "ret_int")?
+                                        .into();
+                                }
+                            }
                         }
-                        self.builder.build_return(Some(&v))?; 
-                    } 
-                    lv = Some(v); 
-                },
-                Statement::If { condition, then_branch, else_branch, .. } => {
-                    let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
-                    let comp = self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "ifcond")?;
-                    let tb = self.context.append_basic_block(function, "then"); 
-                    let eb = self.context.append_basic_block(function, "else"); 
+                        self.builder.build_return(Some(&v))?;
+                    }
+                    lv = Some(v);
+                }
+                Statement::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                    ..
+                } => {
+                    let cv = self
+                        .compile_expr(condition, variables, function)?
+                        .into_int_value();
+                    let comp = self.builder.build_int_compare(
+                        IntPredicate::NE,
+                        cv,
+                        i64_t.const_int(0, false),
+                        "ifcond",
+                    )?;
+                    let tb = self.context.append_basic_block(function, "then");
+                    let eb = self.context.append_basic_block(function, "else");
                     let mb = self.context.append_basic_block(function, "ifcont");
-                    self.builder.build_conditional_branch(comp, tb, eb)?; 
+                    self.builder.build_conditional_branch(comp, tb, eb)?;
                     let mut phis = Vec::new();
-                    
-                    self.builder.position_at_end(tb); 
-                    let mut tv = variables.clone(); 
-                    let tr = self.compile_block(then_branch, &mut tv, function)?; 
-                    let tf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                    if tf.get_terminator().is_none() { 
-                        let v = tr.unwrap_or(i64_t.const_zero().into()); 
-                        phis.push((v, tf)); 
+
+                    self.builder.position_at_end(tb);
+                    let mut tv = variables.clone();
+                    let tr = self.compile_block(then_branch, &mut tv, function)?;
+                    let tf = self.builder.get_insert_block().ok_or_else(|| {
+                        CompileError::internal("No active insert block".to_string())
+                    })?;
+                    if tf.get_terminator().is_none() {
+                        let v = tr.unwrap_or(i64_t.const_zero().into());
+                        phis.push((v, tf));
                     }
-                    
-                    self.builder.position_at_end(eb); 
-                    let mut ev = variables.clone(); 
-                    let er = if let Some(e) = else_branch { self.compile_block(e, &mut ev, function)? } else { None }; 
-                    let ef = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                    if ef.get_terminator().is_none() { 
-                        let v = er.unwrap_or(i64_t.const_zero().into()); 
-                        phis.push((v, ef)); 
+
+                    self.builder.position_at_end(eb);
+                    let mut ev = variables.clone();
+                    let er = if let Some(e) = else_branch {
+                        self.compile_block(e, &mut ev, function)?
+                    } else {
+                        None
+                    };
+                    let ef = self.builder.get_insert_block().ok_or_else(|| {
+                        CompileError::internal("No active insert block".to_string())
+                    })?;
+                    if ef.get_terminator().is_none() {
+                        let v = er.unwrap_or(i64_t.const_zero().into());
+                        phis.push((v, ef));
                     }
-                    
+
                     self.builder.position_at_end(mb);
                     if !phis.is_empty() {
-                        let target_type = phis[0].0.get_type(); 
+                        let target_type = phis[0].0.get_type();
                         let mut final_phis = Vec::new();
                         for (mut v, b) in phis {
                             self.builder.position_at_end(b);
                             if v.get_type() != target_type {
-                                if target_type.is_pointer_type() && v.is_int_value() { 
-                                    v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?.into(); 
-                                } else if target_type.is_int_type() && v.is_pointer_value() { 
-                                    v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?.into(); 
+                                if target_type.is_pointer_type() && v.is_int_value() {
+                                    v = self
+                                        .builder
+                                        .build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?
+                                        .into();
+                                } else if target_type.is_int_type() && v.is_pointer_value() {
+                                    v = self
+                                        .builder
+                                        .build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?
+                                        .into();
                                 }
                             }
                             self.builder.build_unconditional_branch(mb)?;
                             final_phis.push((v, b));
                         }
                         self.builder.position_at_end(mb);
-                        let phi = self.builder.build_phi(target_type, "ifres")?; 
-                        for (v, b) in final_phis { phi.add_incoming(&[(&v, b)]); } 
+                        let phi = self.builder.build_phi(target_type, "ifres")?;
+                        for (v, b) in final_phis {
+                            phi.add_incoming(&[(&v, b)]);
+                        }
                         lv = Some(phi.as_basic_value());
-                    } else { 
-                        if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
-                            self.builder.build_unreachable()?; 
-                        } 
-                        lv = None; 
+                    } else {
+                        if self
+                            .builder
+                            .get_insert_block()
+                            .ok_or_else(|| {
+                                CompileError::internal("No active insert block".to_string())
+                            })?
+                            .get_terminator()
+                            .is_none()
+                        {
+                            self.builder.build_unreachable()?;
+                        }
+                        lv = None;
                     }
-                },
-                Statement::While { condition, body, .. } => {
-                    let cb = self.context.append_basic_block(function, "while_cond"); 
-                    let bb = self.context.append_basic_block(function, "while_body"); 
+                }
+                Statement::While {
+                    condition, body, ..
+                } => {
+                    let cb = self.context.append_basic_block(function, "while_cond");
+                    let bb = self.context.append_basic_block(function, "while_body");
                     let eb = self.context.append_basic_block(function, "while_exit");
-                    self.builder.build_unconditional_branch(cb)?; 
-                    self.builder.position_at_end(cb); 
-                    let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
-                    self.builder.build_conditional_branch(self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "loopcond")?, bb, eb)?;
-                    self.builder.position_at_end(bb); 
+                    self.builder.build_unconditional_branch(cb)?;
+                    self.builder.position_at_end(cb);
+                    let cv = self
+                        .compile_expr(condition, variables, function)?
+                        .into_int_value();
+                    self.builder.build_conditional_branch(
+                        self.builder.build_int_compare(
+                            IntPredicate::NE,
+                            cv,
+                            i64_t.const_int(0, false),
+                            "loopcond",
+                        )?,
+                        bb,
+                        eb,
+                    )?;
+                    self.builder.position_at_end(bb);
                     self.loop_exit_blocks.push(eb);
                     self.loop_cond_blocks.push(cb);
-                    let mut bvars = variables.clone(); 
-                    self.compile_block(body, &mut bvars, function)?; 
+                    let mut bvars = variables.clone();
+                    self.compile_block(body, &mut bvars, function)?;
                     self.loop_exit_blocks.pop();
                     self.loop_cond_blocks.pop();
-                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
-                        self.builder.build_unconditional_branch(cb)?; 
-                    } 
-                    self.builder.position_at_end(eb); 
+                    if self
+                        .builder
+                        .get_insert_block()
+                        .ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?
+                        .get_terminator()
+                        .is_none()
+                    {
+                        self.builder.build_unconditional_branch(cb)?;
+                    }
+                    self.builder.position_at_end(eb);
                     lv = None;
-                },
+                }
                 Statement::Break(_) => {
-                    let eb = self.loop_exit_blocks.last().ok_or_else(|| CompileError::Internal("break outside loop".to_string()))?;
+                    let eb = self
+                        .loop_exit_blocks
+                        .last()
+                        .ok_or_else(|| CompileError::internal("break outside loop".to_string()))?;
                     self.builder.build_unconditional_branch(*eb)?;
                     lv = None;
-                },
+                }
                 Statement::Continue(_) => {
-                    let cb = self.loop_cond_blocks.last().ok_or_else(|| CompileError::Internal("continue outside loop".to_string()))?;
+                    let cb = self.loop_cond_blocks.last().ok_or_else(|| {
+                        CompileError::internal("continue outside loop".to_string())
+                    })?;
                     self.builder.build_unconditional_branch(*cb)?;
                     lv = None;
-                },
-                Statement::Match { condition, arms, .. } => {
-                    let cv = self.compile_expr(condition, variables, function)?; 
-                    let exit_bb = self.context.append_basic_block(function, "matchexit"); 
+                }
+                Statement::Match {
+                    condition, arms, ..
+                } => {
+                    let cv = self.compile_expr(condition, variables, function)?;
+                    let exit_bb = self.context.append_basic_block(function, "matchexit");
                     let mut phis = Vec::new();
-                    let ctn = self.get_expr_type_name(condition, variables); 
-                    let cbn = if ctn.contains('<') { ctn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))?.to_string() } else { ctn.clone() };
-                    let fen = self.resolve_fuzzy_name(&self.enum_types, &cbn).unwrap_or(cbn.clone());
-                    
+                    let ctn = self.get_expr_type_name(condition, variables);
+                    let cbn = if ctn.contains('<') {
+                        ctn.split('<')
+                            .next()
+                            .ok_or_else(|| CompileError::internal("Invalid type name".to_string()))?
+                            .to_string()
+                    } else {
+                        ctn.clone()
+                    };
+                    let fen = self
+                        .resolve_fuzzy_name(&self.enum_types, &cbn)
+                        .unwrap_or(cbn.clone());
+
                     if let Some(et_ref) = self.enum_types.get(&fen) {
-                        let et = *et_ref; 
-                        let ep = cv.into_pointer_value(); 
-                        let tag = self.builder.build_load(i64_t, self.builder.build_struct_gep(et, ep, 0, "tagptr")?, "tag")?.into_int_value();
+                        let et = *et_ref;
+                        let ep = cv.into_pointer_value();
+                        let tag = self
+                            .builder
+                            .build_load(
+                                i64_t,
+                                self.builder.build_struct_gep(et, ep, 0, "tagptr")?,
+                                "tag",
+                            )?
+                            .into_int_value();
                         let na = arms.len();
                         for (i, arm) in arms.iter().enumerate() {
-                            let ab = self.context.append_basic_block(function, &format!("arm_{}_{}", i, arm.pattern)); 
-                            let is_last = i == na - 1; 
-                            let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_next") };
-                            
+                            let ab = self.context.append_basic_block(
+                                function,
+                                &format!("arm_{}_{}", i, arm.pattern),
+                            );
+                            let is_last = i == na - 1;
+                            let nb = if is_last {
+                                exit_bb
+                            } else {
+                                self.context.append_basic_block(function, "match_next")
+                            };
+
                             // Get all patterns to check
                             let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                                 vec![arm.pattern.clone()]
                             } else {
                                 arm.patterns.clone()
                             };
-                            
+
                             let is_default = all_patterns.iter().any(|p| p == "_");
                             let mut arm_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
-                            
+
                             if !is_default {
                                 if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
                                     for pat in &all_patterns {
                                         let mut at = i as u64;
                                         for (vi, v) in e_decl.variants.iter().enumerate() {
-                                            if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
+                                            if pat == &v.name
+                                                || pat.ends_with(&format!(".{}", v.name))
+                                                || pat.ends_with(&format!("::{}", v.name))
+                                            {
                                                 at = vi as u64;
                                                 break;
                                             }
                                         }
                                         // Fallback for common variants
-                                        if at == i as u64 && (pat == "Some" || pat == "Ok" || pat.ends_with(".Some") || pat.ends_with("::Some")) { at = 0; }
-                                        if at == i as u64 && (pat == "None" || pat == "Err" || pat.ends_with(".None") || pat.ends_with("::None")) { at = 1; }
-                                        
-                                        let cond = self.builder.build_int_compare(IntPredicate::EQ, tag, i64_t.const_int(at, false), "is_arm")?;
+                                        if at == i as u64
+                                            && (pat == "Some"
+                                                || pat == "Ok"
+                                                || pat.ends_with(".Some")
+                                                || pat.ends_with("::Some"))
+                                        {
+                                            at = 0;
+                                        }
+                                        if at == i as u64
+                                            && (pat == "None"
+                                                || pat == "Err"
+                                                || pat.ends_with(".None")
+                                                || pat.ends_with("::None"))
+                                        {
+                                            at = 1;
+                                        }
+
+                                        let cond = self.builder.build_int_compare(
+                                            IntPredicate::EQ,
+                                            tag,
+                                            i64_t.const_int(at, false),
+                                            "is_arm",
+                                        )?;
                                         arm_match_cond = Some(match arm_match_cond {
-                                            Some(prev) => self.builder.build_or(prev, cond, "arm_or")?,
+                                            Some(prev) => {
+                                                self.builder.build_or(prev, cond, "arm_or")?
+                                            }
                                             None => cond,
                                         });
                                     }
                                 }
                             }
-                            
+
                             if is_default && arm_match_cond.is_none() {
                                 self.builder.build_unconditional_branch(ab)?;
                             } else if let Some(cond) = arm_match_cond {
@@ -634,110 +1117,206 @@ impl<'ctx> Compiler<'ctx> {
                             } else {
                                 self.builder.build_unconditional_branch(nb)?;
                             }
-                            if is_last && !is_default { 
-                                let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                                phis.push((i64_t.const_zero().into(), test_bb)); 
+                            if is_last && !is_default {
+                                let test_bb = self.builder.get_insert_block().ok_or_else(|| {
+                                    CompileError::internal("No active insert block".to_string())
+                                })?;
+                                phis.push((i64_t.const_zero().into(), test_bb));
                             }
-                            self.builder.position_at_end(ab); 
+                            self.builder.position_at_end(ab);
                             let mut av = variables.clone();
                             if !arm.params.is_empty() {
-                                let dp = self.builder.build_struct_gep(et, ep, 1, "arm_dataptr")?; 
+                                let dp = self.builder.build_struct_gep(et, ep, 1, "arm_dataptr")?;
                                 let mut ptn = "i64".to_string();
-                                if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) { 
-                                    for v in &e_decl.variants { 
-                                        if arm.pattern == v.name || arm.pattern.ends_with(&format!(".{}", v.name)) || arm.pattern.ends_with(&format!("::{}", v.name)) { 
-                                            if !v.data_types.is_empty() { ptn = v.data_types[0].clone(); } 
-                                            break; 
-                                        } 
-                                    } 
+                                if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
+                                    for v in &e_decl.variants {
+                                        if arm.pattern == v.name
+                                            || arm.pattern.ends_with(&format!(".{}", v.name))
+                                            || arm.pattern.ends_with(&format!("::{}", v.name))
+                                        {
+                                            if !v.data_types.is_empty() {
+                                                ptn = v.data_types[0].clone();
+                                            }
+                                            break;
+                                        }
+                                    }
                                 }
-                                let lt = self.aion_type_to_llvm(&ptn); 
-                                let cp = self.builder.build_bit_cast(dp, self.context.ptr_type(AddressSpace::default()), "arm_datacast")?; 
-                                let lv_val = self.builder.build_load(lt, cp.into_pointer_value(), &arm.params[0])?;
-                                let pa = self.builder.build_alloca(lt, &arm.params[0])?; 
-                                self.builder.build_store(pa, lv_val)?; 
+                                let lt = self.aion_type_to_llvm(&ptn);
+                                let cp = self.builder.build_bit_cast(
+                                    dp,
+                                    self.context.ptr_type(AddressSpace::default()),
+                                    "arm_datacast",
+                                )?;
+                                let lv_val = self.builder.build_load(
+                                    lt,
+                                    cp.into_pointer_value(),
+                                    &arm.params[0],
+                                )?;
+                                let pa = self.builder.build_alloca(lt, &arm.params[0])?;
+                                self.builder.build_store(pa, lv_val)?;
                                 av.insert(arm.params[0].clone(), (pa, lt, ptn));
                             }
-                            
+
                             // Evaluate guard condition if present
                             if let Some(guard_expr) = &arm.guard {
-                                let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
-                                let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                                let guard_val = self
+                                    .compile_expr(guard_expr, &av, function)?
+                                    .into_int_value();
+                                let guard_pass_bb =
+                                    self.context.append_basic_block(function, "guard_pass");
                                 let guard_fail_bb = nb;
-                                let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
-                                self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                                let guard_cond = self.builder.build_int_compare(
+                                    IntPredicate::NE,
+                                    guard_val,
+                                    i64_t.const_zero(),
+                                    "guard_cond",
+                                )?;
+                                self.builder.build_conditional_branch(
+                                    guard_cond,
+                                    guard_pass_bb,
+                                    guard_fail_bb,
+                                )?;
                                 self.builder.position_at_end(guard_pass_bb);
                             }
-                            
-                            let ar = self.compile_block(&arm.body, &mut av, function)?; 
-                            let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                            if abf.get_terminator().is_none() { 
-                                let v = ar.unwrap_or(i64_t.const_zero().into()); 
-                                phis.push((v, abf)); 
+
+                            let ar = self.compile_block(&arm.body, &mut av, function)?;
+                            let abf = self.builder.get_insert_block().ok_or_else(|| {
+                                CompileError::internal("No active insert block".to_string())
+                            })?;
+                            if abf.get_terminator().is_none() {
+                                let v = ar.unwrap_or(i64_t.const_zero().into());
+                                phis.push((v, abf));
                             }
-                            if !is_last { self.builder.position_at_end(nb); }
+                            if !is_last {
+                                self.builder.position_at_end(nb);
+                            }
                         }
                     } else {
                         // Match on primitives (i64, String)
                         let na = arms.len();
                         for (i, arm) in arms.iter().enumerate() {
-                            let pattern_clean = arm.pattern.chars().filter(|c| c.is_alphanumeric()).collect::<String>();
-                            let ab = self.context.append_basic_block(function, &format!("arm_{}_{}", i, pattern_clean));
+                            let pattern_clean = arm
+                                .pattern
+                                .chars()
+                                .filter(|c| c.is_alphanumeric())
+                                .collect::<String>();
+                            let ab = self.context.append_basic_block(
+                                function,
+                                &format!("arm_{}_{}", i, pattern_clean),
+                            );
                             let is_last = i == na - 1;
-                            let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_next") };
-                            
+                            let nb = if is_last {
+                                exit_bb
+                            } else {
+                                self.context.append_basic_block(function, "match_next")
+                            };
+
                             // Get all patterns
                             let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                                 vec![arm.pattern.clone()]
                             } else {
                                 arm.patterns.clone()
                             };
-                            
+
                             let is_default = all_patterns.iter().any(|p| p == "_");
                             // If pattern is a binding variable (not a number) and we have params or guard, treat as wildcard
                             let is_binding_var = arm.params.len() > 0 || arm.guard.is_some();
                             let mut prim_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
-                            
+
                             if !is_default && !is_binding_var {
                                 if ctn == "i64" || ctn == "Integer" {
                                     for pat in &all_patterns {
                                         if let Some((start_str, end_str)) = pat.split_once("..") {
-                                            if let (Ok(start), Ok(end)) = (start_str.parse::<i64>(), end_str.parse::<i64>()) {
+                                            if let (Ok(start), Ok(end)) =
+                                                (start_str.parse::<i64>(), end_str.parse::<i64>())
+                                            {
                                                 let cv_val = cv.into_int_value();
-                                                let cond_start = self.builder.build_int_compare(IntPredicate::SGE, cv_val, i64_t.const_int(start as u64, false), "range_start")?;
-                                                let cond_end = self.builder.build_int_compare(IntPredicate::SLE, cv_val, i64_t.const_int(end as u64, false), "range_end")?;
-                                                let range_cond = self.builder.build_and(cond_start, cond_end, "range_cond")?;
+                                                let cond_start = self.builder.build_int_compare(
+                                                    IntPredicate::SGE,
+                                                    cv_val,
+                                                    i64_t.const_int(start as u64, false),
+                                                    "range_start",
+                                                )?;
+                                                let cond_end = self.builder.build_int_compare(
+                                                    IntPredicate::SLE,
+                                                    cv_val,
+                                                    i64_t.const_int(end as u64, false),
+                                                    "range_end",
+                                                )?;
+                                                let range_cond = self.builder.build_and(
+                                                    cond_start,
+                                                    cond_end,
+                                                    "range_cond",
+                                                )?;
                                                 prim_match_cond = Some(match prim_match_cond {
-                                                    Some(prev) => self.builder.build_or(prev, range_cond, "range_or")?,
+                                                    Some(prev) => self
+                                                        .builder
+                                                        .build_or(prev, range_cond, "range_or")?,
                                                     None => range_cond,
                                                 });
                                             }
                                         } else if let Ok(val) = pat.parse::<i64>() {
-                                            let cond = self.builder.build_int_compare(IntPredicate::EQ, cv.into_int_value(), i64_t.const_int(val as u64, false), "match_cond")?;
+                                            let cond = self.builder.build_int_compare(
+                                                IntPredicate::EQ,
+                                                cv.into_int_value(),
+                                                i64_t.const_int(val as u64, false),
+                                                "match_cond",
+                                            )?;
                                             prim_match_cond = Some(match prim_match_cond {
-                                                Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                                Some(prev) => {
+                                                    self.builder.build_or(prev, cond, "match_or")?
+                                                }
                                                 None => cond,
                                             });
                                         }
                                     }
                                 } else if ctn == "String" {
                                     for pat in &all_patterns {
-                                        let pattern_str = if pat.starts_with('"') && pat.ends_with('"') {
-                                            pat[1..pat.len()-1].to_string()
-                                        } else { pat.clone() };
-                                        
-                                        let ps = self.builder.build_global_string_ptr(&pattern_str, "match_pattern")?;
-                                        let fnc = self.module.get_function("aion_str_eq").ok_or_else(|| CompileError::Internal("aion_str_eq not found".to_string()))?;
-                                        let cmp = self.builder.build_call(fnc, &[cv.into(), ps.as_basic_value_enum().into()], "streq")?.try_as_basic_value().unwrap_basic().into_int_value();
-                                        let cond = self.builder.build_int_compare(IntPredicate::NE, cmp, i64_t.const_zero(), "match_cond")?;
+                                        let pattern_str =
+                                            if pat.starts_with('"') && pat.ends_with('"') {
+                                                pat[1..pat.len() - 1].to_string()
+                                            } else {
+                                                pat.clone()
+                                            };
+
+                                        let ps = self.builder.build_global_string_ptr(
+                                            &pattern_str,
+                                            "match_pattern",
+                                        )?;
+                                        let fnc = self
+                                            .module
+                                            .get_function("aion_str_eq")
+                                            .ok_or_else(|| {
+                                                CompileError::internal(
+                                                    "aion_str_eq not found".to_string(),
+                                                )
+                                            })?;
+                                        let cmp = self
+                                            .builder
+                                            .build_call(
+                                                fnc,
+                                                &[cv.into(), ps.as_basic_value_enum().into()],
+                                                "streq",
+                                            )?
+                                            .try_as_basic_value()
+                                            .unwrap_basic()
+                                            .into_int_value();
+                                        let cond = self.builder.build_int_compare(
+                                            IntPredicate::NE,
+                                            cmp,
+                                            i64_t.const_zero(),
+                                            "match_cond",
+                                        )?;
                                         prim_match_cond = Some(match prim_match_cond {
-                                            Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                            Some(prev) => {
+                                                self.builder.build_or(prev, cond, "match_or")?
+                                            }
                                             None => cond,
                                         });
                                     }
                                 }
                             }
-                            
+
                             if is_default && prim_match_cond.is_none() || is_binding_var {
                                 self.builder.build_unconditional_branch(ab)?;
                             } else if let Some(cond) = prim_match_cond {
@@ -745,14 +1324,16 @@ impl<'ctx> Compiler<'ctx> {
                             } else {
                                 self.builder.build_unconditional_branch(nb)?;
                             }
-                            
+
                             if is_last && !is_default {
-                                let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                                let test_bb = self.builder.get_insert_block().ok_or_else(|| {
+                                    CompileError::internal("No active insert block".to_string())
+                                })?;
                                 phis.push((i64_t.const_zero().into(), test_bb));
                             }
 
                             self.builder.position_at_end(ab);
-                            
+
                             // For primitives, bind pattern variable if present and evaluate guard
                             let mut av = variables.clone();
                             if !arm.params.is_empty() {
@@ -768,48 +1349,80 @@ impl<'ctx> Compiler<'ctx> {
                                     self.builder.build_store(pa, cv_ptr)?;
                                     // Update type to pointer so member access works
                                     let ptr_type = self.context.ptr_type(AddressSpace::default());
-                                    av.insert(arm.params[0].clone(), (pa, ptr_type.into(), format!("*{}", ctn)));
+                                    av.insert(
+                                        arm.params[0].clone(),
+                                        (pa, ptr_type.into(), format!("*{}", ctn)),
+                                    );
                                 } else {
                                     self.builder.build_store(pa, cv)?;
-                                    av.insert(arm.params[0].clone(), (pa, cv_type, ctn.to_string()));
+                                    av.insert(
+                                        arm.params[0].clone(),
+                                        (pa, cv_type, ctn.to_string()),
+                                    );
                                 }
                             }
-                            
+
                             // Evaluate guard condition if present
                             if let Some(guard_expr) = &arm.guard {
-                                let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
-                                let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                                let guard_val = self
+                                    .compile_expr(guard_expr, &av, function)?
+                                    .into_int_value();
+                                let guard_pass_bb =
+                                    self.context.append_basic_block(function, "guard_pass");
                                 let guard_fail_bb = nb;
-                                let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
-                                self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                                let guard_cond = self.builder.build_int_compare(
+                                    IntPredicate::NE,
+                                    guard_val,
+                                    i64_t.const_zero(),
+                                    "guard_cond",
+                                )?;
+                                self.builder.build_conditional_branch(
+                                    guard_cond,
+                                    guard_pass_bb,
+                                    guard_fail_bb,
+                                )?;
                                 self.builder.position_at_end(guard_pass_bb);
                             }
-                            
+
                             let ar = self.compile_block(&arm.body, &mut av, function)?;
-                            let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                            let abf = self.builder.get_insert_block().ok_or_else(|| {
+                                CompileError::internal("No active insert block".to_string())
+                            })?;
                             if abf.get_terminator().is_none() {
                                 let v = ar.unwrap_or(i64_t.const_zero().into());
                                 phis.push((v, abf));
                             }
-                            if !is_last { self.builder.position_at_end(nb); }
+                            if !is_last {
+                                self.builder.position_at_end(nb);
+                            }
                         }
                     }
 
                     self.builder.position_at_end(exit_bb);
                     if exit_bb.get_terminator().is_none() {
-                        if phis.is_empty() { 
-                            self.builder.build_unreachable()?; 
-                            lv = None; 
+                        if phis.is_empty() {
+                            self.builder.build_unreachable()?;
+                            lv = None;
                         } else {
-                            let target_type = phis[0].0.get_type(); 
+                            let target_type = phis[0].0.get_type();
                             let mut final_phis = Vec::new();
                             for (mut v, b) in phis {
                                 self.builder.position_at_end(b);
                                 if v.get_type() != target_type {
-                                    if target_type.is_pointer_type() && v.is_int_value() { 
-                                        v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?.into(); 
-                                    } else if target_type.is_int_type() && v.is_pointer_value() { 
-                                        v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?.into(); 
+                                    if target_type.is_pointer_type() && v.is_int_value() {
+                                        v = self
+                                            .builder
+                                            .build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?
+                                            .into();
+                                    } else if target_type.is_int_type() && v.is_pointer_value() {
+                                        v = self
+                                            .builder
+                                            .build_ptr_to_int(
+                                                v.into_pointer_value(),
+                                                i64_t,
+                                                "phi_int",
+                                            )?
+                                            .into();
                                     }
                                 }
                                 if b.get_terminator().is_none() {
@@ -818,355 +1431,853 @@ impl<'ctx> Compiler<'ctx> {
                                 final_phis.push((v, b));
                             }
                             self.builder.position_at_end(exit_bb);
-                            let phi = self.builder.build_phi(target_type, "matchres")?; 
-                            for (v, b) in final_phis { phi.add_incoming(&[(&v, b)]); } 
+                            let phi = self.builder.build_phi(target_type, "matchres")?;
+                            for (v, b) in final_phis {
+                                phi.add_incoming(&[(&v, b)]);
+                            }
                             lv = Some(phi.as_basic_value());
                         }
-                    } else { lv = None; }
-                },
-                Statement::ExpressionStmt(e, _) => { lv = Some(self.compile_expr(e, variables, function)?); },
-                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => { lv = self.compile_block(stmts, variables, function)?; },
-                _ => { lv = None; }
+                    } else {
+                        lv = None;
+                    }
+                }
+                Statement::ExpressionStmt(e, _) => {
+                    lv = Some(self.compile_expr(e, variables, function)?);
+                }
+                Statement::UnsafeBlock(stmts, _) | Statement::Spawn(stmts, _) => {
+                    lv = self.compile_block(stmts, variables, function)?;
+                }
+                _ => {
+                    lv = None;
+                }
             }
         }
         Ok(lv)
     }
 
-    fn compile_lvalue(&mut self, e: &Expression, variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>, function: FunctionValue<'ctx>) -> Result<(PointerValue<'ctx>, BasicTypeEnum<'ctx>), CompileError> {
+    fn compile_lvalue(
+        &mut self,
+        e: &Expression,
+        variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>,
+        function: FunctionValue<'ctx>,
+    ) -> Result<(PointerValue<'ctx>, BasicTypeEnum<'ctx>), CompileError> {
         let pt = self.context.ptr_type(AddressSpace::default());
         match e {
             Expression::Identifier(name, _) => {
-                if let Some((vn, fnm)) = name.split_once('.') { 
-                    if let Some((vptr, vt, vtn)) = variables.get(vn) { 
-                        let btn = if vtn.contains('<') { vtn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))? } else { vtn }; 
-                        let ftn = self.resolve_fuzzy_name(&self.struct_types, btn).unwrap_or(btn.to_string()); 
-                        if let Some(flds) = self.struct_fields.get(ftn.as_str()) { 
-                            if let Some(&idx) = flds.get(fnm) { 
-                                let st = *self.struct_types.get(&ftn).ok_or_else(|| CompileError::Internal(format!("LLVM struct type '{}' not found", ftn)))?; 
-                                let st_ptr = self.builder.build_load(*vt, *vptr, "st_load")?.into_pointer_value();
-                                return Ok((self.builder.build_struct_gep(st, st_ptr, idx, "fldptr")?, self.aion_type_to_llvm(&self.get_field_type(vtn, fnm)))); 
-                            } 
-                        } 
-                    } 
+                if let Some((vn, fnm)) = name.split_once('.') {
+                    if let Some((vptr, vt, vtn)) = variables.get(vn) {
+                        let btn = if vtn.contains('<') {
+                            vtn.split('<').next().ok_or_else(|| {
+                                CompileError::internal("Invalid type name".to_string())
+                            })?
+                        } else {
+                            vtn
+                        };
+                        let ftn = self
+                            .resolve_fuzzy_name(&self.struct_types, btn)
+                            .unwrap_or(btn.to_string());
+                        if let Some(flds) = self.struct_fields.get(ftn.as_str()) {
+                            if let Some(&idx) = flds.get(fnm) {
+                                let st = *self.struct_types.get(&ftn).ok_or_else(|| {
+                                    CompileError::internal(format!(
+                                        "LLVM struct type '{}' not found",
+                                        ftn
+                                    ))
+                                })?;
+                                let st_ptr = self
+                                    .builder
+                                    .build_load(*vt, *vptr, "st_load")?
+                                    .into_pointer_value();
+                                return Ok((
+                                    self.builder.build_struct_gep(st, st_ptr, idx, "fldptr")?,
+                                    self.aion_type_to_llvm(&self.get_field_type(vtn, fnm)),
+                                ));
+                            }
+                        }
+                    }
                 }
-                if let Some((ptr, vt, _)) = variables.get(name) { Ok((*ptr, *vt)) } else { Err(self.err(format!("variable '{}' not found", name), e)) }
-            },
-            Expression::MemberAccess { receiver, member, .. } => {
-                let (rp, rt_llvm) = self.compile_lvalue(receiver, variables, function)?; 
-                let rtn = self.get_expr_type_name(receiver, variables); 
+                if let Some((ptr, vt, _)) = variables.get(name) {
+                    Ok((*ptr, *vt))
+                } else {
+                    Err(self.err(format!("variable '{}' not found", name), e))
+                }
+            }
+            Expression::MemberAccess {
+                receiver, member, ..
+            } => {
+                let (rp, rt_llvm) = self.compile_lvalue(receiver, variables, function)?;
+                let rtn = self.get_expr_type_name(receiver, variables);
                 let ftn = self.get_field_type(&rtn, member);
-                let mut bc = if rtn.contains('<') { rtn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))? } else { &rtn }; 
-                while bc.starts_with('*') { bc = &bc[1..]; }
-                let ft = self.resolve_fuzzy_name(&self.decls, bc).ok_or_else(|| CompileError::Internal(format!("Struct '{}' not found (rec_type={}, receiver={:?})", bc, rtn, receiver)))?;
-                let st = *self.struct_types.get(&ft).ok_or_else(|| CompileError::Internal(format!("LLVM type not found for '{}'", ft)))?;
-                let idx = *self.struct_fields.get(&ft).ok_or_else(|| CompileError::Internal(format!("Fields for struct '{}' not found", ft)))?.get(member).ok_or_else(|| CompileError::Internal(format!("Field '{}' not found", member)))?;
-                
-                let st_ptr = self.builder.build_load(rt_llvm, rp, "st_load")?.into_pointer_value();
-                Ok((self.builder.build_struct_gep(st, st_ptr, idx, member)?, self.aion_type_to_llvm(&ftn)))
-            },
-            Expression::Deref { expr, .. } => { 
-                let v = self.compile_expr(expr, variables, function)?; 
-                let tn = self.get_expr_type_name(expr, variables); 
-                let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" }); 
-                let p = if v.is_int_value() { self.builder.build_int_to_ptr(v.into_int_value(), pt, "i2p")? } else { v.into_pointer_value() }; 
-                Ok((p, et)) 
-            },
-            _ => Err(CompileError::Internal(format!("Not an lvalue: {:?}", e))),
+                let mut bc = if rtn.contains('<') {
+                    rtn.split('<')
+                        .next()
+                        .ok_or_else(|| CompileError::internal("Invalid type name".to_string()))?
+                } else {
+                    &rtn
+                };
+                while bc.starts_with('*') {
+                    bc = &bc[1..];
+                }
+                let ft = self.resolve_fuzzy_name(&self.decls, bc).ok_or_else(|| {
+                    CompileError::internal(format!(
+                        "Struct '{}' not found (rec_type={}, receiver={:?})",
+                        bc, rtn, receiver
+                    ))
+                })?;
+                let st = *self.struct_types.get(&ft).ok_or_else(|| {
+                    CompileError::internal(format!("LLVM type not found for '{}'", ft))
+                })?;
+                let idx = *self
+                    .struct_fields
+                    .get(&ft)
+                    .ok_or_else(|| {
+                        CompileError::internal(format!("Fields for struct '{}' not found", ft))
+                    })?
+                    .get(member)
+                    .ok_or_else(|| {
+                        CompileError::internal(format!("Field '{}' not found", member))
+                    })?;
+
+                let st_ptr = self
+                    .builder
+                    .build_load(rt_llvm, rp, "st_load")?
+                    .into_pointer_value();
+                Ok((
+                    self.builder.build_struct_gep(st, st_ptr, idx, member)?,
+                    self.aion_type_to_llvm(&ftn),
+                ))
+            }
+            Expression::Deref { expr, .. } => {
+                let v = self.compile_expr(expr, variables, function)?;
+                let tn = self.get_expr_type_name(expr, variables);
+                let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" });
+                let p = if v.is_int_value() {
+                    self.builder
+                        .build_int_to_ptr(v.into_int_value(), pt, "i2p")?
+                } else {
+                    v.into_pointer_value()
+                };
+                Ok((p, et))
+            }
+            _ => Err(CompileError::internal(format!("Not an lvalue: {:?}", e))),
         }
     }
 
-    fn compile_expr(&mut self, e: &Expression, variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>, function: FunctionValue<'ctx>) -> Result<BasicValueEnum<'ctx>, CompileError> {
-        let i64_t = self.context.i64_type(); 
+    fn compile_expr(
+        &mut self,
+        e: &Expression,
+        variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>,
+        function: FunctionValue<'ctx>,
+    ) -> Result<BasicValueEnum<'ctx>, CompileError> {
+        let i64_t = self.context.i64_type();
         let pt = self.context.ptr_type(AddressSpace::default());
         match e {
             Expression::Integer(n, _) => Ok(i64_t.const_int(*n as u64, false).into()),
             Expression::Float(f_val, _) => Ok(self.context.f64_type().const_float(*f_val).into()),
             Expression::Char(c, _) => Ok(i64_t.const_int(*c as u64, false).into()),
             Expression::Boolean(b, _) => Ok(i64_t.const_int(if *b { 1 } else { 0 }, false).into()),
-            Expression::String(s, _) => Ok(self.builder.build_global_string_ptr(&format!("{}\0", s), "aion_str")?.as_basic_value_enum()),
-            Expression::Identifier(name, _) => { 
-                if let Some((ptr, vt, _)) = variables.get(name) { 
-                    Ok(self.builder.build_load(*vt, *ptr, name)?) 
-                } else { 
-                    if let Ok((ptr, vt)) = self.compile_lvalue(e, variables, function) { 
-                        return Ok(self.builder.build_load(vt, ptr, name)?); 
-                    } 
-                    if name == "argc" { if let Some(g) = self.module.get_global("aion_argc") { return Ok(self.builder.build_load(i64_t, g.as_pointer_value(), "argc")?); } } 
-                    if name == "argv" { if let Some(g) = self.module.get_global("aion_argv") { return Ok(self.builder.build_load(pt, g.as_pointer_value(), "argv")?); } } 
-                    Err(self.err(format!("variable '{}' not found", name), e)) 
-                } 
-            },
-            Expression::Call { function: fnm, generic_args, arguments, .. } => {
-                let mut afn = fnm.clone(); 
-                let mut aga = generic_args.clone(); 
-                let mut aa = arguments.clone(); 
+            Expression::String(s, _) => Ok(self
+                .builder
+                .build_global_string_ptr(&format!("{}\0", s), "aion_str")?
+                .as_basic_value_enum()),
+            Expression::Identifier(name, _) => {
+                if let Some((ptr, vt, _)) = variables.get(name) {
+                    Ok(self.builder.build_load(*vt, *ptr, name)?)
+                } else {
+                    if let Ok((ptr, vt)) = self.compile_lvalue(e, variables, function) {
+                        return Ok(self.builder.build_load(vt, ptr, name)?);
+                    }
+                    if name == "argc" {
+                        if let Some(g) = self.module.get_global("aion_argc") {
+                            return Ok(self.builder.build_load(
+                                i64_t,
+                                g.as_pointer_value(),
+                                "argc",
+                            )?);
+                        }
+                    }
+                    if name == "argv" {
+                        if let Some(g) = self.module.get_global("aion_argv") {
+                            return Ok(self.builder.build_load(
+                                pt,
+                                g.as_pointer_value(),
+                                "argv",
+                            )?);
+                        }
+                    }
+                    Err(self.err(format!("variable '{}' not found", name), e))
+                }
+            }
+            Expression::Call {
+                function: fnm,
+                generic_args,
+                arguments,
+                ..
+            } => {
+                let mut afn = fnm.clone();
+                let mut aga = generic_args.clone();
+                let mut aa = arguments.clone();
                 let mut is_mc = false;
                 let mut tga_from_receiver: Vec<String> = vec![];
                 if let Some((rn, mn)) = fnm.rsplit_once('.') {
-                     let re = Expression::Identifier(rn.to_string(), Span::zero());
-                     let tn = self.get_expr_type_name(&re, variables);
-                     if (tn.starts_with('*') || tn.contains("ptr")) && mn == "offset" && arguments.len() == 1 {
-                         let idx = self.compile_expr(&arguments[0], variables, function)?.into_int_value();
-                         let ptr = if let Ok((p, _)) = self.compile_lvalue(&re, variables, function) {
-                             self.builder.build_load(self.context.ptr_type(AddressSpace::default()), p, "ptrload")?.into_pointer_value()
-                         } else {
-                             self.compile_expr(&re, variables, function)?.into_pointer_value()
-                         };
-                         let element_type = if tn.starts_with('*') { self.aion_type_to_llvm(&tn[1..]) } else { self.context.i64_type().into() };
-                         return Ok(unsafe { self.builder.build_gep(element_type, ptr, &[idx], "offset_ptr")? }.into());
-                     }
-                     if tn != "unknown" { 
-                         let (btn, tga) = if tn.contains('<') { let p: Vec<&str> = tn.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect(); (p[0].to_string(), p[1..].iter().map(|s| s.trim().to_string()).collect()) } else { (tn.clone(), vec![]) }; 
-                         tga_from_receiver = tga.clone();
-                         let mut bc = btn.as_str(); while bc.starts_with('*') { bc = &bc[1..]; } 
-                         let tp = self.resolve_fuzzy_name(&self.struct_types, bc).or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc)).unwrap_or(btn.clone()); 
-                         let fc = self.resolve_fuzzy_name(&self.decls, &format!("{}::{}", tp, mn))
-                             .or_else(|| self.resolve_fuzzy_name(&self.decls, &format!("{}.{}", tp, mn)))
-                             .unwrap_or(format!("{}.{}", tp, mn)); 
-                         if let Some(Declaration::Function(f_decl)) = self.decls.get(&fc) { 
-                             let has_self = f_decl.params.get(0).map_or(false, |(n, _, _)| n == "self");
-                             if has_self {
-                                 aa.insert(0, re); 
-                                 if aga.is_empty() { aga = tga; } 
-                                 is_mc = true; 
-                             }
-                             afn = fc; 
-                         } 
-                     }
+                    let re = Expression::Identifier(rn.to_string(), Span::zero());
+                    let tn = self.get_expr_type_name(&re, variables);
+                    if (tn.starts_with('*') || tn.contains("ptr"))
+                        && mn == "offset"
+                        && arguments.len() == 1
+                    {
+                        let idx = self
+                            .compile_expr(&arguments[0], variables, function)?
+                            .into_int_value();
+                        let ptr = if let Ok((p, _)) = self.compile_lvalue(&re, variables, function)
+                        {
+                            self.builder
+                                .build_load(
+                                    self.context.ptr_type(AddressSpace::default()),
+                                    p,
+                                    "ptrload",
+                                )?
+                                .into_pointer_value()
+                        } else {
+                            self.compile_expr(&re, variables, function)?
+                                .into_pointer_value()
+                        };
+                        let element_type = if tn.starts_with('*') {
+                            self.aion_type_to_llvm(&tn[1..])
+                        } else {
+                            self.context.i64_type().into()
+                        };
+                        return Ok(unsafe {
+                            self.builder
+                                .build_gep(element_type, ptr, &[idx], "offset_ptr")?
+                        }
+                        .into());
+                    }
+                    if tn != "unknown" {
+                        let (btn, tga) = if tn.contains('<') {
+                            let p: Vec<&str> = tn
+                                .split(['<', '>', ','])
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            (
+                                p[0].to_string(),
+                                p[1..].iter().map(|s| s.trim().to_string()).collect(),
+                            )
+                        } else {
+                            (tn.clone(), vec![])
+                        };
+                        tga_from_receiver = tga.clone();
+                        let mut bc = btn.as_str();
+                        while bc.starts_with('*') {
+                            bc = &bc[1..];
+                        }
+                        let tp = self
+                            .resolve_fuzzy_name(&self.struct_types, bc)
+                            .or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc))
+                            .unwrap_or(btn.clone());
+                        let fc = self
+                            .resolve_fuzzy_name(&self.decls, &format!("{}::{}", tp, mn))
+                            .or_else(|| {
+                                self.resolve_fuzzy_name(&self.decls, &format!("{}.{}", tp, mn))
+                            })
+                            .unwrap_or(format!("{}.{}", tp, mn));
+                        if let Some(Declaration::Function(f_decl)) = self.decls.get(&fc) {
+                            let has_self =
+                                f_decl.params.get(0).map_or(false, |(n, _, _)| n == "self");
+                            if has_self {
+                                aa.insert(0, re);
+                                if aga.is_empty() {
+                                    aga = tga;
+                                }
+                                is_mc = true;
+                            }
+                            afn = fc;
+                        }
+                    }
                 }
-                let full = self.resolve_fuzzy_name(&self.decls, &afn).unwrap_or(afn.clone()); 
-                let mut lnm = full.clone(); 
-                if let Some(Declaration::Function(f_decl)) = self.decls.get(&full) { 
-                    for (an, av) in &f_decl.attributes { if an == "intrinsic" { lnm = av.replace("libc.", ""); break; } } 
+                let full = self
+                    .resolve_fuzzy_name(&self.decls, &afn)
+                    .unwrap_or(afn.clone());
+                let mut lnm = full.clone();
+                if let Some(Declaration::Function(f_decl)) = self.decls.get(&full) {
+                    for (an, av) in &f_decl.attributes {
+                        if an == "intrinsic" {
+                            lnm = av.replace("libc.", "");
+                            break;
+                        }
+                    }
                 }
-                let fv = if !aga.is_empty() { 
-                    let gn = format!("{}_{}", full, aga.join("_")); 
-                    if let Some(e) = self.module.get_function(&gn) { e } else { self.instantiate_function(&full, &aga)? } 
+                let fv = if !aga.is_empty() {
+                    let gn = format!("{}_{}", full, aga.join("_"));
+                    if let Some(e) = self.module.get_function(&gn) {
+                        e
+                    } else {
+                        self.instantiate_function(&full, &aga)?
+                    }
                 } else if let Some(Declaration::Function(f_decl)) = self.decls.get(&full) {
                     if !f_decl.generic_params.is_empty() && is_mc && !tga_from_receiver.is_empty() {
                         // Try to infer generic args from receiver type
                         let gn = format!("{}_{}", full, tga_from_receiver.join("_"));
-                        if let Some(e) = self.module.get_function(&gn) { e } else { self.instantiate_function(&full, &tga_from_receiver)? }
+                        if let Some(e) = self.module.get_function(&gn) {
+                            e
+                        } else {
+                            self.instantiate_function(&full, &tga_from_receiver)?
+                        }
                     } else {
-                        self.module.get_function(&lnm).ok_or_else(|| self.err(format!("function '{}' not found", afn), e))?
+                        self.module
+                            .get_function(&lnm)
+                            .ok_or_else(|| self.err(format!("function '{}' not found", afn), e))?
                     }
                 } else {
-                    self.module.get_function(&lnm).ok_or_else(|| self.err(format!("function '{}' not found", afn), e))?
+                    self.module
+                        .get_function(&lnm)
+                        .ok_or_else(|| self.err(format!("function '{}' not found", afn), e))?
                 };
-                let mut ca = Vec::new(); 
+                let mut ca = Vec::new();
                 let pts = fv.get_type().get_param_types();
-                for (i, arg) in aa.iter().enumerate() { 
-                    let ep = pts.get(i).map_or(false, |t: &inkwell::types::BasicMetadataTypeEnum| t.is_pointer_type()); 
-                    let val = if i == 0 && is_mc { 
+                for (i, arg) in aa.iter().enumerate() {
+                    let ep = pts
+                        .get(i)
+                        .map_or(false, |t: &inkwell::types::BasicMetadataTypeEnum| {
+                            t.is_pointer_type()
+                        });
+                    let val = if i == 0 && is_mc {
                         self.compile_expr(arg, variables, function)?
-                    } else { 
-                        let v = self.compile_expr(arg, variables, function)?; 
+                    } else {
+                        let v = self.compile_expr(arg, variables, function)?;
                         // Auto-convert i64 to string for io.println/io.print
                         if (fnm == "io.println" || fnm == "io.print") && v.is_int_value() {
-                            let conv_fn = self.module.get_function("aion_int_to_str").ok_or_else(|| CompileError::Internal("aion_int_to_str not found".to_string()))?;
-                            self.builder.build_call(conv_fn, &[v.into()], "to_str")?.try_as_basic_value().unwrap_basic()
-                        } else if ep && !v.get_type().is_pointer_type() { 
-                            let a = self.builder.build_alloca(v.get_type(), "temp_arg")?; 
-                            self.builder.build_store(a, v)?; 
-                            a.into() 
-                        } else { v } 
-                    }; 
-                    ca.push(val.into()); 
+                            let conv_fn =
+                                self.module.get_function("aion_int_to_str").ok_or_else(|| {
+                                    CompileError::internal("aion_int_to_str not found".to_string())
+                                })?;
+                            self.builder
+                                .build_call(conv_fn, &[v.into()], "to_str")?
+                                .try_as_basic_value()
+                                .unwrap_basic()
+                        } else if ep && !v.get_type().is_pointer_type() {
+                            let a = self.builder.build_alloca(v.get_type(), "temp_arg")?;
+                            self.builder.build_store(a, v)?;
+                            a.into()
+                        } else {
+                            v
+                        }
+                    };
+                    ca.push(val.into());
                 }
-                let call = if fv.get_type().get_return_type().is_none() { 
-                    self.builder.build_call(fv, &ca, "") 
-                } else { 
-                    self.builder.build_call(fv, &ca, "calltmp") 
-                }?; 
-                Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
-            },
-            Expression::Infix { left, operator, right, .. } => {
-                if operator.kind == TokenKind::And || operator.kind == TokenKind::Or { 
-                    let lhs = self.compile_expr(left, variables, function)?; 
-                    let li = match lhs { BasicValueEnum::IntValue(i) => i, _ => return Err(CompileError::Internal("Expected boolean".to_string())) }; 
-                    let rb = self.context.append_basic_block(function, "logic_rhs"); 
-                    let mb = self.context.append_basic_block(function, "logic_merge"); 
-                    let cond = if operator.kind == TokenKind::And { 
-                        self.builder.build_int_compare(IntPredicate::NE, li, i64_t.const_zero(), "and_cond")? 
-                    } else { 
-                        self.builder.build_int_compare(IntPredicate::EQ, li, i64_t.const_zero(), "or_cond")? 
-                    }; 
-                    self.builder.build_conditional_branch(cond, rb, mb)?; 
-                    let lfb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                    self.builder.position_at_end(rb); 
-                    let rhs = self.compile_expr(right, variables, function)?; 
-                    let ri = match rhs { BasicValueEnum::IntValue(i) => i, _ => return Err(CompileError::Internal("Expected boolean".to_string())) }; 
-                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
-                        self.builder.build_unconditional_branch(mb)?; 
-                    } 
-                    let rfb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                    self.builder.position_at_end(mb); 
-                    let phi = self.builder.build_phi(i64_t, "logic_res")?; 
-                    let lv_v = if operator.kind == TokenKind::And { i64_t.const_zero() } else { i64_t.const_int(1, false) }; 
-                    phi.add_incoming(&[(&lv_v, lfb), (&ri, rfb)]); 
-                    return Ok(phi.as_basic_value().into()); 
+                let call = if fv.get_type().get_return_type().is_none() {
+                    self.builder.build_call(fv, &ca, "")
+                } else {
+                    self.builder.build_call(fv, &ca, "calltmp")
+                }?;
+                Ok(match call.try_as_basic_value() {
+                    ValueKind::Basic(v) => v,
+                    _ => i64_t.const_zero().into(),
+                })
+            }
+            Expression::Infix {
+                left,
+                operator,
+                right,
+                ..
+            } => {
+                if operator.kind == TokenKind::And || operator.kind == TokenKind::Or {
+                    let lhs = self.compile_expr(left, variables, function)?;
+                    let li = match lhs {
+                        BasicValueEnum::IntValue(i) => i,
+                        _ => return Err(CompileError::internal("Expected boolean".to_string())),
+                    };
+                    let rb = self.context.append_basic_block(function, "logic_rhs");
+                    let mb = self.context.append_basic_block(function, "logic_merge");
+                    let cond = if operator.kind == TokenKind::And {
+                        self.builder.build_int_compare(
+                            IntPredicate::NE,
+                            li,
+                            i64_t.const_zero(),
+                            "and_cond",
+                        )?
+                    } else {
+                        self.builder.build_int_compare(
+                            IntPredicate::EQ,
+                            li,
+                            i64_t.const_zero(),
+                            "or_cond",
+                        )?
+                    };
+                    self.builder.build_conditional_branch(cond, rb, mb)?;
+                    let lfb = self.builder.get_insert_block().ok_or_else(|| {
+                        CompileError::internal("No active insert block".to_string())
+                    })?;
+                    self.builder.position_at_end(rb);
+                    let rhs = self.compile_expr(right, variables, function)?;
+                    let ri = match rhs {
+                        BasicValueEnum::IntValue(i) => i,
+                        _ => return Err(CompileError::internal("Expected boolean".to_string())),
+                    };
+                    if self
+                        .builder
+                        .get_insert_block()
+                        .ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?
+                        .get_terminator()
+                        .is_none()
+                    {
+                        self.builder.build_unconditional_branch(mb)?;
+                    }
+                    let rfb = self.builder.get_insert_block().ok_or_else(|| {
+                        CompileError::internal("No active insert block".to_string())
+                    })?;
+                    self.builder.position_at_end(mb);
+                    let phi = self.builder.build_phi(i64_t, "logic_res")?;
+                    let lv_v = if operator.kind == TokenKind::And {
+                        i64_t.const_zero()
+                    } else {
+                        i64_t.const_int(1, false)
+                    };
+                    phi.add_incoming(&[(&lv_v, lfb), (&ri, rfb)]);
+                    return Ok(phi.as_basic_value().into());
                 }
 
-                let lhs = self.compile_expr(left, variables, function)?; 
+                let lhs = self.compile_expr(left, variables, function)?;
 
                 // Special case for 'inside' which needs to peek at 'right' before compiling it
                 if operator.kind == TokenKind::Inside {
-                    if let Expression::Infix { left: r_left, operator: r_op, right: r_right, .. } = &**right {
+                    if let Expression::Infix {
+                        left: r_left,
+                        operator: r_op,
+                        right: r_right,
+                        ..
+                    } = &**right
+                    {
                         if r_op.kind == TokenKind::Range {
                             let l = lhs.into_int_value();
-                            let min = self.compile_expr(r_left, variables, function)?.into_int_value();
-                            let max = self.compile_expr(r_right, variables, function)?.into_int_value();
-                            let c1 = self.builder.build_int_compare(IntPredicate::SGE, l, min, "in_ge")?;
-                            let c2 = self.builder.build_int_compare(IntPredicate::SLT, l, max, "in_lt")?;
+                            let min = self
+                                .compile_expr(r_left, variables, function)?
+                                .into_int_value();
+                            let max = self
+                                .compile_expr(r_right, variables, function)?
+                                .into_int_value();
+                            let c1 = self.builder.build_int_compare(
+                                IntPredicate::SGE,
+                                l,
+                                min,
+                                "in_ge",
+                            )?;
+                            let c2 = self.builder.build_int_compare(
+                                IntPredicate::SLT,
+                                l,
+                                max,
+                                "in_lt",
+                            )?;
                             let res = self.builder.build_and(c1, c2, "in_res")?;
                             return Ok(self.builder.build_int_z_extend(res, i64_t, "bool")?.into());
                         }
                     }
-                    return Err(CompileError::Internal("Operator 'inside' currently only supports ranges (min..max)".to_string()));
+                    return Err(CompileError::internal(
+                        "Operator 'inside' currently only supports ranges (min..max)".to_string(),
+                    ));
                 }
 
                 let rhs = self.compile_expr(right, variables, function)?;
                 if lhs.is_int_value() && rhs.is_int_value() {
-                    let mut l = lhs.into_int_value(); 
-                    let mut r = rhs.into_int_value(); 
-                    if l.get_type().get_bit_width() < 64 { l = self.builder.build_int_s_extend(l, i64_t, "l_ext")?; } 
-                    if r.get_type().get_bit_width() < 64 { r = self.builder.build_int_s_extend(r, i64_t, "r_ext")?; }
-                    match &operator.kind {
-                        TokenKind::Plus => Ok(self.builder.build_int_add(l, r, "add")?.into()), 
-                        TokenKind::Minus => Ok(self.builder.build_int_sub(l, r, "sub")?.into()), 
-                        TokenKind::Star => Ok(self.builder.build_int_mul(l, r, "mul")?.into()), 
-                        TokenKind::Slash => Ok(self.builder.build_int_signed_div(l, r, "div")?.into()),
-                        TokenKind::EqEq => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::EQ, l, r, "eq")?, i64_t, "bool")?.into()), 
-                        TokenKind::NotEq => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::NE, l, r, "ne")?, i64_t, "bool")?.into()),
-                        TokenKind::Lt => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::SLT, l, r, "lt")?, i64_t, "bool")?.into()), 
-                        TokenKind::Gt => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::SGT, l, r, "gt")?, i64_t, "bool")?.into()),
-                        TokenKind::LtEq => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::SLE, l, r, "lteq")?, i64_t, "bool")?.into()), 
-                        TokenKind::GtEq => Ok(self.builder.build_int_z_extend(self.builder.build_int_compare(IntPredicate::SGE, l, r, "gteq")?, i64_t, "bool")?.into()),
-                        TokenKind::Percent => Ok(self.builder.build_int_unsigned_rem(l, r, "rem")?.into()), 
-                        TokenKind::Caret => Ok(self.builder.build_xor(l, r, "xor")?.into()), 
-                        _ => Err(CompileError::Internal(format!("Operator {:?} not supported", operator.kind))),
+                    let mut l = lhs.into_int_value();
+                    let mut r = rhs.into_int_value();
+                    if l.get_type().get_bit_width() < 64 {
+                        l = self.builder.build_int_s_extend(l, i64_t, "l_ext")?;
                     }
-                } else if (lhs.is_pointer_value() || lhs.is_int_value()) && (rhs.is_pointer_value() || rhs.is_int_value()) {
-                    let l = if lhs.is_int_value() { self.builder.build_int_to_ptr(lhs.into_int_value(), pt, "i2p")?.into() } else { lhs };
-                    let r = if rhs.is_int_value() { self.builder.build_int_to_ptr(rhs.into_int_value(), pt, "i2p")?.into() } else { rhs };
-                    let lp = l.into_pointer_value(); 
+                    if r.get_type().get_bit_width() < 64 {
+                        r = self.builder.build_int_s_extend(r, i64_t, "r_ext")?;
+                    }
+                    match &operator.kind {
+                        TokenKind::Plus => Ok(self.builder.build_int_add(l, r, "add")?.into()),
+                        TokenKind::Minus => Ok(self.builder.build_int_sub(l, r, "sub")?.into()),
+                        TokenKind::Star => Ok(self.builder.build_int_mul(l, r, "mul")?.into()),
+                        TokenKind::Slash => {
+                            Ok(self.builder.build_int_signed_div(l, r, "div")?.into())
+                        }
+                        TokenKind::EqEq => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::EQ, l, r, "eq")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::NotEq => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::NE, l, r, "ne")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::Lt => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::SLT, l, r, "lt")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::Gt => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::SGT, l, r, "gt")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::LtEq => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::SLE, l, r, "lteq")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::GtEq => Ok(self
+                            .builder
+                            .build_int_z_extend(
+                                self.builder
+                                    .build_int_compare(IntPredicate::SGE, l, r, "gteq")?,
+                                i64_t,
+                                "bool",
+                            )?
+                            .into()),
+                        TokenKind::Percent => {
+                            Ok(self.builder.build_int_unsigned_rem(l, r, "rem")?.into())
+                        }
+                        TokenKind::Caret => Ok(self.builder.build_xor(l, r, "xor")?.into()),
+                        _ => Err(CompileError::internal(format!(
+                            "Operator {:?} not supported",
+                            operator.kind
+                        ))),
+                    }
+                } else if (lhs.is_pointer_value() || lhs.is_int_value())
+                    && (rhs.is_pointer_value() || rhs.is_int_value())
+                {
+                    let l = if lhs.is_int_value() {
+                        self.builder
+                            .build_int_to_ptr(lhs.into_int_value(), pt, "i2p")?
+                            .into()
+                    } else {
+                        lhs
+                    };
+                    let r = if rhs.is_int_value() {
+                        self.builder
+                            .build_int_to_ptr(rhs.into_int_value(), pt, "i2p")?
+                            .into()
+                    } else {
+                        rhs
+                    };
+                    let lp = l.into_pointer_value();
                     let rp = r.into_pointer_value();
-                    match &operator.kind { 
-                        TokenKind::EqEq | TokenKind::NotEq => { 
+                    match &operator.kind {
+                        TokenKind::EqEq | TokenKind::NotEq => {
                             let ltn = self.get_expr_type_name(left, variables);
                             let rtn = self.get_expr_type_name(right, variables);
                             if ltn == "String" && rtn == "String" {
-                                let fnc = self.module.get_function("aion_str_eq").ok_or_else(|| CompileError::Internal("aion_str_eq not found".to_string()))?;
-                                let cmp = self.builder.build_call(fnc, &[lp.into(), rp.into()], "streq")?.try_as_basic_value().unwrap_basic().into_int_value();
+                                let fnc =
+                                    self.module.get_function("aion_str_eq").ok_or_else(|| {
+                                        CompileError::internal("aion_str_eq not found".to_string())
+                                    })?;
+                                let cmp = self
+                                    .builder
+                                    .build_call(fnc, &[lp.into(), rp.into()], "streq")?
+                                    .try_as_basic_value()
+                                    .unwrap_basic()
+                                    .into_int_value();
                                 let res = if operator.kind == TokenKind::EqEq {
-                                    self.builder.build_int_compare(IntPredicate::NE, cmp, i64_t.const_zero(), "eq")?
+                                    self.builder.build_int_compare(
+                                        IntPredicate::NE,
+                                        cmp,
+                                        i64_t.const_zero(),
+                                        "eq",
+                                    )?
                                 } else {
-                                    self.builder.build_int_compare(IntPredicate::EQ, cmp, i64_t.const_zero(), "ne")?
+                                    self.builder.build_int_compare(
+                                        IntPredicate::EQ,
+                                        cmp,
+                                        i64_t.const_zero(),
+                                        "ne",
+                                    )?
                                 };
                                 Ok(self.builder.build_int_z_extend(res, i64_t, "bool")?.into())
                             } else {
-                                let pred = if operator.kind == TokenKind::EqEq { IntPredicate::EQ } else { IntPredicate::NE }; 
-                                let cmp = self.builder.build_int_compare(pred, lp, rp, "ptrcmp")?; 
-                                Ok(self.builder.build_int_z_extend(cmp, i64_t, "bool")?.into()) 
+                                let pred = if operator.kind == TokenKind::EqEq {
+                                    IntPredicate::EQ
+                                } else {
+                                    IntPredicate::NE
+                                };
+                                let cmp = self.builder.build_int_compare(pred, lp, rp, "ptrcmp")?;
+                                Ok(self.builder.build_int_z_extend(cmp, i64_t, "bool")?.into())
                             }
-                        }, 
-                        TokenKind::Plus if lhs.is_pointer_value() && rhs.is_pointer_value() => { 
-                            let fnc = self.module.get_function("aion_str_concat").ok_or_else(|| CompileError::Internal("aion_str_concat not found".to_string()))?; 
-                            let call = self.builder.build_call(fnc, &[lp.into(), rp.into()], "strconcat")?; 
-                            Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() }) 
-                        },
-                        TokenKind::Plus if lhs.is_pointer_value() && rhs.is_int_value() => { 
-                            let c2s = self.module.get_function("aion_char_to_str").ok_or_else(|| CompileError::Internal("aion_char_to_str not found".to_string()))?; 
-                            let s2 = self.builder.build_call(c2s, &[rhs.into()], "char2str")?.try_as_basic_value().unwrap_basic(); 
-                            let fnc = self.module.get_function("aion_str_concat").ok_or_else(|| CompileError::Internal("aion_str_concat not found".to_string()))?; 
-                            let call = self.builder.build_call(fnc, &[lp.into(), s2.into()], "strconcat")?; 
-                            Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() }) 
-                        }, 
-                        _ => Err(CompileError::Internal(format!("Mixed operator {:?} not supported", operator.kind))),
+                        }
+                        TokenKind::Plus if lhs.is_pointer_value() && rhs.is_pointer_value() => {
+                            let fnc =
+                                self.module.get_function("aion_str_concat").ok_or_else(|| {
+                                    CompileError::internal("aion_str_concat not found".to_string())
+                                })?;
+                            let call = self.builder.build_call(
+                                fnc,
+                                &[lp.into(), rp.into()],
+                                "strconcat",
+                            )?;
+                            Ok(match call.try_as_basic_value() {
+                                ValueKind::Basic(v) => v,
+                                _ => i64_t.const_zero().into(),
+                            })
+                        }
+                        TokenKind::Plus if lhs.is_pointer_value() && rhs.is_int_value() => {
+                            let c2s =
+                                self.module
+                                    .get_function("aion_char_to_str")
+                                    .ok_or_else(|| {
+                                        CompileError::internal(
+                                            "aion_char_to_str not found".to_string(),
+                                        )
+                                    })?;
+                            let s2 = self
+                                .builder
+                                .build_call(c2s, &[rhs.into()], "char2str")?
+                                .try_as_basic_value()
+                                .unwrap_basic();
+                            let fnc =
+                                self.module.get_function("aion_str_concat").ok_or_else(|| {
+                                    CompileError::internal("aion_str_concat not found".to_string())
+                                })?;
+                            let call = self.builder.build_call(
+                                fnc,
+                                &[lp.into(), s2.into()],
+                                "strconcat",
+                            )?;
+                            Ok(match call.try_as_basic_value() {
+                                ValueKind::Basic(v) => v,
+                                _ => i64_t.const_zero().into(),
+                            })
+                        }
+                        _ => Err(CompileError::internal(format!(
+                            "Mixed operator {:?} not supported",
+                            operator.kind
+                        ))),
                     }
-                } else { Err(CompileError::Internal("Type mismatch".to_string())) }
-            },
+                } else {
+                    Err(CompileError::internal("Type mismatch".to_string()))
+                }
+            }
             Expression::StructInst { name, fields, .. } => {
-                let sn = self.resolve_fuzzy_name(&self.struct_types, name).ok_or_else(|| CompileError::Internal(format!("Struct type '{}' not found in StructInst", name)))?; 
-                let st = *self.struct_types.get(&sn).ok_or_else(|| CompileError::Internal(format!("LLVM struct type '{}' not found", sn)))?; 
-                let fm = self.struct_fields.get(&sn).ok_or_else(|| CompileError::Internal(format!("Fields for struct '{}' not found", sn)))?.clone();
-                let mfn = self.module.get_function("aion_malloc").ok_or_else(|| CompileError::Internal("aion_malloc not found".to_string()))?; 
-                let pr = self.builder.build_call(mfn, &[st.size_of().ok_or_else(|| CompileError::Internal("Struct size unknown".to_string()))?.into()], "struct_alloc")?.try_as_basic_value();
-                let ptr = match pr { ValueKind::Basic(v) => v.into_pointer_value(), _ => return Err(CompileError::Internal("malloc failed".to_string())) };
-                for (fnm, fe) in fields { 
-                    let val = self.compile_expr(fe, variables, function)?; 
-                    let idx = *fm.get(fnm).ok_or_else(|| CompileError::Internal(format!("Field '{}' not found in struct '{}'", fnm, sn)))?; 
-                    self.builder.build_store(self.builder.build_struct_gep(st, ptr, idx, fnm)?, val)?; 
+                let sn = self
+                    .resolve_fuzzy_name(&self.struct_types, name)
+                    .ok_or_else(|| {
+                        CompileError::internal(format!(
+                            "Struct type '{}' not found in StructInst",
+                            name
+                        ))
+                    })?;
+                let st = *self.struct_types.get(&sn).ok_or_else(|| {
+                    CompileError::internal(format!("LLVM struct type '{}' not found", sn))
+                })?;
+                let fm = self
+                    .struct_fields
+                    .get(&sn)
+                    .ok_or_else(|| {
+                        CompileError::internal(format!("Fields for struct '{}' not found", sn))
+                    })?
+                    .clone();
+                let mfn = self
+                    .module
+                    .get_function("aion_malloc")
+                    .ok_or_else(|| CompileError::internal("aion_malloc not found".to_string()))?;
+                let pr = self
+                    .builder
+                    .build_call(
+                        mfn,
+                        &[st.size_of()
+                            .ok_or_else(|| {
+                                CompileError::internal("Struct size unknown".to_string())
+                            })?
+                            .into()],
+                        "struct_alloc",
+                    )?
+                    .try_as_basic_value();
+                let ptr = match pr {
+                    ValueKind::Basic(v) => v.into_pointer_value(),
+                    _ => return Err(CompileError::internal("malloc failed".to_string())),
+                };
+                for (fnm, fe) in fields {
+                    let val = self.compile_expr(fe, variables, function)?;
+                    let idx = *fm.get(fnm).ok_or_else(|| {
+                        CompileError::internal(format!(
+                            "Field '{}' not found in struct '{}'",
+                            fnm, sn
+                        ))
+                    })?;
+                    self.builder
+                        .build_store(self.builder.build_struct_gep(st, ptr, idx, fnm)?, val)?;
                 }
                 Ok(ptr.into())
-            },
-            Expression::EnumInst { name, variant, arguments, generic_args, .. } => {
+            }
+            Expression::EnumInst {
+                name,
+                variant,
+                arguments,
+                generic_args,
+                ..
+            } => {
                 if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, name) {
-                    let et = *self.enum_types.get(&en).ok_or_else(|| CompileError::Internal(format!("Enum type '{}' not found", en)))?;
-                    let pr = match self.builder.build_call(self.module.get_function("aion_malloc").ok_or_else(|| CompileError::Internal("aion_malloc not found".to_string()))?, &[et.size_of().ok_or_else(|| CompileError::Internal("Enum size unknown".to_string()))?.into()], "enum_alloc")?.try_as_basic_value() { 
-                        ValueKind::Basic(v) => v.into_pointer_value(), 
-                        _ => return Err(CompileError::Internal("malloc failed".to_string())) 
+                    let et = *self.enum_types.get(&en).ok_or_else(|| {
+                        CompileError::internal(format!("Enum type '{}' not found", en))
+                    })?;
+                    let pr = match self
+                        .builder
+                        .build_call(
+                            self.module.get_function("aion_malloc").ok_or_else(|| {
+                                CompileError::internal("aion_malloc not found".to_string())
+                            })?,
+                            &[et.size_of()
+                                .ok_or_else(|| {
+                                    CompileError::internal("Enum size unknown".to_string())
+                                })?
+                                .into()],
+                            "enum_alloc",
+                        )?
+                        .try_as_basic_value()
+                    {
+                        ValueKind::Basic(v) => v.into_pointer_value(),
+                        _ => return Err(CompileError::internal("malloc failed".to_string())),
                     };
-                    let mut tv = 0; 
-                    if let Some(Declaration::Enum(e_decl)) = self.decls.get(&en) { 
-                        for (idx, v) in e_decl.variants.iter().enumerate() { 
-                            if v.name == *variant { tv = idx as u64; break; } 
-                        } 
+                    let mut tv = 0;
+                    if let Some(Declaration::Enum(e_decl)) = self.decls.get(&en) {
+                        for (idx, v) in e_decl.variants.iter().enumerate() {
+                            if v.name == *variant {
+                                tv = idx as u64;
+                                break;
+                            }
+                        }
                     }
-                    self.builder.build_store(self.builder.build_struct_gep(et, pr, 0, "tag")?, i64_t.const_int(tv, false))?;
-                    if !arguments.is_empty() { 
-                        let val = self.compile_expr(&arguments[0], variables, function)?; 
-                        let cp = self.builder.build_bit_cast(self.builder.build_struct_gep(et, pr, 1, "data")?, pt, "datacast")?; 
-                        self.builder.build_store(cp.into_pointer_value(), val)?; 
+                    self.builder.build_store(
+                        self.builder.build_struct_gep(et, pr, 0, "tag")?,
+                        i64_t.const_int(tv, false),
+                    )?;
+                    if !arguments.is_empty() {
+                        let val = self.compile_expr(&arguments[0], variables, function)?;
+                        let cp = self.builder.build_bit_cast(
+                            self.builder.build_struct_gep(et, pr, 1, "data")?,
+                            pt,
+                            "datacast",
+                        )?;
+                        self.builder.build_store(cp.into_pointer_value(), val)?;
                     }
                     Ok(pr.into())
                 } else {
-                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), span: Span::zero() };
+                    let call_expr = Expression::Call {
+                        function: format!("{}.{}", name, variant),
+                        generic_args: generic_args.clone(),
+                        arguments: arguments.clone(),
+                        span: Span::zero(),
+                    };
                     self.compile_expr(&call_expr, variables, function)
                 }
-            },
+            }
             Expression::MemberAccess { .. } => {
-                let (rp, rt_llvm) = self.compile_lvalue(e, variables, function)?; 
+                let (rp, rt_llvm) = self.compile_lvalue(e, variables, function)?;
                 Ok(self.builder.build_load(rt_llvm, rp, "load_member")?)
-            },
-            Expression::MethodCall { receiver, method, generic_args, arguments, .. } => {
+            }
+            Expression::MethodCall {
+                receiver,
+                method,
+                generic_args,
+                arguments,
+                ..
+            } => {
                 let rtn = self.get_expr_type_name(receiver, variables);
-                if method == "offset" && rtn.starts_with('*') { 
-                    let p = self.compile_expr(receiver, variables, function)?.into_pointer_value(); 
-                    let o = self.compile_expr(&arguments[0], variables, function)?.into_int_value(); 
-                    return Ok(unsafe { self.builder.build_gep(self.aion_type_to_llvm(&rtn[1..]), p, &[o], "offset_ptr")? }.into()); 
+                if method == "offset" && rtn.starts_with('*') {
+                    let p = self
+                        .compile_expr(receiver, variables, function)?
+                        .into_pointer_value();
+                    let o = self
+                        .compile_expr(&arguments[0], variables, function)?
+                        .into_int_value();
+                    return Ok(unsafe {
+                        self.builder.build_gep(
+                            self.aion_type_to_llvm(&rtn[1..]),
+                            p,
+                            &[o],
+                            "offset_ptr",
+                        )?
+                    }
+                    .into());
                 }
-                let (btn, tga) = if rtn.contains('<') { 
-                    let p: Vec<&str> = rtn.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect(); 
-                    (p[0].to_string(), p[1..].iter().map(|s| s.trim().to_string()).collect()) 
-                } else { (rtn.clone(), vec![]) };
-                let mut bc = btn.as_str(); while bc.starts_with('*') { bc = &bc[1..]; }
-                let tp = self.resolve_fuzzy_name(&self.struct_types, bc).or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc)).unwrap_or(btn.clone()); 
-                let fm = self.resolve_fuzzy_name(&self.decls, &format!("{}::{}", tp, method))
+                let (btn, tga) = if rtn.contains('<') {
+                    let p: Vec<&str> = rtn
+                        .split(['<', '>', ','])
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    (
+                        p[0].to_string(),
+                        p[1..].iter().map(|s| s.trim().to_string()).collect(),
+                    )
+                } else {
+                    (rtn.clone(), vec![])
+                };
+                let mut bc = btn.as_str();
+                while bc.starts_with('*') {
+                    bc = &bc[1..];
+                }
+                let tp = self
+                    .resolve_fuzzy_name(&self.struct_types, bc)
+                    .or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc))
+                    .unwrap_or(btn.clone());
+                let fm = self
+                    .resolve_fuzzy_name(&self.decls, &format!("{}::{}", tp, method))
                     .or_else(|| self.resolve_fuzzy_name(&self.decls, &format!("{}.{}", tp, method)))
                     .unwrap_or(format!("{}.{}", tp, method));
-                let mut cg = tga; cg.extend(generic_args.clone());
-                let fv = if !cg.is_empty() { 
-                    let gn = format!("{}_{}", fm, cg.join("_")); 
-                    if let Some(e) = self.module.get_function(&gn) { e } else { self.instantiate_function(&fm, &cg)? } 
-                } else { 
-                    self.module.get_function(&fm).ok_or_else(|| CompileError::Internal(format!("Method '{}' not found", fm)))? 
+                let mut cg = tga;
+                cg.extend(generic_args.clone());
+                let fv = if !cg.is_empty() {
+                    let gn = format!("{}_{}", fm, cg.join("_"));
+                    if let Some(e) = self.module.get_function(&gn) {
+                        e
+                    } else {
+                        self.instantiate_function(&fm, &cg)?
+                    }
+                } else {
+                    self.module.get_function(&fm).ok_or_else(|| {
+                        CompileError::internal(format!("Method '{}' not found", fm))
+                    })?
                 };
-                let mut ca = Vec::new(); 
+                let mut ca = Vec::new();
                 let has_self = self.decls.get(&fm).map_or(false, |d| {
-                    if let Declaration::Function(fd) = d { fd.params.first().map_or(false, |(n, _, _)| n == "self") } else { false }
+                    if let Declaration::Function(fd) = d {
+                        fd.params.first().map_or(false, |(n, _, _)| n == "self")
+                    } else {
+                        false
+                    }
                 });
                 if has_self {
                     let rv = self.compile_expr(receiver, variables, function)?;
-                    ca.push(rv.into()); 
+                    ca.push(rv.into());
                 }
-                for arg in arguments { 
+                for arg in arguments {
                     let compiled = self.compile_expr(arg, variables, function)?;
                     // Auto-convert i64 to string for io.println/io.print
                     if fm == "io.println" || fm == "io.print" {
                         if compiled.is_int_value() {
-                            let conv_fn = self.module.get_function("aion_int_to_str").ok_or_else(|| CompileError::Internal("aion_int_to_str not found".to_string()))?;
-                            let converted = self.builder.build_call(conv_fn, &[compiled.into()], "to_str")?.try_as_basic_value().unwrap_basic();
+                            let conv_fn =
+                                self.module.get_function("aion_int_to_str").ok_or_else(|| {
+                                    CompileError::internal("aion_int_to_str not found".to_string())
+                                })?;
+                            let converted = self
+                                .builder
+                                .build_call(conv_fn, &[compiled.into()], "to_str")?
+                                .try_as_basic_value()
+                                .unwrap_basic();
                             ca.push(converted.into());
                         } else {
                             ca.push(compiled.into());
@@ -1175,9 +2286,12 @@ impl<'ctx> Compiler<'ctx> {
                         ca.push(compiled.into());
                     }
                 }
-                let call = self.builder.build_call(fv, &ca, "call")?; 
-                Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
-            },
+                let call = self.builder.build_call(fv, &ca, "call")?;
+                Ok(match call.try_as_basic_value() {
+                    ValueKind::Basic(v) => v,
+                    _ => i64_t.const_zero().into(),
+                })
+            }
             Expression::Cast { target, expr, .. } => {
                 let v = self.compile_expr(expr, variables, function)?;
                 let t_clean = target.replace(" ", "");
@@ -1185,93 +2299,159 @@ impl<'ctx> Compiler<'ctx> {
                 if v.is_int_value() && dest.is_int_type() {
                     let sw = v.into_int_value().get_type().get_bit_width();
                     let dw = dest.into_int_type().get_bit_width();
-                    if sw < dw { Ok(self.builder.build_int_z_extend(v.into_int_value(), dest.into_int_type(), "ext")?.into()) }
-                    else if sw > dw { Ok(self.builder.build_int_truncate(v.into_int_value(), dest.into_int_type(), "trunc")?.into()) }
-                    else { Ok(v) }
+                    if sw < dw {
+                        Ok(self
+                            .builder
+                            .build_int_z_extend(v.into_int_value(), dest.into_int_type(), "ext")?
+                            .into())
+                    } else if sw > dw {
+                        Ok(self
+                            .builder
+                            .build_int_truncate(v.into_int_value(), dest.into_int_type(), "trunc")?
+                            .into())
+                    } else {
+                        Ok(v)
+                    }
                 } else if v.is_pointer_value() && dest.is_int_type() {
-                    Ok(self.builder.build_ptr_to_int(v.into_pointer_value(), dest.into_int_type(), "p2i")?.into())
+                    Ok(self
+                        .builder
+                        .build_ptr_to_int(v.into_pointer_value(), dest.into_int_type(), "p2i")?
+                        .into())
                 } else if v.is_int_value() && dest.is_pointer_type() {
-                    Ok(self.builder.build_int_to_ptr(v.into_int_value(), dest.into_pointer_type(), "i2p")?.into())
+                    Ok(self
+                        .builder
+                        .build_int_to_ptr(v.into_int_value(), dest.into_pointer_type(), "i2p")?
+                        .into())
                 } else if v.get_type() == dest {
                     Ok(v)
                 } else {
                     Ok(self.builder.build_bit_cast(v, dest, "cast")?)
                 }
-            },
-            Expression::Deref { expr, .. } => { 
-                let v = self.compile_expr(expr, variables, function)?; 
-                let tn = self.get_expr_type_name(expr, variables); 
-                let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" }); 
-                let p = if v.is_int_value() { self.builder.build_int_to_ptr(v.into_int_value(), pt, "i2p")? } else { v.into_pointer_value() }; 
-                Ok(self.builder.build_load(et, p, "deref")?) 
-            },
-            Expression::If { condition, then_branch, else_branch, .. } => {
-                let cv = self.compile_expr(condition, variables, function)?.into_int_value(); 
-                let comp = self.builder.build_int_compare(IntPredicate::NE, cv, i64_t.const_int(0, false), "ifcond")?;
-                let tb = self.context.append_basic_block(function, "then"); 
-                let eb = self.context.append_basic_block(function, "else"); 
+            }
+            Expression::Deref { expr, .. } => {
+                let v = self.compile_expr(expr, variables, function)?;
+                let tn = self.get_expr_type_name(expr, variables);
+                let et = self.aion_type_to_llvm(if tn.starts_with('*') { &tn[1..] } else { "i64" });
+                let p = if v.is_int_value() {
+                    self.builder
+                        .build_int_to_ptr(v.into_int_value(), pt, "i2p")?
+                } else {
+                    v.into_pointer_value()
+                };
+                Ok(self.builder.build_load(et, p, "deref")?)
+            }
+            Expression::If {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                let cv = self
+                    .compile_expr(condition, variables, function)?
+                    .into_int_value();
+                let comp = self.builder.build_int_compare(
+                    IntPredicate::NE,
+                    cv,
+                    i64_t.const_int(0, false),
+                    "ifcond",
+                )?;
+                let tb = self.context.append_basic_block(function, "then");
+                let eb = self.context.append_basic_block(function, "else");
                 let mb = self.context.append_basic_block(function, "ifcont");
-                self.builder.build_conditional_branch(comp, tb, eb)?; 
+                self.builder.build_conditional_branch(comp, tb, eb)?;
                 let mut phis = Vec::new();
-                
-                self.builder.position_at_end(tb); 
-                let mut tv = variables.clone(); 
-                let tr = self.compile_block(then_branch, &mut tv, function)?; 
-                let tf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                if tf.get_terminator().is_none() { 
-                    let v = tr.unwrap_or(i64_t.const_zero().into()); 
-                    phis.push((v, tf)); 
+
+                self.builder.position_at_end(tb);
+                let mut tv = variables.clone();
+                let tr = self.compile_block(then_branch, &mut tv, function)?;
+                let tf = self
+                    .builder
+                    .get_insert_block()
+                    .ok_or_else(|| CompileError::internal("No active insert block".to_string()))?;
+                if tf.get_terminator().is_none() {
+                    let v = tr.unwrap_or(i64_t.const_zero().into());
+                    phis.push((v, tf));
                 }
-                
-                self.builder.position_at_end(eb); 
-                let mut ev = variables.clone(); 
-                let er = if let Some(e) = else_branch { self.compile_block(e, &mut ev, function)? } else { None }; 
-                let ef = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?; 
-                if ef.get_terminator().is_none() { 
-                    let v = er.unwrap_or(i64_t.const_zero().into()); 
-                    phis.push((v, ef)); 
+
+                self.builder.position_at_end(eb);
+                let mut ev = variables.clone();
+                let er = if let Some(e) = else_branch {
+                    self.compile_block(e, &mut ev, function)?
+                } else {
+                    None
+                };
+                let ef = self
+                    .builder
+                    .get_insert_block()
+                    .ok_or_else(|| CompileError::internal("No active insert block".to_string()))?;
+                if ef.get_terminator().is_none() {
+                    let v = er.unwrap_or(i64_t.const_zero().into());
+                    phis.push((v, ef));
                 }
-                
+
                 self.builder.position_at_end(mb);
                 if !phis.is_empty() {
-                    let target_type = phis[0].0.get_type(); 
+                    let target_type = phis[0].0.get_type();
                     let mut final_phis = Vec::new();
                     for (mut v, b) in phis {
                         self.builder.position_at_end(b);
                         if v.get_type() != target_type {
-                            if target_type.is_pointer_type() && v.is_int_value() { 
-                                v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?.into(); 
-                            } else if target_type.is_int_type() && v.is_pointer_value() { 
-                                v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?.into(); 
+                            if target_type.is_pointer_type() && v.is_int_value() {
+                                v = self
+                                    .builder
+                                    .build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?
+                                    .into();
+                            } else if target_type.is_int_type() && v.is_pointer_value() {
+                                v = self
+                                    .builder
+                                    .build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?
+                                    .into();
                             }
                         }
                         self.builder.build_unconditional_branch(mb)?;
                         final_phis.push((v, b));
                     }
                     self.builder.position_at_end(mb);
-                    let phi = self.builder.build_phi(target_type, "ifres")?; 
-                    for (v, b) in final_phis { phi.add_incoming(&[(&v, b)]); } 
+                    let phi = self.builder.build_phi(target_type, "ifres")?;
+                    for (v, b) in final_phis {
+                        phi.add_incoming(&[(&v, b)]);
+                    }
                     Ok(phi.as_basic_value())
-                } else { 
-                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() { 
-                        self.builder.build_unconditional_branch(mb)?; 
-                    } 
+                } else {
+                    if self
+                        .builder
+                        .get_insert_block()
+                        .ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?
+                        .get_terminator()
+                        .is_none()
+                    {
+                        self.builder.build_unconditional_branch(mb)?;
+                    }
                     self.builder.position_at_end(mb);
                     Ok(i64_t.const_zero().into())
                 }
-            },
-            Expression::Block { statements, .. } => { 
-                let mut lv_vars = variables.clone(); 
-                Ok(self.compile_block(statements, &mut lv_vars, function)?.unwrap_or(i64_t.const_zero().into())) 
-            },
-            Expression::Intrinsic { name, arguments, .. } => {
-                let mut an = name.clone(); 
-                let mut aa = arguments.clone(); 
-                if name == "intrinsic" && !arguments.is_empty() { 
-                    if let Expression::String(s, _) = &arguments[0] { an = s.clone(); aa.remove(0); } 
+            }
+            Expression::Block { statements, .. } => {
+                let mut lv_vars = variables.clone();
+                Ok(self
+                    .compile_block(statements, &mut lv_vars, function)?
+                    .unwrap_or(i64_t.const_zero().into()))
+            }
+            Expression::Intrinsic {
+                name, arguments, ..
+            } => {
+                let mut an = name.clone();
+                let mut aa = arguments.clone();
+                if name == "intrinsic" && !arguments.is_empty() {
+                    if let Expression::String(s, _) = &arguments[0] {
+                        an = s.clone();
+                        aa.remove(0);
+                    }
                 }
-                if an == "sizeof" && !aa.is_empty() { 
-                    let tnm = match &aa[0] { 
+                if an == "sizeof" && !aa.is_empty() {
+                    let tnm = match &aa[0] {
                         Expression::Identifier(s, _) => {
                             // First check if it's a variable in the environment
                             if let Some((_, _, vtn)) = variables.get(s) {
@@ -1279,38 +2459,64 @@ impl<'ctx> Compiler<'ctx> {
                             } else {
                                 s.clone()
                             }
-                        },
-                        Expression::TypeRef { name, .. } => name.clone(), 
-                        _ => "i64".to_string() 
-                    }; 
+                        }
+                        Expression::TypeRef { name, .. } => name.clone(),
+                        _ => "i64".to_string(),
+                    };
                     let clean = tnm.replace(" ", "");
-                    let btn = if clean.contains('<') { clean.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))? } else { &clean };
+                    let btn = if clean.contains('<') {
+                        clean.split('<').next().ok_or_else(|| {
+                            CompileError::internal("Invalid type name".to_string())
+                        })?
+                    } else {
+                        &clean
+                    };
                     if let Some(sn) = self.resolve_fuzzy_name(&self.struct_types, btn) {
                         if let Some(st) = self.struct_types.get(&sn) {
-                            return Ok(st.size_of().ok_or_else(|| CompileError::Internal("Struct size unknown".to_string()))?.into());
+                            return Ok(st
+                                .size_of()
+                                .ok_or_else(|| {
+                                    CompileError::internal("Struct size unknown".to_string())
+                                })?
+                                .into());
                         }
                     }
                     if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, btn) {
                         if let Some(et) = self.enum_types.get(&en) {
-                            return Ok(et.size_of().ok_or_else(|| CompileError::Internal("Enum size unknown".to_string()))?.into());
+                            return Ok(et
+                                .size_of()
+                                .ok_or_else(|| {
+                                    CompileError::internal("Enum size unknown".to_string())
+                                })?
+                                .into());
                         }
                     }
                     let lt = self.aion_type_to_llvm(&tnm);
-                    let res = if lt.is_pointer_type() { i64_t.const_int(8, false).into() } 
-                              else { lt.size_of().unwrap_or(i64_t.const_zero()).into() };
+                    let res = if lt.is_pointer_type() {
+                        i64_t.const_int(8, false).into()
+                    } else {
+                        lt.size_of().unwrap_or(i64_t.const_zero()).into()
+                    };
                     return Ok(res);
                 }
                 if an == "mem_is_null" && !aa.is_empty() {
-                    let ptr = self.compile_expr(&aa[0], variables, function)?.into_pointer_value();
-                    let cmp = self.builder.build_int_compare(IntPredicate::EQ, self.builder.build_ptr_to_int(ptr, i64_t, "p2i")?, i64_t.const_zero(), "isnull")?;
+                    let ptr = self
+                        .compile_expr(&aa[0], variables, function)?
+                        .into_pointer_value();
+                    let cmp = self.builder.build_int_compare(
+                        IntPredicate::EQ,
+                        self.builder.build_ptr_to_int(ptr, i64_t, "p2i")?,
+                        i64_t.const_zero(),
+                        "isnull",
+                    )?;
                     return Ok(self.builder.build_int_z_extend(cmp, i64_t, "zext")?.into());
                 }
                 if an == "mem_zero" {
                     if !aa.is_empty() {
-                        let tnm = match &aa[0] { 
-                            Expression::Identifier(s, _) => s.clone(), 
-                            Expression::TypeRef { name, .. } => name.clone(), 
-                            _ => "i64".to_string() 
+                        let tnm = match &aa[0] {
+                            Expression::Identifier(s, _) => s.clone(),
+                            Expression::TypeRef { name, .. } => name.clone(),
+                            _ => "i64".to_string(),
                         };
                         if let Some(sn) = self.resolve_fuzzy_name(&self.struct_types, &tnm) {
                             if let Some(&st) = self.struct_types.get(&sn) {
@@ -1318,11 +2524,24 @@ impl<'ctx> Compiler<'ctx> {
                                 // the StructInst convention (heap-alloc + opaque ptr). Returning an
                                 // inline struct value here would break (*p).field after *p = mem_zero(T)
                                 // — the Deref+MemberAccess path assumes the slot holds a box pointer.
-                                let size = st.size_of().ok_or_else(|| CompileError::Internal("Struct size unknown".to_string()))?;
-                                let malloc_fn = self.module.get_function("aion_malloc").ok_or_else(|| CompileError::Internal("aion_malloc not found".to_string()))?;
-                                let box_ptr = match self.builder.build_call(malloc_fn, &[size.into()], "memzero_box")?.try_as_basic_value() {
+                                let size = st.size_of().ok_or_else(|| {
+                                    CompileError::internal("Struct size unknown".to_string())
+                                })?;
+                                let malloc_fn =
+                                    self.module.get_function("aion_malloc").ok_or_else(|| {
+                                        CompileError::internal("aion_malloc not found".to_string())
+                                    })?;
+                                let box_ptr = match self
+                                    .builder
+                                    .build_call(malloc_fn, &[size.into()], "memzero_box")?
+                                    .try_as_basic_value()
+                                {
                                     ValueKind::Basic(v) => v.into_pointer_value(),
-                                    _ => return Err(CompileError::Internal("aion_malloc did not return a value".to_string())),
+                                    _ => {
+                                        return Err(CompileError::internal(
+                                            "aion_malloc did not return a value".to_string(),
+                                        ));
+                                    }
                                 };
                                 self.builder.build_store(box_ptr, st.const_zero())?;
                                 return Ok(box_ptr.into());
@@ -1330,86 +2549,177 @@ impl<'ctx> Compiler<'ctx> {
                         }
                         if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, &tnm) {
                             if let Some(&et) = self.enum_types.get(&en) {
-                                let size = et.size_of().ok_or_else(|| CompileError::Internal("Enum size unknown".to_string()))?;
-                                let malloc_fn = self.module.get_function("aion_malloc").ok_or_else(|| CompileError::Internal("aion_malloc not found".to_string()))?;
-                                let box_ptr = match self.builder.build_call(malloc_fn, &[size.into()], "memzero_box")?.try_as_basic_value() {
+                                let size = et.size_of().ok_or_else(|| {
+                                    CompileError::internal("Enum size unknown".to_string())
+                                })?;
+                                let malloc_fn =
+                                    self.module.get_function("aion_malloc").ok_or_else(|| {
+                                        CompileError::internal("aion_malloc not found".to_string())
+                                    })?;
+                                let box_ptr = match self
+                                    .builder
+                                    .build_call(malloc_fn, &[size.into()], "memzero_box")?
+                                    .try_as_basic_value()
+                                {
                                     ValueKind::Basic(v) => v.into_pointer_value(),
-                                    _ => return Err(CompileError::Internal("aion_malloc did not return a value".to_string())),
+                                    _ => {
+                                        return Err(CompileError::internal(
+                                            "aion_malloc did not return a value".to_string(),
+                                        ));
+                                    }
                                 };
                                 self.builder.build_store(box_ptr, et.const_zero())?;
                                 return Ok(box_ptr.into());
                             }
                         }
                         let lt = self.aion_type_to_llvm(&tnm);
-                        if lt.is_pointer_type() { return Ok(lt.into_pointer_type().const_null().into()); }
-                        if lt.is_int_type() { return Ok(lt.into_int_type().const_zero().into()); }
-                        if lt.is_float_type() { return Ok(lt.into_float_type().const_zero().into()); }
+                        if lt.is_pointer_type() {
+                            return Ok(lt.into_pointer_type().const_null().into());
+                        }
+                        if lt.is_int_type() {
+                            return Ok(lt.into_int_type().const_zero().into());
+                        }
+                        if lt.is_float_type() {
+                            return Ok(lt.into_float_type().const_zero().into());
+                        }
                     }
                     return Ok(pt.const_null().into());
                 }
                 if an == "mem_zero_ptr" && aa.len() >= 2 {
-                    let ptr = self.compile_expr(&aa[0], variables, function)?.into_pointer_value();
-                    let size = self.compile_expr(&aa[1], variables, function)?.into_int_value();
-                    let fnc = self.module.get_function("aion_memzero").ok_or_else(|| CompileError::Internal("aion_memzero not found".to_string()))?;
-                    self.builder.build_call(fnc, &[ptr.into(), size.into()], "memzero")?;
+                    let ptr = self
+                        .compile_expr(&aa[0], variables, function)?
+                        .into_pointer_value();
+                    let size = self
+                        .compile_expr(&aa[1], variables, function)?
+                        .into_int_value();
+                    let fnc = self.module.get_function("aion_memzero").ok_or_else(|| {
+                        CompileError::internal("aion_memzero not found".to_string())
+                    })?;
+                    self.builder
+                        .build_call(fnc, &[ptr.into(), size.into()], "memzero")?;
                     return Ok(i64_t.const_zero().into());
                 }
-                let lnm = match an.as_str() { "str_len" => "strlen".to_string(), "str_ptr" => return Ok(self.compile_expr(&aa[0], variables, function)?), "fs_read_to_string" => "aion_read_file".to_string(), "fs_write" => "aion_write_file".to_string(), "fs_append" => "aion_append_file".to_string(), "exit" => "exit".to_string(), _ if an.starts_with("libc.") => an.replace("libc.", ""), _ => format!("aion_{}", an) };
-                let fv = self.module.get_function(&lnm).ok_or_else(|| CompileError::Internal(format!("Intrinsic '{}' not found", lnm)))?; 
-                let mut cargs = Vec::new(); 
-                for arg in aa { cargs.push(self.compile_expr(&arg, variables, function)?.into()); }
-                let call = self.builder.build_call(fv, &cargs, "intrinsic_call")?; 
-                Ok(match call.try_as_basic_value() { ValueKind::Basic(v) => v, _ => i64_t.const_zero().into() })
-            },
-            Expression::Match { condition, arms, .. } => {
+                let lnm = match an.as_str() {
+                    "str_len" => "strlen".to_string(),
+                    "str_ptr" => return Ok(self.compile_expr(&aa[0], variables, function)?),
+                    "fs_read_to_string" => "aion_read_file".to_string(),
+                    "fs_write" => "aion_write_file".to_string(),
+                    "fs_append" => "aion_append_file".to_string(),
+                    "exit" => "exit".to_string(),
+                    _ if an.starts_with("libc.") => an.replace("libc.", ""),
+                    _ => format!("aion_{}", an),
+                };
+                let fv = self.module.get_function(&lnm).ok_or_else(|| {
+                    CompileError::internal(format!("Intrinsic '{}' not found", lnm))
+                })?;
+                let mut cargs = Vec::new();
+                for arg in aa {
+                    cargs.push(self.compile_expr(&arg, variables, function)?.into());
+                }
+                let call = self.builder.build_call(fv, &cargs, "intrinsic_call")?;
+                Ok(match call.try_as_basic_value() {
+                    ValueKind::Basic(v) => v,
+                    _ => i64_t.const_zero().into(),
+                })
+            }
+            Expression::Match {
+                condition, arms, ..
+            } => {
                 let cv = self.compile_expr(condition, variables, function)?;
                 let exit_bb = self.context.append_basic_block(function, "match_expr_exit");
                 let mut phis = Vec::new();
                 let ctn = self.get_expr_type_name(condition, variables);
-                let cbn = if ctn.contains('<') { ctn.split('<').next().ok_or_else(|| CompileError::Internal("Invalid type name".to_string()))?.to_string() } else { ctn.clone() };
-                let fen = self.resolve_fuzzy_name(&self.enum_types, &cbn).unwrap_or(cbn.clone());
-                
+                let cbn = if ctn.contains('<') {
+                    ctn.split('<')
+                        .next()
+                        .ok_or_else(|| CompileError::internal("Invalid type name".to_string()))?
+                        .to_string()
+                } else {
+                    ctn.clone()
+                };
+                let fen = self
+                    .resolve_fuzzy_name(&self.enum_types, &cbn)
+                    .unwrap_or(cbn.clone());
+
                 if let Some(et_ref) = self.enum_types.get(&fen) {
                     let et = *et_ref;
                     let ep = cv.into_pointer_value();
-                    let tag = self.builder.build_load(i64_t, self.builder.build_struct_gep(et, ep, 0, "tagptr")?, "tag")?.into_int_value();
+                    let tag = self
+                        .builder
+                        .build_load(
+                            i64_t,
+                            self.builder.build_struct_gep(et, ep, 0, "tagptr")?,
+                            "tag",
+                        )?
+                        .into_int_value();
                     let na = arms.len();
                     for (i, arm) in arms.iter().enumerate() {
-                        let ab = self.context.append_basic_block(function, &format!("match_arm_{}_{}", i, arm.pattern));
+                        let ab = self.context.append_basic_block(
+                            function,
+                            &format!("match_arm_{}_{}", i, arm.pattern),
+                        );
                         let is_last = i == na - 1;
-                        let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_arm_next") };
-                        
+                        let nb = if is_last {
+                            exit_bb
+                        } else {
+                            self.context.append_basic_block(function, "match_arm_next")
+                        };
+
                         let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                             vec![arm.pattern.clone()]
                         } else {
                             arm.patterns.clone()
                         };
-                        
+
                         let is_default = all_patterns.iter().any(|p| p == "_");
                         let mut arm_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
-                        
+
                         if !is_default {
                             if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
                                 for pat in &all_patterns {
                                     let mut at = i as u64;
                                     for (vi, v) in e_decl.variants.iter().enumerate() {
-                                        if pat == &v.name || pat.ends_with(&format!(".{}", v.name)) || pat.ends_with(&format!("::{}", v.name)) {
+                                        if pat == &v.name
+                                            || pat.ends_with(&format!(".{}", v.name))
+                                            || pat.ends_with(&format!("::{}", v.name))
+                                        {
                                             at = vi as u64;
                                             break;
                                         }
                                     }
-                                    if at == i as u64 && (pat == "Some" || pat == "Ok" || pat.ends_with(".Some") || pat.ends_with("::Some")) { at = 0; }
-                                    if at == i as u64 && (pat == "None" || pat == "Err" || pat.ends_with(".None") || pat.ends_with("::None")) { at = 1; }
-                                    
-                                    let cond = self.builder.build_int_compare(IntPredicate::EQ, tag, i64_t.const_int(at, false), "is_arm")?;
+                                    if at == i as u64
+                                        && (pat == "Some"
+                                            || pat == "Ok"
+                                            || pat.ends_with(".Some")
+                                            || pat.ends_with("::Some"))
+                                    {
+                                        at = 0;
+                                    }
+                                    if at == i as u64
+                                        && (pat == "None"
+                                            || pat == "Err"
+                                            || pat.ends_with(".None")
+                                            || pat.ends_with("::None"))
+                                    {
+                                        at = 1;
+                                    }
+
+                                    let cond = self.builder.build_int_compare(
+                                        IntPredicate::EQ,
+                                        tag,
+                                        i64_t.const_int(at, false),
+                                        "is_arm",
+                                    )?;
                                     arm_match_cond = Some(match arm_match_cond {
-                                        Some(prev) => self.builder.build_or(prev, cond, "arm_or")?,
+                                        Some(prev) => {
+                                            self.builder.build_or(prev, cond, "arm_or")?
+                                        }
                                         None => cond,
                                     });
                                 }
                             }
                         }
-                        
+
                         if is_default && arm_match_cond.is_none() {
                             self.builder.build_unconditional_branch(ab)?;
                         } else if let Some(cond) = arm_match_cond {
@@ -1418,7 +2728,9 @@ impl<'ctx> Compiler<'ctx> {
                             self.builder.build_unconditional_branch(nb)?;
                         }
                         if is_last && !is_default {
-                            let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                            let test_bb = self.builder.get_insert_block().ok_or_else(|| {
+                                CompileError::internal("No active insert block".to_string())
+                            })?;
                             phis.push((i64_t.const_zero().into(), test_bb));
                         }
                         self.builder.position_at_end(ab);
@@ -1428,97 +2740,188 @@ impl<'ctx> Compiler<'ctx> {
                             let mut ptn = "i64".to_string();
                             if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
                                 for v in &e_decl.variants {
-                                    if arm.pattern == v.name || arm.pattern.ends_with(&format!(".{}", v.name)) || arm.pattern.ends_with(&format!("::{}", v.name)) {
-                                        if !v.data_types.is_empty() { ptn = v.data_types[0].clone(); }
+                                    if arm.pattern == v.name
+                                        || arm.pattern.ends_with(&format!(".{}", v.name))
+                                        || arm.pattern.ends_with(&format!("::{}", v.name))
+                                    {
+                                        if !v.data_types.is_empty() {
+                                            ptn = v.data_types[0].clone();
+                                        }
                                         break;
                                     }
                                 }
                             }
                             let lt = self.aion_type_to_llvm(&ptn);
-                            let cp = self.builder.build_bit_cast(dp, self.context.ptr_type(AddressSpace::default()), "arm_datacast")?;
-                            let lv_val = self.builder.build_load(lt, cp.into_pointer_value(), &arm.params[0])?;
+                            let cp = self.builder.build_bit_cast(
+                                dp,
+                                self.context.ptr_type(AddressSpace::default()),
+                                "arm_datacast",
+                            )?;
+                            let lv_val = self.builder.build_load(
+                                lt,
+                                cp.into_pointer_value(),
+                                &arm.params[0],
+                            )?;
                             let pa = self.builder.build_alloca(lt, &arm.params[0])?;
                             self.builder.build_store(pa, lv_val)?;
                             av.insert(arm.params[0].clone(), (pa, lt, ptn));
                         }
-                        
+
                         if let Some(guard_expr) = &arm.guard {
-                            let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
-                            let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                            let guard_val = self
+                                .compile_expr(guard_expr, &av, function)?
+                                .into_int_value();
+                            let guard_pass_bb =
+                                self.context.append_basic_block(function, "guard_pass");
                             let guard_fail_bb = nb;
-                            let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
-                            self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                            let guard_cond = self.builder.build_int_compare(
+                                IntPredicate::NE,
+                                guard_val,
+                                i64_t.const_zero(),
+                                "guard_cond",
+                            )?;
+                            self.builder.build_conditional_branch(
+                                guard_cond,
+                                guard_pass_bb,
+                                guard_fail_bb,
+                            )?;
                             self.builder.position_at_end(guard_pass_bb);
                         }
-                        
+
                         let ar = self.compile_block(&arm.body, &mut av, function)?;
-                        let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                        let abf = self.builder.get_insert_block().ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?;
                         if abf.get_terminator().is_none() {
                             let v = ar.unwrap_or(i64_t.const_zero().into());
                             phis.push((v, abf));
                         }
-                        if !is_last { self.builder.position_at_end(nb); }
+                        if !is_last {
+                            self.builder.position_at_end(nb);
+                        }
                     }
                 } else {
                     // Match on primitives (i64, String)
                     let na = arms.len();
                     for (i, arm) in arms.iter().enumerate() {
-                        let pattern_clean = arm.pattern.chars().filter(|c| c.is_alphanumeric()).collect::<String>();
-                        let ab = self.context.append_basic_block(function, &format!("match_arm_{}_{}", i, pattern_clean));
+                        let pattern_clean = arm
+                            .pattern
+                            .chars()
+                            .filter(|c| c.is_alphanumeric())
+                            .collect::<String>();
+                        let ab = self.context.append_basic_block(
+                            function,
+                            &format!("match_arm_{}_{}", i, pattern_clean),
+                        );
                         let is_last = i == na - 1;
-                        let nb = if is_last { exit_bb } else { self.context.append_basic_block(function, "match_arm_next") };
-                        
+                        let nb = if is_last {
+                            exit_bb
+                        } else {
+                            self.context.append_basic_block(function, "match_arm_next")
+                        };
+
                         let all_patterns: Vec<String> = if arm.patterns.is_empty() {
                             vec![arm.pattern.clone()]
                         } else {
                             arm.patterns.clone()
                         };
-                        
+
                         let is_default = all_patterns.iter().any(|p| p == "_");
                         let is_binding_var = arm.params.len() > 0 || arm.guard.is_some();
                         let mut prim_match_cond: Option<inkwell::values::IntValue<'ctx>> = None;
-                        
+
                         if !is_default && !is_binding_var {
                             if ctn == "i64" || ctn == "Integer" {
                                 for pat in &all_patterns {
                                     if let Some((start_str, end_str)) = pat.split_once("..") {
-                                        if let (Ok(start), Ok(end)) = (start_str.parse::<i64>(), end_str.parse::<i64>()) {
+                                        if let (Ok(start), Ok(end)) =
+                                            (start_str.parse::<i64>(), end_str.parse::<i64>())
+                                        {
                                             let cv_val = cv.into_int_value();
-                                            let cond_start = self.builder.build_int_compare(IntPredicate::SGE, cv_val, i64_t.const_int(start as u64, false), "range_start")?;
-                                            let cond_end = self.builder.build_int_compare(IntPredicate::SLE, cv_val, i64_t.const_int(end as u64, false), "range_end")?;
-                                            let range_cond = self.builder.build_and(cond_start, cond_end, "range_cond")?;
+                                            let cond_start = self.builder.build_int_compare(
+                                                IntPredicate::SGE,
+                                                cv_val,
+                                                i64_t.const_int(start as u64, false),
+                                                "range_start",
+                                            )?;
+                                            let cond_end = self.builder.build_int_compare(
+                                                IntPredicate::SLE,
+                                                cv_val,
+                                                i64_t.const_int(end as u64, false),
+                                                "range_end",
+                                            )?;
+                                            let range_cond = self.builder.build_and(
+                                                cond_start,
+                                                cond_end,
+                                                "range_cond",
+                                            )?;
                                             prim_match_cond = Some(match prim_match_cond {
-                                                Some(prev) => self.builder.build_or(prev, range_cond, "range_or")?,
+                                                Some(prev) => self
+                                                    .builder
+                                                    .build_or(prev, range_cond, "range_or")?,
                                                 None => range_cond,
                                             });
                                         }
                                     } else if let Ok(val) = pat.parse::<i64>() {
-                                        let cond = self.builder.build_int_compare(IntPredicate::EQ, cv.into_int_value(), i64_t.const_int(val as u64, false), "match_cond")?;
+                                        let cond = self.builder.build_int_compare(
+                                            IntPredicate::EQ,
+                                            cv.into_int_value(),
+                                            i64_t.const_int(val as u64, false),
+                                            "match_cond",
+                                        )?;
                                         prim_match_cond = Some(match prim_match_cond {
-                                            Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                            Some(prev) => {
+                                                self.builder.build_or(prev, cond, "match_or")?
+                                            }
                                             None => cond,
                                         });
                                     }
                                 }
                             } else if ctn == "String" {
                                 for pat in &all_patterns {
-                                    let pattern_str = if pat.starts_with('"') && pat.ends_with('"') {
-                                        &pat[1..pat.len()-1]
+                                    let pattern_str = if pat.starts_with('"') && pat.ends_with('"')
+                                    {
+                                        &pat[1..pat.len() - 1]
                                     } else {
                                         pat.as_str()
                                     };
-                                    let cmp_fn = self.module.get_function("aion_str_eq").ok_or_else(|| CompileError::Internal("aion_str_eq not found".to_string()))?;
-                                    let pat_global = self.builder.build_global_string_ptr(pattern_str, "match_pat")?;
-                                    let cmp_result = self.builder.build_call(cmp_fn, &[cv.into(), pat_global.as_basic_value_enum().into()], "str_cmp")?.try_as_basic_value().unwrap_basic().into_int_value();
-                                    let cond = self.builder.build_int_compare(IntPredicate::NE, cmp_result, i64_t.const_zero(), "str_match")?;
+                                    let cmp_fn = self
+                                        .module
+                                        .get_function("aion_str_eq")
+                                        .ok_or_else(|| {
+                                            CompileError::internal(
+                                                "aion_str_eq not found".to_string(),
+                                            )
+                                        })?;
+                                    let pat_global = self
+                                        .builder
+                                        .build_global_string_ptr(pattern_str, "match_pat")?;
+                                    let cmp_result = self
+                                        .builder
+                                        .build_call(
+                                            cmp_fn,
+                                            &[cv.into(), pat_global.as_basic_value_enum().into()],
+                                            "str_cmp",
+                                        )?
+                                        .try_as_basic_value()
+                                        .unwrap_basic()
+                                        .into_int_value();
+                                    let cond = self.builder.build_int_compare(
+                                        IntPredicate::NE,
+                                        cmp_result,
+                                        i64_t.const_zero(),
+                                        "str_match",
+                                    )?;
                                     prim_match_cond = Some(match prim_match_cond {
-                                        Some(prev) => self.builder.build_or(prev, cond, "match_or")?,
+                                        Some(prev) => {
+                                            self.builder.build_or(prev, cond, "match_or")?
+                                        }
                                         None => cond,
                                     });
                                 }
                             }
                         }
-                        
+
                         if (is_default || is_binding_var) && prim_match_cond.is_none() {
                             self.builder.build_unconditional_branch(ab)?;
                         } else if let Some(cond) = prim_match_cond {
@@ -1527,7 +2930,9 @@ impl<'ctx> Compiler<'ctx> {
                             self.builder.build_unconditional_branch(nb)?;
                         }
                         if is_last && !is_default && !is_binding_var {
-                            let test_bb = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                            let test_bb = self.builder.get_insert_block().ok_or_else(|| {
+                                CompileError::internal("No active insert block".to_string())
+                            })?;
                             phis.push((i64_t.const_zero().into(), test_bb));
                         }
                         self.builder.position_at_end(ab);
@@ -1538,26 +2943,42 @@ impl<'ctx> Compiler<'ctx> {
                             self.builder.build_store(pa, cv)?;
                             av.insert(arm.params[0].clone(), (pa, lt, ctn.clone()));
                         }
-                        
+
                         if let Some(guard_expr) = &arm.guard {
-                            let guard_val = self.compile_expr(guard_expr, &av, function)?.into_int_value();
-                            let guard_pass_bb = self.context.append_basic_block(function, "guard_pass");
+                            let guard_val = self
+                                .compile_expr(guard_expr, &av, function)?
+                                .into_int_value();
+                            let guard_pass_bb =
+                                self.context.append_basic_block(function, "guard_pass");
                             let guard_fail_bb = nb;
-                            let guard_cond = self.builder.build_int_compare(IntPredicate::NE, guard_val, i64_t.const_zero(), "guard_cond")?;
-                            self.builder.build_conditional_branch(guard_cond, guard_pass_bb, guard_fail_bb)?;
+                            let guard_cond = self.builder.build_int_compare(
+                                IntPredicate::NE,
+                                guard_val,
+                                i64_t.const_zero(),
+                                "guard_cond",
+                            )?;
+                            self.builder.build_conditional_branch(
+                                guard_cond,
+                                guard_pass_bb,
+                                guard_fail_bb,
+                            )?;
                             self.builder.position_at_end(guard_pass_bb);
                         }
-                        
+
                         let ar = self.compile_block(&arm.body, &mut av, function)?;
-                        let abf = self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?;
+                        let abf = self.builder.get_insert_block().ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?;
                         if abf.get_terminator().is_none() {
                             let v = ar.unwrap_or(i64_t.const_zero().into());
                             phis.push((v, abf));
                         }
-                        if !is_last { self.builder.position_at_end(nb); }
+                        if !is_last {
+                            self.builder.position_at_end(nb);
+                        }
                     }
                 }
-                
+
                 self.builder.position_at_end(exit_bb);
                 if !phis.is_empty() {
                     let target_type = phis[0].0.get_type();
@@ -1566,9 +2987,15 @@ impl<'ctx> Compiler<'ctx> {
                         self.builder.position_at_end(b);
                         if v.get_type() != target_type {
                             if target_type.is_pointer_type() && v.is_int_value() {
-                                v = self.builder.build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?.into();
+                                v = self
+                                    .builder
+                                    .build_int_to_ptr(v.into_int_value(), pt, "phi_ptr")?
+                                    .into();
                             } else if target_type.is_int_type() && v.is_pointer_value() {
-                                v = self.builder.build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?.into();
+                                v = self
+                                    .builder
+                                    .build_ptr_to_int(v.into_pointer_value(), i64_t, "phi_int")?
+                                    .into();
                             }
                         }
                         self.builder.build_unconditional_branch(exit_bb)?;
@@ -1576,16 +3003,26 @@ impl<'ctx> Compiler<'ctx> {
                     }
                     self.builder.position_at_end(exit_bb);
                     let phi = self.builder.build_phi(target_type, "match_res")?;
-                    for (v, b) in final_phis { phi.add_incoming(&[(&v, b)]); }
+                    for (v, b) in final_phis {
+                        phi.add_incoming(&[(&v, b)]);
+                    }
                     Ok(phi.as_basic_value())
                 } else {
-                    if self.builder.get_insert_block().ok_or_else(|| CompileError::Internal("No active insert block".to_string()))?.get_terminator().is_none() {
+                    if self
+                        .builder
+                        .get_insert_block()
+                        .ok_or_else(|| {
+                            CompileError::internal("No active insert block".to_string())
+                        })?
+                        .get_terminator()
+                        .is_none()
+                    {
                         self.builder.build_unconditional_branch(exit_bb)?;
                     }
                     self.builder.position_at_end(exit_bb);
                     Ok(i64_t.const_zero().into())
                 }
-            },
+            }
             _ => Ok(i64_t.const_zero().into()),
         }
     }
@@ -1593,12 +3030,27 @@ impl<'ctx> Compiler<'ctx> {
     fn get_field_type(&self, it: &String, fnm: &str) -> String {
         let clean = it.replace(" ", "");
         let mut cs = clean.as_str();
-        while cs.starts_with('*') { cs = &cs[1..]; }
+        while cs.starts_with('*') {
+            cs = &cs[1..];
+        }
         let (btn, tga) = if cs.contains('<') {
-            let p: Vec<&str> = cs.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect();
-            (p[0].to_string(), p[1..].iter().map(|s| s.trim().to_string()).collect::<Vec<String>>())
-        } else { (cs.to_string(), vec![]) };
-        let full = self.resolve_fuzzy_name(&self.struct_types, &btn).unwrap_or(btn);
+            let p: Vec<&str> = cs
+                .split(['<', '>', ','])
+                .filter(|s| !s.is_empty())
+                .collect();
+            (
+                p[0].to_string(),
+                p[1..]
+                    .iter()
+                    .map(|s| s.trim().to_string())
+                    .collect::<Vec<String>>(),
+            )
+        } else {
+            (cs.to_string(), vec![])
+        };
+        let full = self
+            .resolve_fuzzy_name(&self.struct_types, &btn)
+            .unwrap_or(btn);
         if let Some(Declaration::Struct(s)) = self.decls.get(&full) {
             for (f_nm, ft) in &s.fields {
                 if f_nm == fnm {
@@ -1622,7 +3074,9 @@ impl<'ctx> Compiler<'ctx> {
     /// A token containing `.` (a qualified name like `std.foo`) is never
     /// replaced: generic params are always bare identifiers, never dotted paths.
     fn substitute_type_string(s: &str, params: &[String], args: &[String]) -> String {
-        if params.is_empty() || s.is_empty() { return s.to_string(); }
+        if params.is_empty() || s.is_empty() {
+            return s.to_string();
+        }
         let mut out = String::with_capacity(s.len());
         let mut tok = String::new();
         let flush = |tok: &mut String, out: &mut String| {
@@ -1635,7 +3089,9 @@ impl<'ctx> Compiler<'ctx> {
                         break;
                     }
                 }
-                if !replaced { out.push_str(tok); }
+                if !replaced {
+                    out.push_str(tok);
+                }
                 tok.clear();
             }
         };
@@ -1655,80 +3111,198 @@ impl<'ctx> Compiler<'ctx> {
         Self::substitute_type_string(res_type, params, args)
     }
 
-    fn get_expr_type_name(&self, e: &Expression, variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>) -> String {
+    fn get_expr_type_name(
+        &self,
+        e: &Expression,
+        variables: &HashMap<String, (PointerValue<'ctx>, BasicTypeEnum<'ctx>, String)>,
+    ) -> String {
         let res = match e {
-            Expression::Integer(_, _) => "i64".to_string(), 
-            Expression::Float(_, _) => "f64".to_string(), 
-            Expression::Char(_, _) => "i64".to_string(), 
-            Expression::Boolean(_, _) => "bool".to_string(), 
+            Expression::Integer(_, _) => "i64".to_string(),
+            Expression::Float(_, _) => "f64".to_string(),
+            Expression::Char(_, _) => "i64".to_string(),
+            Expression::Boolean(_, _) => "bool".to_string(),
             Expression::String(_, _) => "String".to_string(),
             Expression::Identifier(name, _) => {
                 let parts: Vec<&str> = name.split('.').collect();
                 if parts.len() > 1 {
-                    let mut ct = if let Some((_, _, t)) = variables.get(parts[0]) { t.clone() } else { "unknown".to_string() };
-                    for i in 1..parts.len() { if ct == "unknown" { break; } ct = self.get_field_type(&ct, parts[i]); }
+                    let mut ct = if let Some((_, _, t)) = variables.get(parts[0]) {
+                        t.clone()
+                    } else {
+                        "unknown".to_string()
+                    };
+                    for i in 1..parts.len() {
+                        if ct == "unknown" {
+                            break;
+                        }
+                        ct = self.get_field_type(&ct, parts[i]);
+                    }
                     return ct.replace(" ", "");
                 }
-                if let Some((_, _, t)) = variables.get(name) { t.clone().replace(" ", "") } else { "unknown".to_string() }
-            },
-            Expression::Call { function: name, generic_args, .. } => {
+                if let Some((_, _, t)) = variables.get(name) {
+                    t.clone().replace(" ", "")
+                } else {
+                    "unknown".to_string()
+                }
+            }
+            Expression::Call {
+                function: name,
+                generic_args,
+                ..
+            } => {
                 if let Some((rn, mn)) = name.rsplit_once('.') {
                     if mn == "offset" {
-                        let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string(), Span::zero()), variables);
-                        if rt.starts_with('*') { return rt.replace(" ", ""); }
+                        let rt = self.get_expr_type_name(
+                            &Expression::Identifier(rn.to_string(), Span::zero()),
+                            variables,
+                        );
+                        if rt.starts_with('*') {
+                            return rt.replace(" ", "");
+                        }
                     }
-                    let rt = self.get_expr_type_name(&Expression::Identifier(rn.to_string(), Span::zero()), variables);
+                    let rt = self.get_expr_type_name(
+                        &Expression::Identifier(rn.to_string(), Span::zero()),
+                        variables,
+                    );
                     if rt != "unknown" {
                         let (btn, tga) = if rt.contains('<') {
-                            let p: Vec<&str> = rt.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect();
-                            (p[0].to_string(), p[1..].iter().map(|s| s.trim().to_string()).collect::<Vec<String>>())
-                        } else { (rt.clone(), vec![]) };
-                        let mut bc = btn.as_str(); while bc.starts_with('*') { bc = &bc[1..]; }
-                        let tp = self.resolve_fuzzy_name(&self.struct_types, bc).or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc)).unwrap_or(btn.clone());
+                            let p: Vec<&str> = rt
+                                .split(['<', '>', ','])
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            (
+                                p[0].to_string(),
+                                p[1..]
+                                    .iter()
+                                    .map(|s| s.trim().to_string())
+                                    .collect::<Vec<String>>(),
+                            )
+                        } else {
+                            (rt.clone(), vec![])
+                        };
+                        let mut bc = btn.as_str();
+                        while bc.starts_with('*') {
+                            bc = &bc[1..];
+                        }
+                        let tp = self
+                            .resolve_fuzzy_name(&self.struct_types, bc)
+                            .or_else(|| self.resolve_fuzzy_name(&self.enum_types, bc))
+                            .unwrap_or(btn.clone());
                         let method_name_colon = format!("{}::{}", tp, mn);
                         let method_name_dot = format!("{}.{}", tp, mn);
-                        if let Some(Declaration::Function(f_decl)) = self.decls.get(&method_name_colon).or_else(|| self.decls.get(&method_name_dot)) {
+                        if let Some(Declaration::Function(f_decl)) = self
+                            .decls
+                            .get(&method_name_colon)
+                            .or_else(|| self.decls.get(&method_name_dot))
+                        {
                             let mut res_type = f_decl.return_type.clone();
-                            let combined_args = if generic_args.is_empty() { &tga } else { generic_args };
-                            res_type = Self::substitute_generic_params(&res_type, &f_decl.generic_params, combined_args);
+                            let combined_args = if generic_args.is_empty() {
+                                &tga
+                            } else {
+                                generic_args
+                            };
+                            res_type = Self::substitute_generic_params(
+                                &res_type,
+                                &f_decl.generic_params,
+                                combined_args,
+                            );
                             return res_type.replace(" ", "");
                         }
                     }
                 }
-                let full = self.resolve_fuzzy_name(&self.decls, name).unwrap_or(name.clone());
+                let full = self
+                    .resolve_fuzzy_name(&self.decls, name)
+                    .unwrap_or(name.clone());
                 if let Some(Declaration::Function(f_decl)) = self.decls.get(&full) {
-                    let r = Self::substitute_generic_params(&f_decl.return_type, &f_decl.generic_params, generic_args);
+                    let r = Self::substitute_generic_params(
+                        &f_decl.return_type,
+                        &f_decl.generic_params,
+                        generic_args,
+                    );
                     return r.replace(" ", "");
                 }
                 "unknown".to_string()
-            },
-            Expression::MemberAccess { receiver, member, .. } => { let rt = self.get_expr_type_name(receiver, variables); self.get_field_type(&rt, member) },
-            Expression::MethodCall { receiver, method, generic_args, .. } => {
-                let rt = self.get_expr_type_name(receiver, variables); 
-                if method == "offset" && rt.starts_with('*') { return rt.clone(); }
+            }
+            Expression::MemberAccess {
+                receiver, member, ..
+            } => {
+                let rt = self.get_expr_type_name(receiver, variables);
+                self.get_field_type(&rt, member)
+            }
+            Expression::MethodCall {
+                receiver,
+                method,
+                generic_args,
+                ..
+            } => {
+                let rt = self.get_expr_type_name(receiver, variables);
+                if method == "offset" && rt.starts_with('*') {
+                    return rt.clone();
+                }
                 let (btn, tga) = if rt.contains('<') {
-                    let p: Vec<&str> = rt.split(['<', '>', ',']).filter(|s| !s.is_empty()).collect();
-                    (p[0].to_string(), p[1..].iter().map(|s| s.trim().to_string()).collect::<Vec<String>>())
-                } else { (rt.clone(), vec![]) };
-                let mut bc = btn.as_str(); while bc.starts_with('*') { bc = &bc[1..]; }
-                let full = self.resolve_fuzzy_name(&self.decls, bc).unwrap_or(btn.clone());
+                    let p: Vec<&str> = rt
+                        .split(['<', '>', ','])
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                    (
+                        p[0].to_string(),
+                        p[1..]
+                            .iter()
+                            .map(|s| s.trim().to_string())
+                            .collect::<Vec<String>>(),
+                    )
+                } else {
+                    (rt.clone(), vec![])
+                };
+                let mut bc = btn.as_str();
+                while bc.starts_with('*') {
+                    bc = &bc[1..];
+                }
+                let full = self
+                    .resolve_fuzzy_name(&self.decls, bc)
+                    .unwrap_or(btn.clone());
                 let method_name_colon = format!("{}::{}", full, method);
                 let method_name_dot = format!("{}.{}", full, method);
-                if let Some(Declaration::Function(f_decl)) = self.decls.get(&method_name_colon).or_else(|| self.decls.get(&method_name_dot)) {
-                    let mut res_type = Self::substitute_generic_params(&f_decl.return_type, &f_decl.generic_params, generic_args);
-                    if let Some(decl) = self.decls.get(&full) { 
-                        let bp = match decl { Declaration::Struct(s) => &s.generic_params, Declaration::Enum(e) => &e.generic_params, _ => &vec![] }; 
+                if let Some(Declaration::Function(f_decl)) = self
+                    .decls
+                    .get(&method_name_colon)
+                    .or_else(|| self.decls.get(&method_name_dot))
+                {
+                    let mut res_type = Self::substitute_generic_params(
+                        &f_decl.return_type,
+                        &f_decl.generic_params,
+                        generic_args,
+                    );
+                    if let Some(decl) = self.decls.get(&full) {
+                        let bp = match decl {
+                            Declaration::Struct(s) => &s.generic_params,
+                            Declaration::Enum(e) => &e.generic_params,
+                            _ => &vec![],
+                        };
                         res_type = Self::substitute_generic_params(&res_type, bp, &tga);
                     }
                     return res_type.replace(" ", "");
                 }
                 "unknown".to_string()
-            },
-            Expression::StructInst { name, generic_args, .. } => {
-                let sn = self.resolve_fuzzy_name(&self.struct_types, name).unwrap_or(name.clone());
-                if generic_args.is_empty() { sn.replace(" ", "") } else { format!("{}<{}>", sn, generic_args.join(",")).replace(" ", "") }
-            },
-            Expression::EnumInst { name, variant, arguments, generic_args, .. } => {
+            }
+            Expression::StructInst {
+                name, generic_args, ..
+            } => {
+                let sn = self
+                    .resolve_fuzzy_name(&self.struct_types, name)
+                    .unwrap_or(name.clone());
+                if generic_args.is_empty() {
+                    sn.replace(" ", "")
+                } else {
+                    format!("{}<{}>", sn, generic_args.join(",")).replace(" ", "")
+                }
+            }
+            Expression::EnumInst {
+                name,
+                variant,
+                arguments,
+                generic_args,
+                ..
+            } => {
                 if let Some(en) = self.resolve_fuzzy_name(&self.enum_types, name) {
                     if !generic_args.is_empty() {
                         format!("{}<{}>", en, generic_args.join(",")).replace(" ", "")
@@ -1740,43 +3314,75 @@ impl<'ctx> Compiler<'ctx> {
                                 inferred_args.push(self.get_expr_type_name(arg, variables));
                             }
                         }
-                        if inferred_args.is_empty() { en.replace(" ", "") } else { format!("{}<{}>", en, inferred_args.join(",")).replace(" ", "") }
+                        if inferred_args.is_empty() {
+                            en.replace(" ", "")
+                        } else {
+                            format!("{}<{}>", en, inferred_args.join(",")).replace(" ", "")
+                        }
                     }
                 } else {
-                    let call_expr = Expression::Call { function: format!("{}.{}", name, variant), generic_args: generic_args.clone(), arguments: arguments.clone(), span: Span::zero() };
+                    let call_expr = Expression::Call {
+                        function: format!("{}.{}", name, variant),
+                        generic_args: generic_args.clone(),
+                        arguments: arguments.clone(),
+                        span: Span::zero(),
+                    };
                     self.get_expr_type_name(&call_expr, variables)
                 }
-            },
+            }
             Expression::Cast { target, .. } => target.replace(" ", ""),
             Expression::Block { statements, .. } => {
                 if let Some(s) = statements.last() {
                     match s {
-                        Statement::ExpressionStmt(e, _) | Statement::Return { value: e, .. } => self.get_expr_type_name(e, variables),
-                        _ => "unknown".to_string()
+                        Statement::ExpressionStmt(e, _) | Statement::Return { value: e, .. } => {
+                            self.get_expr_type_name(e, variables)
+                        }
+                        _ => "unknown".to_string(),
                     }
-                } else { "unknown".to_string() }
-            },
+                } else {
+                    "unknown".to_string()
+                }
+            }
             Expression::Deref { expr, .. } => {
                 let t = self.get_expr_type_name(expr, variables);
-                if t.starts_with('*') { t[1..].to_string().replace(" ", "") } else { "unknown".to_string() }
-            },
-            Expression::TypeRef { name, generic_args, .. } => { if generic_args.is_empty() { name.clone() } else { format!("{}<{}>", name, generic_args.join(",")) } },
+                if t.starts_with('*') {
+                    t[1..].to_string().replace(" ", "")
+                } else {
+                    "unknown".to_string()
+                }
+            }
+            Expression::TypeRef {
+                name, generic_args, ..
+            } => {
+                if generic_args.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{}<{}>", name, generic_args.join(","))
+                }
+            }
             Expression::Match { arms, .. } => {
                 if let Some(arm) = arms.first() {
                     if let Some(s) = arm.body.last() {
                         match s {
-                            Statement::ExpressionStmt(e, _) | Statement::Return { value: e, .. } => self.get_expr_type_name(e, variables),
-                            _ => "unknown".to_string()
+                            Statement::ExpressionStmt(e, _)
+                            | Statement::Return { value: e, .. } => {
+                                self.get_expr_type_name(e, variables)
+                            }
+                            _ => "unknown".to_string(),
                         }
-                    } else { "unknown".to_string() }
-                } else { "unknown".to_string() }
-            },
+                    } else {
+                        "unknown".to_string()
+                    }
+                } else {
+                    "unknown".to_string()
+                }
+            }
             _ => "unknown".to_string(),
         };
         res.replace(" ", "")
     }
 
-     pub fn optimize(&self) -> Result<(), CompileError> {
+    pub fn optimize(&self) -> Result<(), CompileError> {
         let builder = PassManagerBuilder::create();
         builder.set_optimization_level(OptimizationLevel::Aggressive);
 
@@ -1794,7 +3400,9 @@ impl<'ctx> Compiler<'ctx> {
         Ok(())
     }
 
-    pub fn print_to_file(&self, path: &Path) -> Result<(), CompileError> { 
-        self.module.print_to_file(path).map_err(|e| CompileError::Io(e.to_string())) 
+    pub fn print_to_file(&self, path: &Path) -> Result<(), CompileError> {
+        self.module
+            .print_to_file(path)
+            .map_err(|e| CompileError::io(e.to_string()))
     }
 }

--- a/src/codegen/transpiler/sql.rs
+++ b/src/codegen/transpiler/sql.rs
@@ -13,7 +13,9 @@ impl Default for SqlTranspiler {
 
 impl SqlTranspiler {
     pub fn new() -> Self {
-        Self { buffer: String::new() }
+        Self {
+            buffer: String::new(),
+        }
     }
 
     pub fn transpile(&mut self, program: &Program) -> String {
@@ -27,7 +29,8 @@ impl SqlTranspiler {
 
     fn transpile_function(&mut self, f: &Function) {
         let ret_type = self.map_type(&f.return_type);
-        self.buffer.push_str(&format!("CREATE OR REPLACE FUNCTION {}(", f.name));
+        self.buffer
+            .push_str(&format!("CREATE OR REPLACE FUNCTION {}(", f.name));
 
         let params: Vec<String> = f
             .params
@@ -36,14 +39,16 @@ impl SqlTranspiler {
             .collect();
 
         self.buffer.push_str(&params.join(", "));
-        self.buffer.push_str(&format!(") RETURNS {} AS $$\n", ret_type));
+        self.buffer
+            .push_str(&format!(") RETURNS {} AS $$\n", ret_type));
 
         // Collect variable declarations from Let statements
         let vars = self.collect_vars(&f.body);
         if !vars.is_empty() {
             self.buffer.push_str("DECLARE\n");
             for (name, vtype) in &vars {
-                self.buffer.push_str(&format!("    {} {};\n", name, self.map_type(vtype)));
+                self.buffer
+                    .push_str(&format!("    {} {};\n", name, self.map_type(vtype)));
             }
         }
 
@@ -69,13 +74,10 @@ impl SqlTranspiler {
     fn collect_vars_from_stmts(&self, stmts: &[Statement], vars: &mut Vec<(String, String)>) {
         for stmt in stmts {
             match stmt {
-                Statement::Let {
-                    name, value, ..
+                Statement::Let { name, value, .. } if !vars.iter().any(|(n, _)| n == name) => {
+                    let vtype = self.infer_type(value);
+                    vars.push((name.clone(), vtype));
                 }
-                    if !vars.iter().any(|(n, _)| n == name) => {
-                        let vtype = self.infer_type(value);
-                        vars.push((name.clone(), vtype));
-                    }
                 Statement::If {
                     then_branch,
                     else_branch,
@@ -190,7 +192,9 @@ impl SqlTranspiler {
                 }
                 self.buffer.push_str("    END IF;\n");
             }
-            Statement::While { condition, body, .. } => {
+            Statement::While {
+                condition, body, ..
+            } => {
                 self.buffer.push_str("    WHILE ");
                 self.transpile_expression(condition);
                 self.buffer.push_str(" LOOP\n");
@@ -204,7 +208,9 @@ impl SqlTranspiler {
                 self.transpile_expression(expr);
                 self.buffer.push_str(";\n");
             }
-            Statement::Match { condition, arms, .. } => {
+            Statement::Match {
+                condition, arms, ..
+            } => {
                 self.buffer.push_str("    CASE ");
                 self.transpile_expression(condition);
                 self.buffer.push('\n');
@@ -276,9 +282,7 @@ impl SqlTranspiler {
                 self.buffer.push(')');
             }
             Expression::MemberAccess {
-                receiver,
-                member,
-                ..
+                receiver, member, ..
             } => {
                 self.transpile_expression(receiver);
                 self.buffer.push('.');

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,10 +16,11 @@ pub enum CompileError {
         snippet: Option<String>,
     },
 
-    #[error("Not Found: {kind} '{name}' is not defined")]
+    #[error("Not Found: {kind} '{name}' is not defined{suggestion}")]
     NotFound {
         kind: String,
         name: String,
+        suggestion: String,
         line: usize,
         col: usize,
         snippet: Option<String>,
@@ -43,17 +44,45 @@ pub enum CompileError {
         snippet: Option<String>,
     },
 
-    #[error("LLVM error: {0}")]
-    Inkwell(String),
+    #[error("LLVM error: {message}")]
+    Inkwell {
+        message: String,
+        line: usize,
+        col: usize,
+        snippet: Option<String>,
+    },
 
-    #[error("IO error: {0}")]
-    Io(String),
+    #[error("IO error: {message}")]
+    Io {
+        message: String,
+        line: usize,
+        col: usize,
+        snippet: Option<String>,
+    },
 
-    #[error("Import error: {0}")]
-    Import(String),
+    #[error("Import error: {message}")]
+    Import {
+        message: String,
+        line: usize,
+        col: usize,
+        snippet: Option<String>,
+    },
 
-    #[error("{0}")]
-    Internal(String),
+    #[error("internal compiler error: {message}")]
+    Internal {
+        message: String,
+        line: usize,
+        col: usize,
+        snippet: Option<String>,
+    },
+
+    #[error("warning: {message}")]
+    Warning {
+        message: String,
+        line: usize,
+        col: usize,
+        snippet: Option<String>,
+    },
 }
 
 impl CompileError {
@@ -66,14 +95,91 @@ impl CompileError {
         }
     }
 
+    /// Construct an `Internal` error with the typed location prefix applied
+    /// (the `#[error("internal compiler error: {message}")]` format already
+    /// prepends the label, so the caller passes the raw message). Use this
+    /// instead of building the struct variant directly so the line/col default
+    /// is centralized and future layout changes hit one site. #40.
+    pub fn internal(message: impl Into<String>) -> Self {
+        CompileError::Internal {
+            message: message.into(),
+            line: 0,
+            col: 0,
+            snippet: None,
+        }
+    }
+
+    pub fn inkwell(message: impl Into<String>) -> Self {
+        CompileError::Inkwell {
+            message: message.into(),
+            line: 0,
+            col: 0,
+            snippet: None,
+        }
+    }
+
+    pub fn io(message: impl Into<String>) -> Self {
+        CompileError::Io {
+            message: message.into(),
+            line: 0,
+            col: 0,
+            snippet: None,
+        }
+    }
+
+    pub fn import(message: impl Into<String>) -> Self {
+        CompileError::Import {
+            message: message.into(),
+            line: 0,
+            col: 0,
+            snippet: None,
+        }
+    }
+
+    pub fn warning(message: impl Into<String>, line: usize, col: usize) -> Self {
+        CompileError::Warning {
+            message: message.into(),
+            line,
+            col,
+            snippet: None,
+        }
+    }
+
+    /// `NotFound` carrying an optional "did you mean X?" suggestion. Pass an
+    /// empty `suggestion` string when no close match was found. #40.
+    pub fn not_found(
+        kind: impl Into<String>,
+        name: impl Into<String>,
+        suggestion: impl Into<String>,
+        line: usize,
+        col: usize,
+    ) -> Self {
+        let mut s = suggestion.into();
+        if !s.is_empty() {
+            s = format!(" (did you mean '{}'?)", s);
+        }
+        CompileError::NotFound {
+            kind: kind.into(),
+            name: name.into(),
+            suggestion: s,
+            line,
+            col,
+            snippet: None,
+        }
+    }
+
     pub fn with_snippet(mut self, source: &str) -> Self {
         let line = match &self {
             CompileError::Type { line, .. }
             | CompileError::Unsafe { line, .. }
             | CompileError::NotFound { line, .. }
             | CompileError::NotFunction { line, .. }
-            | CompileError::InvalidOperator { line, .. } => *line,
-            _ => return self,
+            | CompileError::InvalidOperator { line, .. }
+            | CompileError::Inkwell { line, .. }
+            | CompileError::Io { line, .. }
+            | CompileError::Import { line, .. }
+            | CompileError::Internal { line, .. }
+            | CompileError::Warning { line, .. } => *line,
         };
 
         if line > 0 {
@@ -83,8 +189,12 @@ impl CompileError {
                 | CompileError::Unsafe { snippet: s, .. }
                 | CompileError::NotFound { snippet: s, .. }
                 | CompileError::NotFunction { snippet: s, .. }
-                | CompileError::InvalidOperator { snippet: s, .. } => *s = snippet,
-                _ => {}
+                | CompileError::InvalidOperator { snippet: s, .. }
+                | CompileError::Inkwell { snippet: s, .. }
+                | CompileError::Io { snippet: s, .. }
+                | CompileError::Import { snippet: s, .. }
+                | CompileError::Internal { snippet: s, .. }
+                | CompileError::Warning { snippet: s, .. } => *s = snippet,
             }
         }
         self
@@ -96,9 +206,19 @@ impl CompileError {
             | CompileError::Unsafe { col, .. }
             | CompileError::NotFound { col, .. }
             | CompileError::NotFunction { col, .. }
-            | CompileError::InvalidOperator { col, .. } => *col,
-            _ => 0,
+            | CompileError::InvalidOperator { col, .. }
+            | CompileError::Inkwell { col, .. }
+            | CompileError::Io { col, .. }
+            | CompileError::Import { col, .. }
+            | CompileError::Internal { col, .. }
+            | CompileError::Warning { col, .. } => *col,
         }
+    }
+
+    /// True if this error is non-fatal (only the `Warning` variant today).
+    /// Used by the driver to print to stderr without halting compilation. #40.
+    pub fn is_warning(&self) -> bool {
+        matches!(self, CompileError::Warning { .. })
     }
 }
 
@@ -124,8 +244,84 @@ fn extract_snippet(source: &str, line: usize, col: usize) -> Option<String> {
     Some(result)
 }
 
+/// Returns the closest match from `candidates` to `name`, or `None` if no
+/// candidate is "close enough" (Levenshtein distance <= 3 AND within the
+/// worst case of (len/3)). Used by the type checker for "did you mean X?"
+/// suggestions on undefined-variable / function / field errors. #40.
+pub fn suggest_closest<'a, I>(name: &str, candidates: I) -> Option<String>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut best: Option<(usize, String)> = None;
+    for c in candidates {
+        if c == name {
+            continue;
+        }
+        // Skip qualified names — only suggest simple names the user typed.
+        let token = c.rsplit('.').next().unwrap_or(c);
+        if token.is_empty() {
+            continue;
+        }
+        let d = levenshtein(name, token);
+        let threshold = (name.len().max(token.len()) / 3).max(1);
+        // Require both a small absolute distance and a relative threshold so
+        // that short names (len 1-2) don't match wildly unrelated candidates.
+        if d <= 3 && d <= threshold {
+            match &best {
+                Some((bd, _)) if d >= *bd => {}
+                _ => best = Some((d, token.to_string())),
+            }
+        }
+    }
+    best.map(|(_, s)| s)
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr: Vec<usize> = vec![0; n + 1];
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
 impl From<inkwell::builder::BuilderError> for CompileError {
     fn from(e: inkwell::builder::BuilderError) -> Self {
-        CompileError::Inkwell(e.to_string())
+        CompileError::inkwell(e.to_string())
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::{levenshtein, suggest_closest};
+
+    #[test]
+    fn levenshtein_basic() {
+        // Substitution, insertion, deletion each cost 1.
+        assert_eq!(levenshtein("greeb", "greet"), 1); // substitution
+        assert_eq!(levenshtein("nme", "name"), 1); // insertion
+        assert_eq!(levenshtein("greet_word", "greet_world"), 1); // deletion
+        assert_eq!(levenshtein("grety", "greet"), 2); // two substitutions
+    }
+
+    #[test]
+    fn suggest_closest_simple() {
+        let cs: Vec<String> = vec!["greet".to_string()];
+        assert_eq!(suggest_closest("greeb", &cs), Some("greet".to_string()));
+        // Distance-2 typo rejected by the default 3-edit / (len/3) threshold.
+        assert_eq!(suggest_closest("grety", &cs), None);
     }
 }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -10,7 +10,7 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
-        Self { 
+        Self {
             input: input.chars().peekable(),
             line: 1,
             col: 1,
@@ -66,53 +66,95 @@ impl<'a> Lexer<'a> {
                     } else {
                         TokenKind::Slash
                     }
-                },
+                }
                 '?' => TokenKind::Question,
                 '.' => {
-                    if self.peek_char() == '.' { self.read_char(); TokenKind::Range } 
-                    else { TokenKind::Dot }
+                    if self.peek_char() == '.' {
+                        self.read_char();
+                        TokenKind::Range
+                    } else {
+                        TokenKind::Dot
+                    }
                 }
                 '-' => {
-                    if self.peek_char() == '>' { self.read_char(); TokenKind::Arrow } 
-                    else { TokenKind::Minus }
+                    if self.peek_char() == '>' {
+                        self.read_char();
+                        TokenKind::Arrow
+                    } else {
+                        TokenKind::Minus
+                    }
                 }
                 '=' => {
-                    if self.peek_char() == '=' { self.read_char(); TokenKind::EqEq } 
-                    else if self.peek_char() == '>' { self.read_char(); TokenKind::Arrow }
-                    else { TokenKind::Eq }
+                    if self.peek_char() == '=' {
+                        self.read_char();
+                        TokenKind::EqEq
+                    } else if self.peek_char() == '>' {
+                        self.read_char();
+                        TokenKind::Arrow
+                    } else {
+                        TokenKind::Eq
+                    }
                 }
                 '!' => {
-                    if self.peek_char() == '=' { self.read_char(); TokenKind::NotEq } 
-                    else { TokenKind::Bang }
+                    if self.peek_char() == '=' {
+                        self.read_char();
+                        TokenKind::NotEq
+                    } else {
+                        TokenKind::Bang
+                    }
                 }
                 '&' => {
-                    if self.peek_char() == '&' { self.read_char(); TokenKind::And }
-                    else { TokenKind::Illegal('&') }
-                },
-'|' => {
-                    if self.peek_char() == '|' { self.read_char(); TokenKind::Or }
-                    else if self.peek_char() == '>' { self.read_char(); TokenKind::Pipeline }
-                    else { TokenKind::Pipe }
-                },
+                    if self.peek_char() == '&' {
+                        self.read_char();
+                        TokenKind::And
+                    } else {
+                        TokenKind::Illegal('&')
+                    }
+                }
+                '|' => {
+                    if self.peek_char() == '|' {
+                        self.read_char();
+                        TokenKind::Or
+                    } else if self.peek_char() == '>' {
+                        self.read_char();
+                        TokenKind::Pipeline
+                    } else {
+                        TokenKind::Pipe
+                    }
+                }
                 '>' => {
-                    if self.peek_char() == '=' { self.read_char(); TokenKind::GtEq } 
-                    else { TokenKind::Gt }
+                    if self.peek_char() == '=' {
+                        self.read_char();
+                        TokenKind::GtEq
+                    } else {
+                        TokenKind::Gt
+                    }
                 }
                 '<' => {
-                    if self.peek_char() == '=' { self.read_char(); TokenKind::LtEq } 
-                    else if self.peek_char() == '-' { self.read_char(); TokenKind::LArrow }
-                    else { TokenKind::Lt }
+                    if self.peek_char() == '=' {
+                        self.read_char();
+                        TokenKind::LtEq
+                    } else if self.peek_char() == '-' {
+                        self.read_char();
+                        TokenKind::LArrow
+                    } else {
+                        TokenKind::Lt
+                    }
                 }
                 ':' => {
-                    if self.peek_char() == ':' { self.read_char(); TokenKind::DoubleColon } 
-                    else { TokenKind::Colon }
+                    if self.peek_char() == ':' {
+                        self.read_char();
+                        TokenKind::DoubleColon
+                    } else {
+                        TokenKind::Colon
+                    }
                 }
                 '@' => TokenKind::At,
                 '\'' => self.read_char_literal(),
                 '"' => self.read_string(),
                 c if c.is_alphabetic() || c == '_' => {
                     if c == 'f' && self.peek_char() == '"' {
-                        self.read_char(); 
+                        self.read_char();
                         self.read_fstring()
                     } else if c == 'D' && self.peek_char().is_numeric() {
                         self.read_date()
@@ -167,7 +209,9 @@ impl<'a> Lexer<'a> {
 
     fn read_line_comment(&mut self) {
         while let Some(&ch) = self.input.peek() {
-            if ch == '\n' { break; }
+            if ch == '\n' {
+                break;
+            }
             self.read_char();
         }
     }
@@ -175,8 +219,12 @@ impl<'a> Lexer<'a> {
     fn read_doc_comment(&mut self, line: usize, col: usize) -> Token {
         let mut text = String::new();
         while let Some(&ch) = self.input.peek() {
-            if ch == '\n' { break; }
-            if let Some(c) = self.read_char() { text.push(c); }
+            if ch == '\n' {
+                break;
+            }
+            if let Some(c) = self.read_char() {
+                text.push(c);
+            }
         }
         Token::new(TokenKind::DocComment(text.trim().to_string()), line, col)
     }
@@ -185,16 +233,19 @@ impl<'a> Lexer<'a> {
         while let Some(ch) = self.read_char() {
             if ch == '*'
                 && let Some(&next) = self.input.peek()
-                    && next == '/' {
-                        self.read_char();
-                        break;
-                    }
+                && next == '/'
+            {
+                self.read_char();
+                break;
+            }
         }
     }
 
     fn skip_whitespace(&mut self) {
         while let Some(&ch) = self.input.peek() {
-            if !ch.is_whitespace() { break; }
+            if !ch.is_whitespace() {
+                break;
+            }
             self.read_char();
         }
     }
@@ -206,8 +257,12 @@ impl<'a> Lexer<'a> {
     fn read_identifier(&mut self, first: char) -> String {
         let mut ident = String::from(first);
         while let Some(&ch) = self.input.peek() {
-            if !ch.is_alphanumeric() && ch != '_' { break; }
-            if let Some(c) = self.read_char() { ident.push(c); }
+            if !ch.is_alphanumeric() && ch != '_' {
+                break;
+            }
+            if let Some(c) = self.read_char() {
+                ident.push(c);
+            }
         }
         ident
     }
@@ -215,7 +270,10 @@ impl<'a> Lexer<'a> {
     fn read_string(&mut self) -> TokenKind {
         let mut s = String::new();
         while let Some(&ch) = self.input.peek() {
-            if ch == '"' { self.read_char(); break; }
+            if ch == '"' {
+                self.read_char();
+                break;
+            }
             if ch == '\\' {
                 self.read_char();
                 match self.read_char() {
@@ -263,11 +321,17 @@ impl<'a> Lexer<'a> {
         let mut s = String::new();
         let mut depth: i32 = 0;
         while let Some(&ch) = self.input.peek() {
-            if ch == '"' && depth == 0 { self.read_char(); break; }
+            if ch == '"' && depth == 0 {
+                self.read_char();
+                break;
+            }
             let c = self.read_char().unwrap();
-            if c == '{' { depth += 1; }
-            else if c == '}' {
-                if depth > 0 { depth -= 1; }
+            if c == '{' {
+                depth += 1;
+            } else if c == '}' {
+                if depth > 0 {
+                    depth -= 1;
+                }
             }
             s.push(c);
         }
@@ -283,13 +347,13 @@ impl<'a> Lexer<'a> {
                 break;
             }
         }
-        
+
         let parts: Vec<&str> = s.split('-').collect();
         if parts.len() == 3 {
             let y: i64 = parts[0].parse().unwrap_or(0);
             let m: i64 = parts[1].parse().unwrap_or(1);
             let d: i64 = parts[2].parse().unwrap_or(1);
-            
+
             let mut total_days = 0;
             for year in 1970..y {
                 if (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0) {
@@ -298,7 +362,7 @@ impl<'a> Lexer<'a> {
                     total_days += 365;
                 }
             }
-            
+
             let days_in_month = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
             for month in 1..m {
                 total_days += days_in_month[month as usize];
@@ -306,9 +370,9 @@ impl<'a> Lexer<'a> {
                     total_days += 1;
                 }
             }
-            
+
             total_days += d - 1;
-            
+
             let ts = total_days * 86400;
             TokenKind::DateLiteral(ts)
         } else {
@@ -319,18 +383,25 @@ impl<'a> Lexer<'a> {
     fn read_number(&mut self, first: char) -> TokenKind {
         let mut num_str = String::from(first);
         let mut is_float = false;
-        
+
         while let Some(&ch) = self.input.peek() {
             if ch == '.' {
                 let mut lookahead = self.input.clone();
                 lookahead.next();
                 if let Some(&next) = lookahead.peek()
-                    && next == '.' { break; }
-                
+                    && next == '.'
+                {
+                    break;
+                }
+
                 is_float = true;
-                if let Some(c) = self.read_char() { num_str.push(c); }
+                if let Some(c) = self.read_char() {
+                    num_str.push(c);
+                }
             } else if ch.is_numeric() {
-                if let Some(c) = self.read_char() { num_str.push(c); }
+                if let Some(c) = self.read_char() {
+                    num_str.push(c);
+                }
             } else {
                 break;
             }
@@ -339,7 +410,9 @@ impl<'a> Lexer<'a> {
         let mut suffix = String::new();
         while let Some(&ch) = self.input.peek() {
             if ch.is_alphabetic() {
-                if let Some(c) = self.read_char() { suffix.push(c); }
+                if let Some(c) = self.read_char() {
+                    suffix.push(c);
+                }
             } else {
                 break;
             }
@@ -350,8 +423,14 @@ impl<'a> Lexer<'a> {
             let (secs, nanos) = match suffix.as_str() {
                 "s" => (val as u64, (val.fract() * 1_000_000_000.0) as u32),
                 "ms" => ((val / 1000.0) as u64, ((val % 1000.0) * 1_000_000.0) as u32),
-                "us" => ((val / 1_000_000.0) as u64, ((val % 1_000_000.0) * 1000.0) as u32),
-                "ns" => ((val / 1_000_000_000.0) as u64, (val % 1_000_000_000.0) as u32),
+                "us" => (
+                    (val / 1_000_000.0) as u64,
+                    ((val % 1_000_000.0) * 1000.0) as u32,
+                ),
+                "ns" => (
+                    (val / 1_000_000_000.0) as u64,
+                    (val % 1_000_000_000.0) as u32,
+                ),
                 "m" => ((val * 60.0) as u64, 0),
                 "h" => ((val * 3600.0) as u64, 0),
                 "d" => ((val * 86400.0) as u64, 0),
@@ -360,24 +439,24 @@ impl<'a> Lexer<'a> {
             return TokenKind::DurationLiteral(secs, nanos);
         }
 
-        if is_float { 
-            TokenKind::FloatLiteral(num_str.parse().unwrap_or(0.0)) 
-        } else { 
-            TokenKind::IntLiteral(num_str.parse().unwrap_or(0)) 
+        if is_float {
+            TokenKind::FloatLiteral(num_str.parse().unwrap_or(0.0))
+        } else {
+            TokenKind::IntLiteral(num_str.parse().unwrap_or(0))
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::lexer::token::TokenKind;
     use super::Lexer;
+    use crate::lexer::token::TokenKind;
 
     #[test]
     fn test_basic_tokens() {
         let input = "fn main() { let x = 10; }";
         let mut lexer = Lexer::new(input);
-        
+
         let expected = vec![
             (TokenKind::Fn, 1, 1),
             (TokenKind::Identifier("main".into()), 1, 4),
@@ -404,13 +483,13 @@ mod tests {
     fn test_durations() {
         let input = "10s 500ms 1.5ms";
         let mut lexer = Lexer::new(input);
-        
+
         let tok1 = lexer.next_token();
         assert_eq!(tok1.kind, TokenKind::DurationLiteral(10, 0));
-        
+
         let tok2 = lexer.next_token();
         assert_eq!(tok2.kind, TokenKind::DurationLiteral(0, 500_000_000));
-        
+
         let tok3 = lexer.next_token();
         assert_eq!(tok3.kind, TokenKind::DurationLiteral(0, 1_500_000));
     }
@@ -419,12 +498,12 @@ mod tests {
     fn test_multiline_position() {
         let input = "let a = 1\nlet b = 2";
         let mut lexer = Lexer::new(input);
-        
+
         lexer.next_token(); // let
         lexer.next_token(); // a
         lexer.next_token(); // =
         lexer.next_token(); // 1
-        
+
         let tok = lexer.next_token(); // second 'let'
         assert_eq!(tok.kind, TokenKind::Let);
         assert_eq!(tok.line, 2);
@@ -435,15 +514,15 @@ mod tests {
     fn test_comments() {
         let input = "// line comment\nlet x = 1 /* block\ncomment */ let y = 2";
         let mut lexer = Lexer::new(input);
-        
+
         let tok1 = lexer.next_token();
         assert_eq!(tok1.kind, TokenKind::Let);
         assert_eq!(tok1.line, 2);
-        
+
         lexer.next_token(); // x
         lexer.next_token(); // =
         lexer.next_token(); // 1
-        
+
         let tok2 = lexer.next_token(); // y 'let'
         assert_eq!(tok2.kind, TokenKind::Let);
         assert_eq!(tok2.line, 3);

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,5 +1,5 @@
-pub mod token;
 pub mod lexer;
+pub mod token;
 
-pub use token::{Token, TokenKind};
 pub use lexer::Lexer;
+pub use token::{Token, TokenKind};

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -14,16 +14,39 @@ impl Token {
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
     // System Keywords
-    Fn, Let, Mut, Struct, Enum, Return, If, Else, Match, As, While,
-    Use, Pub, Async, Unsafe, Require, Extern,
-    Interface, Impl, Channel,
-    For, In, Type, SelfToken, Spawn,
-    Break, Continue, Loop,
-    
+    Fn,
+    Let,
+    Mut,
+    Struct,
+    Enum,
+    Return,
+    If,
+    Else,
+    Match,
+    As,
+    While,
+    Use,
+    Pub,
+    Async,
+    Unsafe,
+    Require,
+    Extern,
+    Interface,
+    Impl,
+    Channel,
+    For,
+    In,
+    Type,
+    SelfToken,
+    Spawn,
+    Break,
+    Continue,
+    Loop,
+
     // AI-Native & Logic
-    Intent, 
+    Intent,
     Invariant,
-    Inside, 
+    Inside,
 
     // Identifiers and Literals
     Identifier(String),
@@ -34,26 +57,48 @@ pub enum TokenKind {
     FloatLiteral(f64),
     DurationLiteral(u64, u32),
     DateLiteral(i64),
-    True, False, // Keywords
+    True,
+    False, // Keywords
 
     // Symbols and Operators
-    Plus, Minus, Star, Slash, Percent, Caret, // Arithmetic (+ % ^)
-    Eq, EqEq, NotEq, Arrow, 
-    LArrow, // <- (Send/Receive)
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Percent,
+    Caret, // Arithmetic (+ % ^)
+    Eq,
+    EqEq,
+    NotEq,
+    Arrow,
+    LArrow,   // <- (Send/Receive)
     Pipeline, // |>
-    And, Or, Bang, // Logic (&& || !)
-    Gt, Lt, GtEq, LtEq,
-    LParen, RParen, LBrace, RBrace, LBracket, RBracket, 
-    Colon, Semicolon, Comma, Dot, 
+    And,
+    Or,
+    Bang, // Logic (&& || !)
+    Gt,
+    Lt,
+    GtEq,
+    LtEq,
+    LParen,
+    RParen,
+    LBrace,
+    RBrace,
+    LBracket,
+    RBracket,
+    Colon,
+    Semicolon,
+    Comma,
+    Dot,
     Pipe,
-    DoubleColon, 
-    Range,       
+    DoubleColon,
+    Range,
     At,
     Question,
 
     // End of File
     EOF,
-    
+
     // Doc Comments
     DocComment(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,37 @@
-pub mod lexer;
-pub mod ast;
-pub mod parser;
 pub mod analysis;
-
+pub mod ast;
+pub mod lexer;
+pub mod parser;
 
 pub mod codegen;
 
 pub mod error;
 
-use std::fs;
-use std::path::Path;
-use inkwell::context::Context;
+use crate::analysis::checker::TypeChecker;
+use crate::ast::Program;
+use crate::codegen::compiler::Compiler;
+use crate::codegen::transpiler::sql::SqlTranspiler;
+use crate::error::CompileError;
 use crate::lexer::Lexer;
 use crate::parser::Parser;
-use crate::analysis::checker::TypeChecker;
-use crate::codegen::transpiler::sql::SqlTranspiler;
-use crate::codegen::compiler::Compiler;
-use crate::ast::Program;
-use crate::error::CompileError;
+use inkwell::context::Context;
+use std::fs;
+use std::path::Path;
 
 use std::collections::HashSet;
 use std::path::PathBuf;
 
 fn resolve_import_path(import_path: &[String]) -> PathBuf {
     let mut path = if let Some(first) = import_path.first() {
-        if first == "compiler" { PathBuf::from(".") } else { PathBuf::from("stdlib") }
+        if first == "compiler" {
+            PathBuf::from(".")
+        } else {
+            PathBuf::from("stdlib")
+        }
     } else {
         PathBuf::from("stdlib")
     };
-    
+
     for part in import_path {
         path.push(part);
     }
@@ -36,66 +39,101 @@ fn resolve_import_path(import_path: &[String]) -> PathBuf {
     path
 }
 
-fn process_imports(program: &mut Program, visited: &mut HashSet<PathBuf>) -> Result<(), CompileError> {
+fn process_imports(
+    program: &mut Program,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<(), CompileError> {
     let imports = std::mem::take(&mut program.imports);
     for import in imports {
         let path = resolve_import_path(&import.path);
-        if visited.contains(&path) { 
-            continue; 
-        }
-        
-        if !path.exists() {
-            return Err(CompileError::Import(format!("Import not found: {:?}", path)));
+        if visited.contains(&path) {
+            continue;
         }
 
-        let source = fs::read_to_string(&path).map_err(|e| CompileError::Io(format!("Failed to read {:?}: {}", path, e)))?;
+        if !path.exists() {
+            return Err(CompileError::import(format!(
+                "Import not found: {:?}",
+                path
+            )));
+        }
+
+        let source = fs::read_to_string(&path)
+            .map_err(|e| CompileError::io(format!("Failed to read {:?}: {}", path, e)))?;
         let lexer = Lexer::new(&source);
         let mut parser = Parser::new(lexer);
         let mut imported_program = parser.parse_program().map_err(|e| {
             let msgs: Vec<String> = e.iter().map(|e| e.to_string()).collect();
-            CompileError::Import(format!("Import parse errors in {:?}: {}", path, msgs.join("; ")))
+            CompileError::import(format!(
+                "Import parse errors in {:?}: {}",
+                path,
+                msgs.join("; ")
+            ))
         })?;
-        
+
         // Rename local declarations before recursion to avoid double-prefixing
         let prefix = import.path.join(".");
         for decl in &mut imported_program.declarations {
             match decl {
-                crate::ast::Declaration::Function(f) => { f.name = format!("{}.{}", prefix, f.name); },
-                crate::ast::Declaration::Struct(s) => { s.name = format!("{}.{}", prefix, s.name); },
-                crate::ast::Declaration::Enum(e) => { e.name = format!("{}.{}", prefix, e.name); },
-                crate::ast::Declaration::Impl(i) => { i.target_name = format!("{}.{}", prefix, i.target_name); },
+                crate::ast::Declaration::Function(f) => {
+                    f.name = format!("{}.{}", prefix, f.name);
+                }
+                crate::ast::Declaration::Struct(s) => {
+                    s.name = format!("{}.{}", prefix, s.name);
+                }
+                crate::ast::Declaration::Enum(e) => {
+                    e.name = format!("{}.{}", prefix, e.name);
+                }
+                crate::ast::Declaration::Impl(i) => {
+                    i.target_name = format!("{}.{}", prefix, i.target_name);
+                }
                 _ => {}
             }
         }
 
         visited.insert(path.clone());
         process_imports(&mut imported_program, visited)?;
-        
+
         program.declarations.extend(imported_program.declarations);
     }
     Ok(())
 }
 
 pub fn transpile_sql(input_path: &str) -> Result<String, CompileError> {
-    let source = fs::read_to_string(input_path).map_err(|e| CompileError::Io(e.to_string()))?;
+    let source = fs::read_to_string(input_path).map_err(|e| CompileError::io(e.to_string()))?;
     let lexer = Lexer::new(&source);
     let mut parser = Parser::new(lexer);
     let program = parser.parse_program().map_err(|e| CompileError::Type {
-        message: format!("Parse errors: {}", e.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")),
-        line: 0, col: 0, snippet: None,
+        message: format!(
+            "Parse errors: {}",
+            e.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ),
+        line: 0,
+        col: 0,
+        snippet: None,
     })?;
-    
+
     let mut transpiler = SqlTranspiler::new();
     Ok(transpiler.transpile(&program))
 }
 
 pub fn compile_file(input_path: &str, output_path: &str) -> Result<(), CompileError> {
-    let source = fs::read_to_string(input_path).map_err(|e| CompileError::Io(e.to_string()))?;
+    let source = fs::read_to_string(input_path).map_err(|e| CompileError::io(e.to_string()))?;
     let lexer = Lexer::new(&source);
     let mut parser = Parser::new(lexer);
     let mut program = parser.parse_program().map_err(|e| CompileError::Type {
-        message: format!("Parse errors: {}", e.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")),
-        line: 0, col: 0, snippet: None,
+        message: format!(
+            "Parse errors: {}",
+            e.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ),
+        line: 0,
+        col: 0,
+        snippet: None,
     })?;
 
     // 0. Resolve Imports
@@ -120,12 +158,20 @@ pub fn compile_file(input_path: &str, output_path: &str) -> Result<(), CompileEr
 }
 
 pub fn generate_docs(input_path: &str) -> Result<String, CompileError> {
-    let source = fs::read_to_string(input_path).map_err(|e| CompileError::Io(e.to_string()))?;
+    let source = fs::read_to_string(input_path).map_err(|e| CompileError::io(e.to_string()))?;
     let lexer = Lexer::new(&source);
     let mut parser = Parser::new(lexer);
     let program = parser.parse_program().map_err(|e| CompileError::Type {
-        message: format!("Parse errors: {}", e.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("; ")),
-        line: 0, col: 0, snippet: None,
+        message: format!(
+            "Parse errors: {}",
+            e.iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("; ")
+        ),
+        line: 0,
+        col: 0,
+        snippet: None,
     })?;
 
     let mut doc = String::new();
@@ -157,7 +203,10 @@ pub fn generate_docs(input_path: &str) -> Result<String, CompileError> {
                     doc.push_str(&format!("{}\n\n", comment));
                 }
                 if !s.generic_params.is_empty() {
-                    doc.push_str(&format!("**Generics:** `<{}>`\n\n", s.generic_params.join(", ")));
+                    doc.push_str(&format!(
+                        "**Generics:** `<{}>`\n\n",
+                        s.generic_params.join(", ")
+                    ));
                 }
                 if !s.fields.is_empty() {
                     doc.push_str("| Field | Type |\n|-------|------|\n");
@@ -173,7 +222,10 @@ pub fn generate_docs(input_path: &str) -> Result<String, CompileError> {
                     doc.push_str(&format!("{}\n\n", comment));
                 }
                 if !e.generic_params.is_empty() {
-                    doc.push_str(&format!("**Generics:** `<{}>`\n\n", e.generic_params.join(", ")));
+                    doc.push_str(&format!(
+                        "**Generics:** `<{}>`\n\n",
+                        e.generic_params.join(", ")
+                    ));
                 }
                 if !e.variants.is_empty() {
                     doc.push_str("| Variant | Data |\n|---------|------|\n");
@@ -208,8 +260,15 @@ pub fn generate_docs(input_path: &str) -> Result<String, CompileError> {
                 } else {
                     format!("<{}>", impl_block.generic_params.join(", "))
                 };
-                let iface = impl_block.interface_name.as_deref().map(|i| format!(" for `{}`", i)).unwrap_or_default();
-                doc.push_str(&format!("## Impl `{}`{}{}\n\n", impl_block.target_name, generics, iface));
+                let iface = impl_block
+                    .interface_name
+                    .as_deref()
+                    .map(|i| format!(" for `{}`", i))
+                    .unwrap_or_default();
+                doc.push_str(&format!(
+                    "## Impl `{}`{}{}\n\n",
+                    impl_block.target_name, generics, iface
+                ));
                 for method in &impl_block.functions {
                     if let Some(ref mc) = method.doc_comment {
                         doc.push_str(&format!("{}\n\n", mc));
@@ -227,12 +286,16 @@ pub fn generate_docs(input_path: &str) -> Result<String, CompileError> {
 fn generate_function_signature(f: &ast::Function) -> String {
     let mut sig = String::from("```aion\n");
 
-    let modifiers: Vec<&str> = f.modifiers.iter().filter_map(|t| match t.kind {
-        crate::lexer::TokenKind::Extern => Some("extern"),
-        crate::lexer::TokenKind::Spawn => Some("spawn"),
-        crate::lexer::TokenKind::Unsafe => Some("unsafe"),
-        _ => None,
-    }).collect();
+    let modifiers: Vec<&str> = f
+        .modifiers
+        .iter()
+        .filter_map(|t| match t.kind {
+            crate::lexer::TokenKind::Extern => Some("extern"),
+            crate::lexer::TokenKind::Spawn => Some("spawn"),
+            crate::lexer::TokenKind::Unsafe => Some("unsafe"),
+            _ => None,
+        })
+        .collect();
     if !modifiers.is_empty() {
         sig.push_str(&format!("{} ", modifiers.join(" ")));
     }
@@ -245,7 +308,9 @@ fn generate_function_signature(f: &ast::Function) -> String {
 
     sig.push('(');
     for (i, (name, ty, default)) in f.params.iter().enumerate() {
-        if i > 0 { sig.push_str(", "); }
+        if i > 0 {
+            sig.push_str(", ");
+        }
         sig.push_str(&format!("{}: {}", name, ty));
         if let Some(default) = default {
             sig.push_str(&format!(" = {:?}", default));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use clap::{Parser, Subcommand};
 use aionc::{compile_file, generate_docs, transpile_sql};
+use clap::{Parser, Subcommand};
 use std::fs;
 use std::process::Command;
 
@@ -33,7 +33,7 @@ enum Commands {
         output: String,
         #[arg(short, long, default_value = "sql")]
         target: String,
-    }
+    },
 }
 
 fn main() {
@@ -46,23 +46,21 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Commands::Doc { input, output } => {
-            match generate_docs(&input) {
-                Ok(doc) => {
-                    if let Err(e) = fs::write(&output, doc) {
-                        eprintln!("error: {}", e);
-                        std::process::exit(1);
-                    }
-                },
-                Err(e) => {
+        Commands::Doc { input, output } => match generate_docs(&input) {
+            Ok(doc) => {
+                if let Err(e) = fs::write(&output, doc) {
                     eprintln!("error: {}", e);
                     std::process::exit(1);
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("error: {}", e);
+                std::process::exit(1);
+            }
+        },
         Commands::Run { input, args } => {
-            
-            let run_id = std::env::var("AION_RUN_ID").unwrap_or_else(|_| std::process::id().to_string());
+            let run_id =
+                std::env::var("AION_RUN_ID").unwrap_or_else(|_| std::process::id().to_string());
             let ir_file = format!("temp_{}.ll", run_id);
             let obj_file = format!("temp_{}.o", run_id);
             let bin_file = format!("./aion_app_{}", run_id);
@@ -74,7 +72,13 @@ fn main() {
 
             // Fix: Add PIC relocation model for modern Linux compatibility
             let llc_status = Command::new("llc-15")
-                .args(["-filetype=obj", "-relocation-model=pic", &ir_file, "-o", &obj_file])
+                .args([
+                    "-filetype=obj",
+                    "-relocation-model=pic",
+                    &ir_file,
+                    "-o",
+                    &obj_file,
+                ])
                 .status();
 
             if let Err(e) = llc_status {
@@ -86,7 +90,14 @@ fn main() {
             }
 
             let gcc_status = Command::new("gcc")
-                .args([&obj_file, "src/runtime.c", "-o", &bin_file, "-lpthread", "-lgc"])
+                .args([
+                    &obj_file,
+                    "src/runtime.c",
+                    "-o",
+                    &bin_file,
+                    "-lpthread",
+                    "-lgc",
+                ])
                 .status();
 
             if let Err(e) = gcc_status {
@@ -98,18 +109,19 @@ fn main() {
             }
 
             println!("-------------------------------");
-            let output = Command::new(&bin_file)
-                .args(&args)
-                .output();
-            
+            let output = Command::new(&bin_file).args(&args).output();
+
             match output {
                 Ok(out) => {
                     print!("{}", String::from_utf8_lossy(&out.stdout));
                     eprint!("{}", String::from_utf8_lossy(&out.stderr));
                     if !out.status.success() {
-                        eprintln!("error: process exited with code: {}", out.status.code().unwrap_or(-1));
+                        eprintln!(
+                            "error: process exited with code: {}",
+                            out.status.code().unwrap_or(-1)
+                        );
                     }
-                },
+                }
                 Err(e) => eprintln!("error: execution failed: {}", e),
             }
             println!("-------------------------------");
@@ -118,19 +130,23 @@ fn main() {
             let _ = fs::remove_file(obj_file);
             let _ = fs::remove_file(bin_file);
         }
-        Commands::Transpile { input, output, target } => {
+        Commands::Transpile {
+            input,
+            output,
+            target,
+        } => {
             if target != "sql" {
                 eprintln!("error: only SQL target is supported for now");
                 return;
             }
-            
+
             match transpile_sql(&input) {
                 Ok(sql) => {
                     if let Err(e) = fs::write(&output, sql) {
                         eprintln!("error: {}", e);
                         std::process::exit(1);
                     }
-                },
+                }
                 Err(e) => eprintln!("error: {}", e),
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,7 @@
-use crate::lexer::token::{Token, TokenKind};
-use crate::lexer::Lexer;
 use crate::ast::*;
 use crate::error::CompileError;
+use crate::lexer::Lexer;
+use crate::lexer::token::{Token, TokenKind};
 
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
@@ -13,7 +13,12 @@ pub struct Parser<'a> {
 impl<'a> Parser<'a> {
     pub fn new(mut lexer: Lexer<'a>) -> Self {
         let current_token = lexer.next_token();
-        Self { lexer, current_token, peek_buffer: Vec::new(), errors: Vec::new() }
+        Self {
+            lexer,
+            current_token,
+            peek_buffer: Vec::new(),
+            errors: Vec::new(),
+        }
     }
 
     fn next_token(&mut self) {
@@ -25,7 +30,10 @@ impl<'a> Parser<'a> {
     }
 
     fn error(&self, message: &str) -> String {
-        format!("{} at line {}, col {}", message, self.current_token.line, self.current_token.col)
+        format!(
+            "{} at line {}, col {}",
+            message, self.current_token.line, self.current_token.col
+        )
     }
 
     fn push_error(&mut self, message: impl Into<String>) {
@@ -55,8 +63,10 @@ impl<'a> Parser<'a> {
                     self.next_token();
                     let path = self.parse_path();
                     module_name = Some(path.join("."));
-                    if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                },
+                    if self.current_token.kind == TokenKind::Semicolon {
+                        self.next_token();
+                    }
+                }
                 TokenKind::Use => imports.push(self.parse_import()),
                 TokenKind::DoubleColon => {
                     if self.peek_at(0).kind == TokenKind::Intent {
@@ -69,7 +79,7 @@ impl<'a> Parser<'a> {
                         self.push_error("Syntax Error: Unexpected :: at top level");
                         self.next_token();
                     }
-                },
+                }
                 _ => {
                     if let Some(decl) = self.parse_declaration() {
                         declarations.push(decl);
@@ -77,11 +87,15 @@ impl<'a> Parser<'a> {
                         self.push_error("Syntax Error: Unexpected token in declaration");
                         self.next_token();
                     }
-                },
+                }
             }
         }
         if self.errors.is_empty() {
-            Ok(Program { module_name, imports, declarations })
+            Ok(Program {
+                module_name,
+                imports,
+                declarations,
+            })
         } else {
             Err(std::mem::take(&mut self.errors))
         }
@@ -94,9 +108,9 @@ impl<'a> Parser<'a> {
             self.next_token();
             while self.current_token.kind == TokenKind::Dot {
                 self.next_token();
-                if let TokenKind::Identifier(sub) = &self.current_token.kind { 
-                    path.push(sub.clone()); 
-                    self.next_token(); 
+                if let TokenKind::Identifier(sub) = &self.current_token.kind {
+                    path.push(sub.clone());
+                    self.next_token();
                 } else {
                     break;
                 }
@@ -108,7 +122,9 @@ impl<'a> Parser<'a> {
     fn parse_import(&mut self) -> Import {
         self.next_token();
         let path = self.parse_path();
-        if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
+        if self.current_token.kind == TokenKind::Semicolon {
+            self.next_token();
+        }
         Import { path, alias: None }
     }
 
@@ -130,11 +146,13 @@ impl<'a> Parser<'a> {
                 let mut attr_val = String::new();
                 if self.current_token.kind == TokenKind::LParen {
                     self.next_token();
-                    if let TokenKind::StringLiteral(s) = &self.current_token.kind { 
-                        attr_val = s.clone(); 
-                        self.next_token(); 
+                    if let TokenKind::StringLiteral(s) = &self.current_token.kind {
+                        attr_val = s.clone();
+                        self.next_token();
                     }
-                    if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                    if self.current_token.kind == TokenKind::RParen {
+                        self.next_token();
+                    }
                 }
                 attributes.push((attr_name, attr_val));
             } else {
@@ -142,15 +160,24 @@ impl<'a> Parser<'a> {
             }
         }
         let mut modifiers = Vec::new();
-        while matches!(self.current_token.kind, TokenKind::Pub | TokenKind::Async | TokenKind::Unsafe | TokenKind::Extern) {
+        while matches!(
+            self.current_token.kind,
+            TokenKind::Pub | TokenKind::Async | TokenKind::Unsafe | TokenKind::Extern
+        ) {
             modifiers.push(self.current_token.clone());
             self.next_token();
         }
         match self.current_token.kind {
-            TokenKind::Fn => self.parse_function(modifiers, attributes, doc_comment).map(Declaration::Function),
-            TokenKind::Struct => self.parse_struct(attributes, doc_comment).map(Declaration::Struct),
+            TokenKind::Fn => self
+                .parse_function(modifiers, attributes, doc_comment)
+                .map(Declaration::Function),
+            TokenKind::Struct => self
+                .parse_struct(attributes, doc_comment)
+                .map(Declaration::Struct),
             TokenKind::Enum => self.parse_enum(doc_comment).map(Declaration::Enum),
-            TokenKind::Interface => self.parse_interface(doc_comment).map(Declaration::Interface),
+            TokenKind::Interface => self
+                .parse_interface(doc_comment)
+                .map(Declaration::Interface),
             TokenKind::Impl => self.parse_impl().map(Declaration::Impl),
             _ => None,
         }
@@ -158,24 +185,37 @@ impl<'a> Parser<'a> {
 
     fn parse_impl(&mut self) -> Option<ImplBlock> {
         self.next_token();
-        let name1 = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+        let name1 = match &self.current_token.kind {
+            TokenKind::Identifier(n) => n.clone(),
+            _ => return None,
+        };
         self.next_token();
         let generic_params = self.parse_generic_params();
-        
-        let (interface_name, target_name) = if self.current_token.kind == TokenKind::For {
-                self.next_token();
-                let target = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
-                self.next_token();
-                (Some(name1), target)
-        } else { (None, name1) };
 
-        if self.current_token.kind != TokenKind::LBrace { 
-            eprintln!("{}", self.error("Syntax Error: Expected '{' after impl target"));
-            return None; 
+        let (interface_name, target_name) = if self.current_token.kind == TokenKind::For {
+            self.next_token();
+            let target = match &self.current_token.kind {
+                TokenKind::Identifier(n) => n.clone(),
+                _ => return None,
+            };
+            self.next_token();
+            (Some(name1), target)
+        } else {
+            (None, name1)
+        };
+
+        if self.current_token.kind != TokenKind::LBrace {
+            eprintln!(
+                "{}",
+                self.error("Syntax Error: Expected '{' after impl target")
+            );
+            return None;
         }
         self.next_token();
         let mut functions = Vec::new();
-        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+        while self.current_token.kind != TokenKind::RBrace
+            && self.current_token.kind != TokenKind::EOF
+        {
             let mut method_doc = None;
             while let TokenKind::DocComment(_) = &self.current_token.kind {
                 if let TokenKind::DocComment(text) = &self.current_token.kind {
@@ -184,71 +224,125 @@ impl<'a> Parser<'a> {
                 self.next_token();
             }
             let mut modifiers = Vec::new();
-            while matches!(self.current_token.kind, TokenKind::Pub | TokenKind::Async | TokenKind::Unsafe) {
+            while matches!(
+                self.current_token.kind,
+                TokenKind::Pub | TokenKind::Async | TokenKind::Unsafe
+            ) {
                 modifiers.push(self.current_token.clone());
                 self.next_token();
             }
             if self.current_token.kind == TokenKind::Fn {
-                if let Some(f) = self.parse_function(modifiers, vec![], method_doc) { functions.push(f); }
+                if let Some(f) = self.parse_function(modifiers, vec![], method_doc) {
+                    functions.push(f);
+                }
             } else {
                 self.next_token();
             }
         }
-        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-        Some(ImplBlock { target_name, generic_params, interface_name, functions })
+        if self.current_token.kind == TokenKind::RBrace {
+            self.next_token();
+        }
+        Some(ImplBlock {
+            target_name,
+            generic_params,
+            interface_name,
+            functions,
+        })
     }
 
     fn parse_generic_params(&mut self) -> Vec<String> {
         let mut params = Vec::new();
         if self.current_token.kind == TokenKind::Lt {
             self.next_token();
-            while self.current_token.kind != TokenKind::Gt && self.current_token.kind != TokenKind::EOF {
-                if let TokenKind::Identifier(id) = &self.current_token.kind { params.push(id.clone()); self.next_token(); }
-                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+            while self.current_token.kind != TokenKind::Gt
+                && self.current_token.kind != TokenKind::EOF
+            {
+                if let TokenKind::Identifier(id) = &self.current_token.kind {
+                    params.push(id.clone());
+                    self.next_token();
+                }
+                if self.current_token.kind == TokenKind::Comma {
+                    self.next_token();
+                }
             }
-            if self.current_token.kind == TokenKind::Gt { self.next_token(); }
+            if self.current_token.kind == TokenKind::Gt {
+                self.next_token();
+            }
         }
         params
     }
 
     fn parse_enum(&mut self, doc_comment: Option<String>) -> Option<Enum> {
         self.next_token();
-        let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+        let name = match &self.current_token.kind {
+            TokenKind::Identifier(n) => n.clone(),
+            _ => return None,
+        };
         self.next_token();
         let generic_params = self.parse_generic_params();
-        if self.current_token.kind != TokenKind::LBrace { return None; }
+        if self.current_token.kind != TokenKind::LBrace {
+            return None;
+        }
         self.next_token();
         let mut variants = Vec::new();
-        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+        while self.current_token.kind != TokenKind::RBrace
+            && self.current_token.kind != TokenKind::EOF
+        {
             if let TokenKind::Identifier(v_name) = &self.current_token.kind {
-                let v_name = v_name.clone(); self.next_token();
+                let v_name = v_name.clone();
+                self.next_token();
                 let mut data_types = Vec::new();
                 if self.current_token.kind == TokenKind::LParen {
                     self.next_token();
-                    while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                    while self.current_token.kind != TokenKind::RParen
+                        && self.current_token.kind != TokenKind::EOF
+                    {
                         data_types.push(self.parse_type_name());
-                        if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                        if self.current_token.kind == TokenKind::Comma {
+                            self.next_token();
+                        }
                     }
-                    if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                    if self.current_token.kind == TokenKind::RParen {
+                        self.next_token();
+                    }
                 }
-                variants.push(EnumVariant { name: v_name, data_types });
+                variants.push(EnumVariant {
+                    name: v_name,
+                    data_types,
+                });
             } else if self.current_token.kind != TokenKind::Comma {
                 self.next_token();
             }
-            if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+            if self.current_token.kind == TokenKind::Comma {
+                self.next_token();
+            }
         }
-        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-        Some(Enum { name, generic_params, variants, doc_comment })
+        if self.current_token.kind == TokenKind::RBrace {
+            self.next_token();
+        }
+        Some(Enum {
+            name,
+            generic_params,
+            variants,
+            doc_comment,
+        })
     }
 
     fn parse_interface(&mut self, doc_comment: Option<String>) -> Option<Interface> {
         self.next_token();
-        let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+        let name = match &self.current_token.kind {
+            TokenKind::Identifier(n) => n.clone(),
+            _ => return None,
+        };
         self.next_token();
-        if self.current_token.kind != TokenKind::LBrace { return None; }
+        if self.current_token.kind != TokenKind::LBrace {
+            return None;
+        }
         self.next_token();
         let mut methods = Vec::new();
-        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+        while self.current_token.kind != TokenKind::RBrace
+            && self.current_token.kind != TokenKind::EOF
+        {
             let mut method_doc = None;
             while let TokenKind::DocComment(_) = &self.current_token.kind {
                 if let TokenKind::DocComment(text) = &self.current_token.kind {
@@ -256,34 +350,66 @@ impl<'a> Parser<'a> {
                 }
                 self.next_token();
             }
-            if let Some(f) = self.parse_function(vec![], vec![], method_doc) { methods.push(f); }
-            if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
+            if let Some(f) = self.parse_function(vec![], vec![], method_doc) {
+                methods.push(f);
+            }
+            if self.current_token.kind == TokenKind::Semicolon {
+                self.next_token();
+            }
         }
-        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-        Some(Interface { name, methods, doc_comment })
+        if self.current_token.kind == TokenKind::RBrace {
+            self.next_token();
+        }
+        Some(Interface {
+            name,
+            methods,
+            doc_comment,
+        })
     }
 
-    fn parse_struct(&mut self, attributes: Vec<(String, String)>, doc_comment: Option<String>) -> Option<Struct> {
+    fn parse_struct(
+        &mut self,
+        attributes: Vec<(String, String)>,
+        doc_comment: Option<String>,
+    ) -> Option<Struct> {
         self.next_token();
-        let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+        let name = match &self.current_token.kind {
+            TokenKind::Identifier(n) => n.clone(),
+            _ => return None,
+        };
         self.next_token();
         let generic_params = self.parse_generic_params();
-        if self.current_token.kind != TokenKind::LBrace { return None; }
+        if self.current_token.kind != TokenKind::LBrace {
+            return None;
+        }
         self.next_token();
         let mut fields = Vec::new();
-        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+        while self.current_token.kind != TokenKind::RBrace
+            && self.current_token.kind != TokenKind::EOF
+        {
             if let TokenKind::Identifier(f_name) = &self.current_token.kind {
-                let f_name = f_name.clone(); self.next_token();
+                let f_name = f_name.clone();
+                self.next_token();
                 if self.current_token.kind == TokenKind::Colon {
                     self.next_token();
                     fields.push((f_name, self.parse_type_name()));
                 }
             }
-            if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+            if self.current_token.kind == TokenKind::Comma {
+                self.next_token();
+            }
         }
-        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-        let attrs = attributes.into_iter().map(|(k,_)| k).collect();
-        Some(Struct { name, generic_params, fields, attributes: attrs, doc_comment })
+        if self.current_token.kind == TokenKind::RBrace {
+            self.next_token();
+        }
+        let attrs = attributes.into_iter().map(|(k, _)| k).collect();
+        Some(Struct {
+            name,
+            generic_params,
+            fields,
+            attributes: attrs,
+            doc_comment,
+        })
     }
 
     fn parse_type_name(&mut self) -> String {
@@ -301,13 +427,16 @@ impl<'a> Parser<'a> {
             self.next_token();
             return format!("invalid_type_{:?}", tok);
         }
-        
-        while self.current_token.kind == TokenKind::Dot || self.current_token.kind == TokenKind::DoubleColon {
+
+        while self.current_token.kind == TokenKind::Dot
+            || self.current_token.kind == TokenKind::DoubleColon
+        {
             if let TokenKind::Identifier(_) = self.peek_at(0).kind {
                 self.next_token();
-                if let TokenKind::Identifier(sub) = &self.current_token.kind { 
-                    full_type.push('.'); full_type.push_str(sub); 
-                    self.next_token(); 
+                if let TokenKind::Identifier(sub) = &self.current_token.kind {
+                    full_type.push('.');
+                    full_type.push_str(sub);
+                    self.next_token();
                 }
             } else {
                 break;
@@ -317,10 +446,12 @@ impl<'a> Parser<'a> {
         if self.current_token.kind == TokenKind::Lt {
             full_type.push('<');
             self.next_token();
-            while self.current_token.kind != TokenKind::Gt && self.current_token.kind != TokenKind::EOF {
+            while self.current_token.kind != TokenKind::Gt
+                && self.current_token.kind != TokenKind::EOF
+            {
                 let sub_type = self.parse_type_name();
                 full_type.push_str(&sub_type);
-                
+
                 if self.current_token.kind == TokenKind::Comma {
                     full_type.push_str(", ");
                     self.next_token();
@@ -339,16 +470,26 @@ impl<'a> Parser<'a> {
         full_type
     }
 
-    fn parse_function(&mut self, modifiers: Vec<Token>, attributes: Vec<(String, String)>, doc_comment: Option<String>) -> Option<Function> {
+    fn parse_function(
+        &mut self,
+        modifiers: Vec<Token>,
+        attributes: Vec<(String, String)>,
+        doc_comment: Option<String>,
+    ) -> Option<Function> {
         self.next_token();
-        let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+        let name = match &self.current_token.kind {
+            TokenKind::Identifier(n) => n.clone(),
+            _ => return None,
+        };
         self.next_token();
         let generic_params = self.parse_generic_params();
-        
+
         let mut params = Vec::new();
         if self.current_token.kind == TokenKind::LParen {
             self.next_token();
-            while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+            while self.current_token.kind != TokenKind::RParen
+                && self.current_token.kind != TokenKind::EOF
+            {
                 if self.current_token.kind == TokenKind::SelfToken {
                     params.push(("self".to_string(), "Self".to_string(), None));
                     self.next_token();
@@ -383,12 +524,16 @@ impl<'a> Parser<'a> {
                 } else {
                     self.next_token();
                 }
-                
-                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+
+                if self.current_token.kind == TokenKind::Comma {
+                    self.next_token();
+                }
             }
-            if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+            if self.current_token.kind == TokenKind::RParen {
+                self.next_token();
+            }
         } else {
-            return None; 
+            return None;
         }
 
         let mut return_type = "void".to_string();
@@ -397,33 +542,51 @@ impl<'a> Parser<'a> {
             return_type = self.parse_type_name();
         }
         let mut body = None;
-        if self.current_token.kind == TokenKind::LBrace { 
-            body = Some(self.parse_block()); 
+        if self.current_token.kind == TokenKind::LBrace {
+            body = Some(self.parse_block());
         } else {
             let is_extern = modifiers.iter().any(|m| m.kind == TokenKind::Extern);
             let is_intrinsic = attributes.iter().any(|(k, _)| k == "intrinsic");
-            if (is_extern || is_intrinsic)
-                && self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
+            if (is_extern || is_intrinsic) && self.current_token.kind == TokenKind::Semicolon {
+                self.next_token();
+            }
         }
-        Some(Function { name, generic_params, params, return_type, body, modifiers, attributes, doc_comment })
+        Some(Function {
+            name,
+            generic_params,
+            params,
+            return_type,
+            body,
+            modifiers,
+            attributes,
+            doc_comment,
+        })
     }
 
     fn parse_block(&mut self) -> Vec<Statement> {
         let mut stmts = Vec::new();
-        if self.current_token.kind == TokenKind::LBrace { self.next_token(); }
-        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+        if self.current_token.kind == TokenKind::LBrace {
+            self.next_token();
+        }
+        while self.current_token.kind != TokenKind::RBrace
+            && self.current_token.kind != TokenKind::EOF
+        {
             if self.current_token.kind == TokenKind::Semicolon {
                 self.next_token();
                 continue;
             }
-            if let Some(s) = self.parse_statement() { 
-                stmts.push(s); 
+            if let Some(s) = self.parse_statement() {
+                stmts.push(s);
             } else {
                 self.next_token();
             }
-            if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
+            if self.current_token.kind == TokenKind::Semicolon {
+                self.next_token();
+            }
         }
-        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
+        if self.current_token.kind == TokenKind::RBrace {
+            self.next_token();
+        }
         stmts
     }
 
@@ -441,36 +604,65 @@ impl<'a> Parser<'a> {
                     let span = Span::from_token(&self.current_token);
                     Some(Statement::ExpressionStmt(self.parse_expression(), span))
                 }
-            },
+            }
             TokenKind::Let => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
-                let is_mut = if self.current_token.kind == TokenKind::Mut { self.next_token(); true } else { false };
-                let name = match &self.current_token.kind { TokenKind::Identifier(n) => n.clone(), _ => return None };
+                let is_mut = if self.current_token.kind == TokenKind::Mut {
+                    self.next_token();
+                    true
+                } else {
+                    false
+                };
+                let name = match &self.current_token.kind {
+                    TokenKind::Identifier(n) => n.clone(),
+                    _ => return None,
+                };
                 self.next_token();
                 let explicit_type = if self.current_token.kind == TokenKind::Colon {
                     self.next_token();
                     Some(self.parse_type_name())
-                } else { None };
+                } else {
+                    None
+                };
                 if self.current_token.kind == TokenKind::Eq {
                     self.next_token();
                     let value = self.parse_expression();
-                    if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::Let { name, value, explicit_type, intent: None, is_mut, span })
-                } else { None }
-            },
-            TokenKind::Return => { 
+                    if self.current_token.kind == TokenKind::Semicolon {
+                        self.next_token();
+                    }
+                    Some(Statement::Let {
+                        name,
+                        value,
+                        explicit_type,
+                        intent: None,
+                        is_mut,
+                        span,
+                    })
+                } else {
+                    None
+                }
+            }
+            TokenKind::Return => {
                 let span = Span::from_token(&self.current_token);
-                self.next_token(); 
-                let value = if self.current_token.kind == TokenKind::Semicolon || self.current_token.kind == TokenKind::RBrace {
+                self.next_token();
+                let value = if self.current_token.kind == TokenKind::Semicolon
+                    || self.current_token.kind == TokenKind::RBrace
+                {
                     Expression::Integer(0, Span::zero())
                 } else {
                     self.parse_expression()
                 };
-                if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                let stmt = Statement::Return { value, intent: None, span };
+                if self.current_token.kind == TokenKind::Semicolon {
+                    self.next_token();
+                }
+                let stmt = Statement::Return {
+                    value,
+                    intent: None,
+                    span,
+                };
                 Some(stmt)
-            },
+            }
             TokenKind::If => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -487,57 +679,80 @@ impl<'a> Parser<'a> {
                         else_branch = Some(self.parse_block());
                     }
                 }
-                Some(Statement::If { condition, then_branch, else_branch, span })
-            },
+                Some(Statement::If {
+                    condition,
+                    then_branch,
+                    else_branch,
+                    span,
+                })
+            }
             TokenKind::While => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
                 let body = self.parse_block();
-                Some(Statement::While { condition, body, span })
-            },
+                Some(Statement::While {
+                    condition,
+                    body,
+                    span,
+                })
+            }
             TokenKind::Break => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Some(Statement::Break(span))
-            },
+            }
             TokenKind::Continue => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Some(Statement::Continue(span))
-            },
+            }
             TokenKind::Loop => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let body = self.parse_block();
                 let condition = Expression::Boolean(true, span.clone());
-                Some(Statement::While { condition, body, span })
-            },
+                Some(Statement::While {
+                    condition,
+                    body,
+                    span,
+                })
+            }
             TokenKind::Match => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
-                if self.current_token.kind != TokenKind::LBrace { return None; }
+                if self.current_token.kind != TokenKind::LBrace {
+                    return None;
+                }
                 self.next_token();
                 let mut arms = Vec::new();
-                while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+                while self.current_token.kind != TokenKind::RBrace
+                    && self.current_token.kind != TokenKind::EOF
+                {
                     let mut pattern = String::new();
                     let mut is_valid_pattern = false;
-                    
+
                     match &self.current_token.kind {
                         TokenKind::Identifier(p) => {
-                            pattern = p.clone(); 
+                            pattern = p.clone();
                             self.next_token();
                             let mut struct_fields: Vec<(String, String)> = Vec::new();
                             if self.current_token.kind == TokenKind::LBrace {
                                 self.next_token();
-                                while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
-                                    if let TokenKind::Identifier(field_name) = &self.current_token.kind {
+                                while self.current_token.kind != TokenKind::RBrace
+                                    && self.current_token.kind != TokenKind::EOF
+                                {
+                                    if let TokenKind::Identifier(field_name) =
+                                        &self.current_token.kind
+                                    {
                                         let fn_str = field_name.clone();
                                         self.next_token();
                                         if self.current_token.kind == TokenKind::Colon {
                                             self.next_token();
-                                            if let TokenKind::Identifier(var_name) = &self.current_token.kind {
+                                            if let TokenKind::Identifier(var_name) =
+                                                &self.current_token.kind
+                                            {
                                                 struct_fields.push((fn_str, var_name.clone()));
                                                 self.next_token();
                                             }
@@ -552,24 +767,33 @@ impl<'a> Parser<'a> {
                                 }
                             }
                             if !struct_fields.is_empty() {
-                                let fields_str = struct_fields.iter()
+                                let fields_str = struct_fields
+                                    .iter()
                                     .map(|(f, v)| format!("{}:{}", f, v))
                                     .collect::<Vec<_>>()
                                     .join(",");
                                 pattern = format!("{}_{{{}}}", pattern, fields_str);
                             }
-                            
-                            while self.current_token.kind == TokenKind::DoubleColon || self.current_token.kind == TokenKind::Dot {
-                                let op = if self.current_token.kind == TokenKind::DoubleColon { "::" } else { "." };
+
+                            while self.current_token.kind == TokenKind::DoubleColon
+                                || self.current_token.kind == TokenKind::Dot
+                            {
+                                let op = if self.current_token.kind == TokenKind::DoubleColon {
+                                    "::"
+                                } else {
+                                    "."
+                                };
                                 self.next_token();
                                 if let TokenKind::Identifier(sub) = &self.current_token.kind {
                                     pattern.push_str(op);
                                     pattern.push_str(sub);
                                     self.next_token();
-                                } else { break; }
+                                } else {
+                                    break;
+                                }
                             }
                             is_valid_pattern = true;
-                        },
+                        }
                         TokenKind::IntLiteral(n) => {
                             pattern = n.to_string();
                             self.next_token();
@@ -581,15 +805,15 @@ impl<'a> Parser<'a> {
                                 }
                             }
                             is_valid_pattern = true;
-                        },
+                        }
                         TokenKind::StringLiteral(s) => {
                             pattern = format!("\"{}\"", s);
                             self.next_token();
                             is_valid_pattern = true;
-                        },
+                        }
                         TokenKind::Range => {
                             self.next_token();
-                        },
+                        }
                         _ => {
                             self.next_token();
                         }
@@ -600,40 +824,65 @@ impl<'a> Parser<'a> {
                         while self.current_token.kind == TokenKind::Pipe {
                             self.next_token();
                             match &self.current_token.kind {
-                                TokenKind::Identifier(p) => { patterns.push(p.clone()); self.next_token(); },
-                                TokenKind::IntLiteral(n) => { patterns.push(n.to_string()); self.next_token(); },
-                                TokenKind::StringLiteral(s) => { patterns.push(format!("\"{}\"", s)); self.next_token(); },
-                                _ => { break; }
+                                TokenKind::Identifier(p) => {
+                                    patterns.push(p.clone());
+                                    self.next_token();
+                                }
+                                TokenKind::IntLiteral(n) => {
+                                    patterns.push(n.to_string());
+                                    self.next_token();
+                                }
+                                TokenKind::StringLiteral(s) => {
+                                    patterns.push(format!("\"{}\"", s));
+                                    self.next_token();
+                                }
+                                _ => {
+                                    break;
+                                }
                             }
                         }
-                        
+
                         let mut params = Vec::new();
-                        
+
                         if patterns.len() == 1 {
                             let pat = &patterns[0];
-                            let is_lower = !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
-                            let is_identifier = pat.chars().all(|c| c.is_alphanumeric() || c == '_');
+                            let is_lower =
+                                !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
+                            let is_identifier =
+                                pat.chars().all(|c| c.is_alphanumeric() || c == '_');
                             let is_not_underscore = pat != "_";
-                            let followed_by_guard_or_arrow = self.current_token.kind == TokenKind::If || self.current_token.kind == TokenKind::Arrow;
-                            
-                            if is_lower && is_identifier && is_not_underscore && followed_by_guard_or_arrow {
+                            let followed_by_guard_or_arrow = self.current_token.kind
+                                == TokenKind::If
+                                || self.current_token.kind == TokenKind::Arrow;
+
+                            if is_lower
+                                && is_identifier
+                                && is_not_underscore
+                                && followed_by_guard_or_arrow
+                            {
                                 params.push(pat.clone());
                                 patterns.clear();
                             }
                         }
-                        
+
                         if self.current_token.kind == TokenKind::LParen {
                             self.next_token();
-                            while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                            while self.current_token.kind != TokenKind::RParen
+                                && self.current_token.kind != TokenKind::EOF
+                            {
                                 if let TokenKind::Identifier(param) = &self.current_token.kind {
                                     params.push(param.clone());
                                     self.next_token();
                                 } else {
                                     self.next_token();
                                 }
-                                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                                if self.current_token.kind == TokenKind::Comma {
+                                    self.next_token();
+                                }
                             }
-                            if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                            if self.current_token.kind == TokenKind::RParen {
+                                self.next_token();
+                            }
                         }
 
                         let guard = if self.current_token.kind == TokenKind::If {
@@ -645,20 +894,36 @@ impl<'a> Parser<'a> {
 
                         if self.current_token.kind == TokenKind::Arrow {
                             self.next_token();
-                            let body = if self.current_token.kind == TokenKind::LBrace { self.parse_block() } else {
+                            let body = if self.current_token.kind == TokenKind::LBrace {
+                                self.parse_block()
+                            } else {
                                 match self.parse_statement() {
                                     Some(s) => vec![s],
                                     None => vec![],
                                 }
                             };
-                            arms.push(MatchArm { pattern, patterns, guard, params, body });
+                            arms.push(MatchArm {
+                                pattern,
+                                patterns,
+                                guard,
+                                params,
+                                body,
+                            });
                         }
                     }
-                    if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                    if self.current_token.kind == TokenKind::Comma {
+                        self.next_token();
+                    }
                 }
-                if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-                Some(Statement::Match { condition, arms, span })
-            },
+                if self.current_token.kind == TokenKind::RBrace {
+                    self.next_token();
+                }
+                Some(Statement::Match {
+                    condition,
+                    arms,
+                    span,
+                })
+            }
             TokenKind::Unsafe => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -667,7 +932,7 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 }
-            },
+            }
             TokenKind::Spawn => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -676,20 +941,28 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 }
-            },
+            }
             _ => {
                 let span = Span::from_token(&self.current_token);
                 let expr = self.parse_expression();
                 if self.current_token.kind == TokenKind::Eq {
                     self.next_token();
                     let value = self.parse_expression();
-                    if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
-                    Some(Statement::Assignment { target: expr, value, span })
+                    if self.current_token.kind == TokenKind::Semicolon {
+                        self.next_token();
+                    }
+                    Some(Statement::Assignment {
+                        target: expr,
+                        value,
+                        span,
+                    })
                 } else {
-                    if self.current_token.kind == TokenKind::Semicolon { self.next_token(); }
+                    if self.current_token.kind == TokenKind::Semicolon {
+                        self.next_token();
+                    }
                     Some(Statement::ExpressionStmt(expr, span))
                 }
-            },
+            }
         }
     }
 
@@ -704,32 +977,59 @@ impl<'a> Parser<'a> {
             let op = self.current_token.clone();
             let op_prec = self.get_precedence();
             self.next_token();
-                
+
             if op.kind == TokenKind::As {
                 let target = self.parse_type_name();
-                left = Expression::Cast { expr: Box::new(left), target, span: Span::from_token(&op) };
+                left = Expression::Cast {
+                    expr: Box::new(left),
+                    target,
+                    span: Span::from_token(&op),
+                };
                 continue;
             }
 
             if op.kind == TokenKind::Pipeline {
                 let right = self.parse_infix(1);
                 left = match right {
-                    Expression::Call { function, mut arguments, generic_args, .. } => {
+                    Expression::Call {
+                        function,
+                        mut arguments,
+                        generic_args,
+                        ..
+                    } => {
                         arguments.insert(0, left);
-                        Expression::Call { function, generic_args, arguments, span: Span::from_token(&op) }
-                    },
-                    Expression::Identifier(function, _) => {
-                        Expression::Call { function, generic_args: vec![], arguments: vec![left], span: Span::from_token(&op) }
+                        Expression::Call {
+                            function,
+                            generic_args,
+                            arguments,
+                            span: Span::from_token(&op),
+                        }
+                    }
+                    Expression::Identifier(function, _) => Expression::Call {
+                        function,
+                        generic_args: vec![],
+                        arguments: vec![left],
+                        span: Span::from_token(&op),
                     },
                     _ => {
                         let op_span = Span::from_token(&op);
-                        Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right), span: op_span }
+                        Expression::Infix {
+                            left: Box::new(left),
+                            operator: op,
+                            right: Box::new(right),
+                            span: op_span,
+                        }
                     }
                 };
             } else {
                 let right = self.parse_infix(op_prec);
                 let op_span = Span::from_token(&op);
-                left = Expression::Infix { left: Box::new(left), operator: op, right: Box::new(right), span: op_span };
+                left = Expression::Infix {
+                    left: Box::new(left),
+                    operator: op,
+                    right: Box::new(right),
+                    span: op_span,
+                };
             }
         }
         left
@@ -742,7 +1042,13 @@ impl<'a> Parser<'a> {
             TokenKind::Plus | TokenKind::Minus => 6,
             TokenKind::Range => 5,
             TokenKind::Caret => 5,
-            TokenKind::Gt | TokenKind::Lt | TokenKind::GtEq | TokenKind::LtEq | TokenKind::EqEq | TokenKind::NotEq | TokenKind::Inside => 4,
+            TokenKind::Gt
+            | TokenKind::Lt
+            | TokenKind::GtEq
+            | TokenKind::LtEq
+            | TokenKind::EqEq
+            | TokenKind::NotEq
+            | TokenKind::Inside => 4,
             TokenKind::And => 3,
             TokenKind::Or => 2,
             TokenKind::Pipeline => 1,
@@ -750,48 +1056,63 @@ impl<'a> Parser<'a> {
         }
     }
 
-        fn is_generic_args_ahead(&mut self) -> bool {
-            if self.current_token.kind != TokenKind::Lt { return false; }
-            let mut i = 0;
-            let mut angle_count = 1;
-            
-            while angle_count > 0 {
-                let tok = self.peek_at(i);
-                match tok.kind {
-                    // Tokens that cannot appear inside a generic-argument list but do
-                    // appear in a less-than comparison context. Comma is intentionally
-                    // NOT here: Aion has no comma operator at the expression level, and
-                    // `foo<A, B>(...)` needs the comma to keep scanning. Less-than inside
-                    // call/struct/aggregate args is still rejected because RParen/LBrace
-                    // abort the scan before the angles can balance.
-                    TokenKind::EOF | TokenKind::LBrace | TokenKind::Semicolon | TokenKind::Eq | 
-                    TokenKind::Or | TokenKind::And | TokenKind::Plus | TokenKind::Minus | 
-                    TokenKind::RParen => return false,
-                    TokenKind::Lt => angle_count += 1,
-                    TokenKind::Gt => angle_count -= 1,
-                    _ => {}
-                }
-                i += 1;
-                if i > 50 { return false; } 
-            }
-            true
+    fn is_generic_args_ahead(&mut self) -> bool {
+        if self.current_token.kind != TokenKind::Lt {
+            return false;
         }
-    
+        let mut i = 0;
+        let mut angle_count = 1;
+
+        while angle_count > 0 {
+            let tok = self.peek_at(i);
+            match tok.kind {
+                // Tokens that cannot appear inside a generic-argument list but do
+                // appear in a less-than comparison context. Comma is intentionally
+                // NOT here: Aion has no comma operator at the expression level, and
+                // `foo<A, B>(...)` needs the comma to keep scanning. Less-than inside
+                // call/struct/aggregate args is still rejected because RParen/LBrace
+                // abort the scan before the angles can balance.
+                TokenKind::EOF
+                | TokenKind::LBrace
+                | TokenKind::Semicolon
+                | TokenKind::Eq
+                | TokenKind::Or
+                | TokenKind::And
+                | TokenKind::Plus
+                | TokenKind::Minus
+                | TokenKind::RParen => return false,
+                TokenKind::Lt => angle_count += 1,
+                TokenKind::Gt => angle_count -= 1,
+                _ => {}
+            }
+            i += 1;
+            if i > 50 {
+                return false;
+            }
+        }
+        true
+    }
 
     fn parse_generic_args(&mut self) -> Vec<String> {
         let mut args = Vec::new();
         if self.is_generic_args_ahead() {
             self.next_token();
-            while self.current_token.kind != TokenKind::Gt && self.current_token.kind != TokenKind::EOF {
-                if let TokenKind::Identifier(id) = &self.current_token.kind { 
-                    args.push(id.clone()); 
-                    self.next_token(); 
+            while self.current_token.kind != TokenKind::Gt
+                && self.current_token.kind != TokenKind::EOF
+            {
+                if let TokenKind::Identifier(id) = &self.current_token.kind {
+                    args.push(id.clone());
+                    self.next_token();
                 } else {
                     self.next_token();
                 }
-                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                if self.current_token.kind == TokenKind::Comma {
+                    self.next_token();
+                }
             }
-            if self.current_token.kind == TokenKind::Gt { self.next_token(); }
+            if self.current_token.kind == TokenKind::Gt {
+                self.next_token();
+            }
         }
         args
     }
@@ -814,35 +1135,52 @@ impl<'a> Parser<'a> {
                         else_branch = Some(self.parse_block());
                     }
                 }
-                Expression::If { condition: Box::new(condition), then_branch, else_branch, span }
-            },
+                Expression::If {
+                    condition: Box::new(condition),
+                    then_branch,
+                    else_branch,
+                    span,
+                }
+            }
             TokenKind::Match => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let condition = self.parse_expression();
-                if self.current_token.kind != TokenKind::LBrace { 
-                    Expression::Match { condition: Box::new(condition), arms: vec![], span }
+                if self.current_token.kind != TokenKind::LBrace {
+                    Expression::Match {
+                        condition: Box::new(condition),
+                        arms: vec![],
+                        span,
+                    }
                 } else {
                     self.next_token();
                     let mut arms = Vec::new();
-                    while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+                    while self.current_token.kind != TokenKind::RBrace
+                        && self.current_token.kind != TokenKind::EOF
+                    {
                         let mut pattern = String::new();
                         let mut is_valid_pattern = false;
-                        
+
                         match &self.current_token.kind {
                             TokenKind::Identifier(p) => {
-                                pattern = p.clone(); 
+                                pattern = p.clone();
                                 self.next_token();
                                 let mut struct_fields: Vec<(String, String)> = Vec::new();
                                 if self.current_token.kind == TokenKind::LBrace {
                                     self.next_token();
-                                    while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
-                                        if let TokenKind::Identifier(field_name) = &self.current_token.kind {
+                                    while self.current_token.kind != TokenKind::RBrace
+                                        && self.current_token.kind != TokenKind::EOF
+                                    {
+                                        if let TokenKind::Identifier(field_name) =
+                                            &self.current_token.kind
+                                        {
                                             let fn_str = field_name.clone();
                                             self.next_token();
                                             if self.current_token.kind == TokenKind::Colon {
                                                 self.next_token();
-                                                if let TokenKind::Identifier(var_name) = &self.current_token.kind {
+                                                if let TokenKind::Identifier(var_name) =
+                                                    &self.current_token.kind
+                                                {
                                                     struct_fields.push((fn_str, var_name.clone()));
                                                     self.next_token();
                                                 }
@@ -857,24 +1195,33 @@ impl<'a> Parser<'a> {
                                     }
                                 }
                                 if !struct_fields.is_empty() {
-                                    let fields_str = struct_fields.iter()
+                                    let fields_str = struct_fields
+                                        .iter()
                                         .map(|(f, v)| format!("{}:{}", f, v))
                                         .collect::<Vec<_>>()
                                         .join(",");
                                     pattern = format!("{}_{{{}}}", pattern, fields_str);
                                 }
-                                
-                                while self.current_token.kind == TokenKind::DoubleColon || self.current_token.kind == TokenKind::Dot {
-                                    let op = if self.current_token.kind == TokenKind::DoubleColon { "::" } else { "." };
+
+                                while self.current_token.kind == TokenKind::DoubleColon
+                                    || self.current_token.kind == TokenKind::Dot
+                                {
+                                    let op = if self.current_token.kind == TokenKind::DoubleColon {
+                                        "::"
+                                    } else {
+                                        "."
+                                    };
                                     self.next_token();
                                     if let TokenKind::Identifier(sub) = &self.current_token.kind {
                                         pattern.push_str(op);
                                         pattern.push_str(sub);
                                         self.next_token();
-                                    } else { break; }
+                                    } else {
+                                        break;
+                                    }
                                 }
                                 is_valid_pattern = true;
-                            },
+                            }
                             TokenKind::IntLiteral(n) => {
                                 pattern = n.to_string();
                                 self.next_token();
@@ -886,15 +1233,15 @@ impl<'a> Parser<'a> {
                                     }
                                 }
                                 is_valid_pattern = true;
-                            },
+                            }
                             TokenKind::StringLiteral(s) => {
                                 pattern = format!("\"{}\"", s);
                                 self.next_token();
                                 is_valid_pattern = true;
-                            },
+                            }
                             TokenKind::Range => {
                                 self.next_token();
-                            },
+                            }
                             _ => {
                                 self.next_token();
                             }
@@ -905,40 +1252,65 @@ impl<'a> Parser<'a> {
                             while self.current_token.kind == TokenKind::Pipe {
                                 self.next_token();
                                 match &self.current_token.kind {
-                                    TokenKind::Identifier(p) => { patterns.push(p.clone()); self.next_token(); },
-                                    TokenKind::IntLiteral(n) => { patterns.push(n.to_string()); self.next_token(); },
-                                    TokenKind::StringLiteral(s) => { patterns.push(format!("\"{}\"", s)); self.next_token(); },
-                                    _ => { break; }
+                                    TokenKind::Identifier(p) => {
+                                        patterns.push(p.clone());
+                                        self.next_token();
+                                    }
+                                    TokenKind::IntLiteral(n) => {
+                                        patterns.push(n.to_string());
+                                        self.next_token();
+                                    }
+                                    TokenKind::StringLiteral(s) => {
+                                        patterns.push(format!("\"{}\"", s));
+                                        self.next_token();
+                                    }
+                                    _ => {
+                                        break;
+                                    }
                                 }
                             }
-                            
+
                             let mut params = Vec::new();
-                            
+
                             if patterns.len() == 1 {
                                 let pat = &patterns[0];
-                                let is_lower = !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
-                                let is_identifier = pat.chars().all(|c| c.is_alphanumeric() || c == '_');
+                                let is_lower =
+                                    !pat.is_empty() && pat.chars().next().unwrap().is_lowercase();
+                                let is_identifier =
+                                    pat.chars().all(|c| c.is_alphanumeric() || c == '_');
                                 let is_not_underscore = pat != "_";
-                                let followed_by_guard_or_arrow = self.current_token.kind == TokenKind::If || self.current_token.kind == TokenKind::Arrow;
-                                
-                                if is_lower && is_identifier && is_not_underscore && followed_by_guard_or_arrow {
+                                let followed_by_guard_or_arrow = self.current_token.kind
+                                    == TokenKind::If
+                                    || self.current_token.kind == TokenKind::Arrow;
+
+                                if is_lower
+                                    && is_identifier
+                                    && is_not_underscore
+                                    && followed_by_guard_or_arrow
+                                {
                                     params.push(pat.clone());
                                     patterns.clear();
                                 }
                             }
-                            
+
                             if self.current_token.kind == TokenKind::LParen {
                                 self.next_token();
-                                while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                                while self.current_token.kind != TokenKind::RParen
+                                    && self.current_token.kind != TokenKind::EOF
+                                {
                                     if let TokenKind::Identifier(param) = &self.current_token.kind {
                                         params.push(param.clone());
                                         self.next_token();
                                     } else {
                                         self.next_token();
                                     }
-                                    if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                                    if self.current_token.kind == TokenKind::Comma {
+                                        self.next_token();
+                                    }
                                 }
-                                if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                                if self.current_token.kind == TokenKind::RParen {
+                                    self.next_token();
+                                }
                             }
 
                             let guard = if self.current_token.kind == TokenKind::If {
@@ -950,62 +1322,91 @@ impl<'a> Parser<'a> {
 
                             if self.current_token.kind == TokenKind::Arrow {
                                 self.next_token();
-                                let body = if self.current_token.kind == TokenKind::LBrace { self.parse_block() } else {
+                                let body = if self.current_token.kind == TokenKind::LBrace {
+                                    self.parse_block()
+                                } else {
                                     match self.parse_statement() {
                                         Some(s) => vec![s],
                                         None => vec![],
                                     }
                                 };
-                                arms.push(MatchArm { pattern, patterns, guard, params, body });
+                                arms.push(MatchArm {
+                                    pattern,
+                                    patterns,
+                                    guard,
+                                    params,
+                                    body,
+                                });
                             }
                         }
-                        if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                        if self.current_token.kind == TokenKind::Comma {
+                            self.next_token();
+                        }
                     }
-                    if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
-                    Expression::Match { condition: Box::new(condition), arms, span }
+                    if self.current_token.kind == TokenKind::RBrace {
+                        self.next_token();
+                    }
+                    Expression::Match {
+                        condition: Box::new(condition),
+                        arms,
+                        span,
+                    }
                 }
-            },
+            }
             TokenKind::LBrace => {
                 let span = Span::from_token(&self.current_token);
-                Expression::Block { statements: self.parse_block(), is_unsafe: false, span }
-            },
+                Expression::Block {
+                    statements: self.parse_block(),
+                    is_unsafe: false,
+                    span,
+                }
+            }
             TokenKind::SelfToken => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Identifier("self".to_string(), span)
-            },
+            }
             TokenKind::Star => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
-                Expression::Deref { expr: Box::new(self.parse_primary()), span }
-            },
+                Expression::Deref {
+                    expr: Box::new(self.parse_primary()),
+                    span,
+                }
+            }
             TokenKind::Bang => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let inner = self.parse_primary();
-                Expression::Infix { 
+                Expression::Infix {
                     left: Box::new(inner),
-                    operator: Token::new(TokenKind::EqEq, self.current_token.line, self.current_token.col),
+                    operator: Token::new(
+                        TokenKind::EqEq,
+                        self.current_token.line,
+                        self.current_token.col,
+                    ),
                     right: Box::new(Expression::Boolean(false, Span::zero())),
                     span,
                 }
-            },
+            }
             TokenKind::LParen => {
                 self.next_token();
                 let e = self.parse_expression();
-                if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                if self.current_token.kind == TokenKind::RParen {
+                    self.next_token();
+                }
                 e
-            },
+            }
             TokenKind::True => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Boolean(true, span)
-            },
+            }
             TokenKind::False => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Boolean(false, span)
-            },
+            }
             TokenKind::Minus => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -1018,47 +1419,51 @@ impl<'a> Parser<'a> {
                 } else {
                     Expression::Infix {
                         left: Box::new(Expression::Integer(0, Span::zero())),
-                        operator: Token::new(TokenKind::Minus, self.current_token.line, self.current_token.col),
+                        operator: Token::new(
+                            TokenKind::Minus,
+                            self.current_token.line,
+                            self.current_token.col,
+                        ),
                         right: Box::new(self.parse_primary()),
                         span,
                     }
                 }
-            },
+            }
             TokenKind::IntLiteral(n) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Integer(n, span)
-            },
+            }
             TokenKind::FloatLiteral(f) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Float(f, span)
-            },
+            }
             TokenKind::StringLiteral(s) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::String(s, span)
-            },
+            }
             TokenKind::CharLiteral(c) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Char(c, span)
-            },
+            }
             TokenKind::FString(s) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 self.parse_fstring(s, span)
-            },
+            }
             TokenKind::DurationLiteral(s, n) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Duration(s, n, span)
-            },
+            }
             TokenKind::DateLiteral(ts) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 Expression::Date(ts, span)
-            },
+            }
             TokenKind::At => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -1067,53 +1472,73 @@ impl<'a> Parser<'a> {
                     if self.current_token.kind == TokenKind::LParen {
                         self.next_token();
                         let mut args = Vec::new();
-                        while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                        while self.current_token.kind != TokenKind::RParen
+                            && self.current_token.kind != TokenKind::EOF
+                        {
                             args.push(self.parse_expression());
-                            if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                            if self.current_token.kind == TokenKind::Comma {
+                                self.next_token();
+                            }
                         }
-                        if self.current_token.kind == TokenKind::RParen { self.next_token(); }
-                        Expression::Intrinsic { name, arguments: args, span }
+                        if self.current_token.kind == TokenKind::RParen {
+                            self.next_token();
+                        }
+                        Expression::Intrinsic {
+                            name,
+                            arguments: args,
+                            span,
+                        }
                     } else {
                         Expression::Identifier(format!("invalid_attribute_{}", name), span)
                     }
                 } else {
                     Expression::Identifier("invalid_at_usage".to_string(), span)
                 }
-            },
+            }
             TokenKind::Unsafe => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 if self.current_token.kind == TokenKind::LBrace {
-                    Expression::Block { statements: self.parse_block(), is_unsafe: true, span }
+                    Expression::Block {
+                        statements: self.parse_block(),
+                        is_unsafe: true,
+                        span,
+                    }
                 } else {
                     Expression::Identifier("invalid_unsafe_usage".to_string(), span)
                 }
-            },
+            }
             TokenKind::Identifier(n) => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let mut full_name = n;
                 while self.current_token.kind == TokenKind::Dot {
                     if let TokenKind::Identifier(sub) = self.peek_at(0).kind {
-                        self.next_token(); 
+                        self.next_token();
                         full_name.push('.');
                         full_name.push_str(&sub);
-                        self.next_token(); 
-                    } else { break; }
+                        self.next_token();
+                    } else {
+                        break;
+                    }
                 }
                 let generic_args = self.parse_generic_args();
                 if generic_args.is_empty() {
                     Expression::Identifier(full_name, span)
                 } else {
-                    Expression::TypeRef { name: full_name, generic_args, span }
+                    Expression::TypeRef {
+                        name: full_name,
+                        generic_args,
+                        span,
+                    }
                 }
-            },
-            _ => { 
+            }
+            _ => {
                 let span = Span::from_token(&self.current_token);
                 let tok = self.current_token.clone();
-                self.next_token(); 
+                self.next_token();
                 Expression::Identifier(format!("invalid_token_{:?}", tok), span)
-            },
+            }
         };
 
         loop {
@@ -1128,38 +1553,58 @@ impl<'a> Parser<'a> {
                         if self.current_token.kind == TokenKind::LParen {
                             self.next_token();
                             let mut args = Vec::new();
-                            while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                            while self.current_token.kind != TokenKind::RParen
+                                && self.current_token.kind != TokenKind::EOF
+                            {
                                 args.push(self.parse_expression());
-                                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                                if self.current_token.kind == TokenKind::Comma {
+                                    self.next_token();
+                                }
                             }
-                            if self.current_token.kind == TokenKind::RParen { self.next_token(); }
-                            
-                            expr = Expression::MethodCall { 
-                                receiver: Box::new(expr.clone()), 
-                                method: member_name, 
-                                generic_args: m_generic_args, 
+                            if self.current_token.kind == TokenKind::RParen {
+                                self.next_token();
+                            }
+
+                            expr = Expression::MethodCall {
+                                receiver: Box::new(expr.clone()),
+                                method: member_name,
+                                generic_args: m_generic_args,
                                 arguments: args,
                                 span: dot_span,
                             };
                         } else {
                             if let Expression::Identifier(ref name, _) = expr {
-                                expr = Expression::Identifier(format!("{}.{}", name, member_name), dot_span);
+                                expr = Expression::Identifier(
+                                    format!("{}.{}", name, member_name),
+                                    dot_span,
+                                );
                             } else if let Expression::TypeRef { ref name, .. } = expr {
-                                expr = Expression::Identifier(format!("{}.{}", name, member_name), dot_span);
+                                expr = Expression::Identifier(
+                                    format!("{}.{}", name, member_name),
+                                    dot_span,
+                                );
                             } else {
-                                expr = Expression::MemberAccess { receiver: Box::new(expr.clone()), member: member_name, span: dot_span };
+                                expr = Expression::MemberAccess {
+                                    receiver: Box::new(expr.clone()),
+                                    member: member_name,
+                                    span: dot_span,
+                                };
                             }
                         }
-                    } else { break; }
-                },
+                    } else {
+                        break;
+                    }
+                }
                 TokenKind::DoubleColon => {
-                    if self.peek_at(0).kind == TokenKind::Intent { break; }
+                    if self.peek_at(0).kind == TokenKind::Intent {
+                        break;
+                    }
                     let dc_span = Span::from_token(&self.current_token);
                     self.next_token();
                     if let TokenKind::Identifier(variant) = self.current_token.clone().kind {
                         let variant_name = variant;
                         self.next_token();
-                        
+
                         let mut m_generic_args = Vec::new();
                         if self.current_token.kind == TokenKind::Lt {
                             m_generic_args = self.parse_generic_args();
@@ -1168,56 +1613,110 @@ impl<'a> Parser<'a> {
                         let mut args = Vec::new();
                         if self.current_token.kind == TokenKind::LParen {
                             self.next_token();
-                            while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                            while self.current_token.kind != TokenKind::RParen
+                                && self.current_token.kind != TokenKind::EOF
+                            {
                                 args.push(self.parse_expression());
-                                if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                                if self.current_token.kind == TokenKind::Comma {
+                                    self.next_token();
+                                }
                             }
-                            if self.current_token.kind == TokenKind::RParen { self.next_token(); }
+                            if self.current_token.kind == TokenKind::RParen {
+                                self.next_token();
+                            }
                         }
                         let (name, mut combined_generic_args) = match expr {
                             Expression::Identifier(ref n, _) => (n.clone(), vec![]),
-                            Expression::TypeRef { ref name, ref generic_args, .. } => (name.clone(), generic_args.clone()),
-                            Expression::EnumInst { ref name, ref variant, ref generic_args, .. } => {
-                                (format!("{}.{}", name, variant), generic_args.clone())
-                            }
+                            Expression::TypeRef {
+                                ref name,
+                                ref generic_args,
+                                ..
+                            } => (name.clone(), generic_args.clone()),
+                            Expression::EnumInst {
+                                ref name,
+                                ref variant,
+                                ref generic_args,
+                                ..
+                            } => (format!("{}.{}", name, variant), generic_args.clone()),
                             _ => ("unknown_enum".to_string(), vec![]),
                         };
                         combined_generic_args.extend(m_generic_args);
-                        expr = Expression::EnumInst { name, variant: variant_name, generic_args: combined_generic_args, arguments: args, span: dc_span };
-                    } else { break; }
-                },
+                        expr = Expression::EnumInst {
+                            name,
+                            variant: variant_name,
+                            generic_args: combined_generic_args,
+                            arguments: args,
+                            span: dc_span,
+                        };
+                    } else {
+                        break;
+                    }
+                }
                 TokenKind::LParen => {
                     let call_span = Span::from_token(&self.current_token);
                     self.next_token();
                     let mut args = Vec::new();
-                    while self.current_token.kind != TokenKind::RParen && self.current_token.kind != TokenKind::EOF {
+                    while self.current_token.kind != TokenKind::RParen
+                        && self.current_token.kind != TokenKind::EOF
+                    {
                         args.push(self.parse_expression());
-                        if self.current_token.kind == TokenKind::Comma { self.next_token(); }
+                        if self.current_token.kind == TokenKind::Comma {
+                            self.next_token();
+                        }
                     }
-                    if self.current_token.kind == TokenKind::RParen { self.next_token(); }
-                    
+                    if self.current_token.kind == TokenKind::RParen {
+                        self.next_token();
+                    }
+
                     if let Expression::Identifier(ref name, _) = expr {
-                        expr = Expression::Call { function: name.clone(), generic_args: vec![], arguments: args, span: call_span };
-                    } else if let Expression::TypeRef { ref name, ref generic_args, .. } = expr {
-                        expr = Expression::Call { function: name.clone(), generic_args: generic_args.clone(), arguments: args, span: call_span };
-                    } else { break; }
-                },
+                        expr = Expression::Call {
+                            function: name.clone(),
+                            generic_args: vec![],
+                            arguments: args,
+                            span: call_span,
+                        };
+                    } else if let Expression::TypeRef {
+                        ref name,
+                        ref generic_args,
+                        ..
+                    } = expr
+                    {
+                        expr = Expression::Call {
+                            function: name.clone(),
+                            generic_args: generic_args.clone(),
+                            arguments: args,
+                            span: call_span,
+                        };
+                    } else {
+                        break;
+                    }
+                }
                 TokenKind::LBrace => {
-                    let is_type_like = matches!(expr, Expression::Identifier(..) | Expression::TypeRef { .. });
-                    if !is_type_like { break; }
+                    let is_type_like = matches!(
+                        expr,
+                        Expression::Identifier(..) | Expression::TypeRef { .. }
+                    );
+                    if !is_type_like {
+                        break;
+                    }
 
                     let next_tok = self.peek_at(0);
-                    let is_struct = if next_tok.kind == TokenKind::RBrace { true } 
-                        else if let TokenKind::Identifier(_) = next_tok.kind {
-                            let next_next = self.peek_at(1);
-                            next_next.kind == TokenKind::Colon
-                        } else { false };
-                    
+                    let is_struct = if next_tok.kind == TokenKind::RBrace {
+                        true
+                    } else if let TokenKind::Identifier(_) = next_tok.kind {
+                        let next_next = self.peek_at(1);
+                        next_next.kind == TokenKind::Colon
+                    } else {
+                        false
+                    };
+
                     if is_struct {
                         let struct_span = Span::from_token(&self.current_token);
                         self.next_token();
                         let mut fields = Vec::new();
-                        while self.current_token.kind != TokenKind::RBrace && self.current_token.kind != TokenKind::EOF {
+                        while self.current_token.kind != TokenKind::RBrace
+                            && self.current_token.kind != TokenKind::EOF
+                        {
                             if let TokenKind::Identifier(f_name) = self.current_token.clone().kind {
                                 self.next_token();
                                 if self.current_token.kind == TokenKind::Colon {
@@ -1229,31 +1728,52 @@ impl<'a> Parser<'a> {
                             } else {
                                 break;
                             }
-                            if self.current_token.kind == TokenKind::Comma { 
-                                self.next_token(); 
+                            if self.current_token.kind == TokenKind::Comma {
+                                self.next_token();
                             } else if self.current_token.kind != TokenKind::RBrace {
                                 break;
                             }
                         }
-                        if self.current_token.kind == TokenKind::RBrace { self.next_token(); }
+                        if self.current_token.kind == TokenKind::RBrace {
+                            self.next_token();
+                        }
                         let (name, generic_args) = match expr {
                             Expression::Identifier(ref n, _) => (n.clone(), vec![]),
-                            Expression::TypeRef { ref name, ref generic_args, .. } => (name.clone(), generic_args.clone()),
+                            Expression::TypeRef {
+                                ref name,
+                                ref generic_args,
+                                ..
+                            } => (name.clone(), generic_args.clone()),
                             _ => ("unknown_struct".to_string(), vec![]),
                         };
-                        expr = Expression::StructInst { name, generic_args, fields, span: struct_span };
-                    } else { break; }
-                },
+                        expr = Expression::StructInst {
+                            name,
+                            generic_args,
+                            fields,
+                            span: struct_span,
+                        };
+                    } else {
+                        break;
+                    }
+                }
                 TokenKind::Lt => {
                     if let Expression::Identifier(ref name, _) = expr {
                         let n = name.clone();
                         let ident_span = expr.span();
                         let generic_args = self.parse_generic_args();
                         if !generic_args.is_empty() {
-                            expr = Expression::TypeRef { name: n, generic_args, span: ident_span };
-                        } else { break; }
-                    } else { break; }
-                },
+                            expr = Expression::TypeRef {
+                                name: n,
+                                generic_args,
+                                span: ident_span,
+                            };
+                        } else {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
                 _ => break,
             }
         }
@@ -1261,21 +1781,31 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_fstring(&mut self, s: String, span: Span) -> Expression {
-        enum Seg { Lit(String), Expr(String) }
+        enum Seg {
+            Lit(String),
+            Expr(String),
+        }
         let mut segments: Vec<Seg> = Vec::new();
         let mut cur = String::new();
         let mut chars = s.chars().peekable();
         while let Some(c) = chars.next() {
             if c == '{' {
-                if !cur.is_empty() { segments.push(Seg::Lit(std::mem::take(&mut cur))); }
+                if !cur.is_empty() {
+                    segments.push(Seg::Lit(std::mem::take(&mut cur)));
+                }
                 let mut depth = 1;
                 let mut expr_src = String::new();
                 while let Some(&nc) = chars.peek() {
-                    if nc == '{' { depth += 1; expr_src.push(nc); chars.next(); }
-                    else if nc == '}' {
+                    if nc == '{' {
+                        depth += 1;
+                        expr_src.push(nc);
+                        chars.next();
+                    } else if nc == '}' {
                         chars.next();
                         depth -= 1;
-                        if depth == 0 { break; }
+                        if depth == 0 {
+                            break;
+                        }
                         expr_src.push('}');
                     } else {
                         expr_src.push(nc);
@@ -1289,7 +1819,9 @@ impl<'a> Parser<'a> {
                 cur.push(c);
             }
         }
-        if !cur.is_empty() { segments.push(Seg::Lit(cur)); }
+        if !cur.is_empty() {
+            segments.push(Seg::Lit(cur));
+        }
 
         let plus_tok = Token::new(TokenKind::Plus, span.line, span.col);
         let mut result: Option<Expression> = None;
@@ -1330,10 +1862,19 @@ mod tests {
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
         let expr = parser.parse_expression();
-        
-        if let Expression::Infix { left: _, operator, right, .. } = expr {
+
+        if let Expression::Infix {
+            left: _,
+            operator,
+            right,
+            ..
+        } = expr
+        {
             assert_eq!(operator.kind, TokenKind::Plus);
-            assert!(matches!(*right, Expression::Infix { .. }), "Expected right to be an infix expression");
+            assert!(
+                matches!(*right, Expression::Infix { .. }),
+                "Expected right to be an infix expression"
+            );
             if let Expression::Infix { operator: op2, .. } = *right {
                 assert_eq!(op2.kind, TokenKind::Star);
             }
@@ -1348,7 +1889,7 @@ mod tests {
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
         let expr = parser.parse_expression();
-        
+
         let is_method_call = matches!(expr, Expression::MethodCall { .. });
         assert!(is_method_call, "Expected method call, got {:?}", expr);
     }
@@ -1359,7 +1900,7 @@ mod tests {
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
         let program = parser.parse_program().expect("parse should succeed");
-        
+
         assert_eq!(program.declarations.len(), 1);
         let is_fn = matches!(program.declarations[0], Declaration::Function(_));
         assert!(is_fn, "Expected function declaration");

--- a/tests/fixtures/compiler/error_internal.ai
+++ b/tests/fixtures/compiler/error_internal.ai
@@ -1,0 +1,10 @@
+// Reference a struct that is never declared. The type checker does not reject
+// unknown struct literals (it resolves the name fuzzily and falls back to the
+// typed name), so codegen hits the StructInst-not-found Internal path. The
+// Internal variant must surface as `internal compiler error: ...` (#40).
+
+fn main() {
+    let s = NoSuchStruct { x: 1, y: 2 }
+    io.println(s.x)
+    return 0
+}

--- a/tests/fixtures/compiler/error_undefined_field.ai
+++ b/tests/fixtures/compiler/error_undefined_field.ai
@@ -1,0 +1,19 @@
+use core.heap
+
+// Field typo via pointer-deref member access `(*p).nme`. This form parses as
+// `MemberAccess` (not the dotted-`Identifier` shortcut), so the type checker's
+// field-undefined path fires and emits `Not Found: field 'nme' is not defined
+// (did you mean 'name'?)` (#40).
+
+struct Person {
+    name: i64,
+    age: i64,
+}
+
+fn main() {
+    let p: *Person = unsafe { core.heap.alloc(16) as *Person }
+    unsafe { *p = Person { name: 1, age: 2 } }
+    let v = unsafe { (*p).nme }
+    io.println(v)
+    return 0
+}

--- a/tests/fixtures/compiler/error_undefined_function.ai
+++ b/tests/fixtures/compiler/error_undefined_function.ai
@@ -1,0 +1,13 @@
+// Close typo in a function call: `greet_word()` within 1 edit of the
+// declared `greet_world()` should trigger `Not Found: function 'greet_word'
+// is not defined (did you mean 'greet_world'?)` (#40).
+
+fn greet_world() -> i64 {
+    io.println("hello, world")
+    return 0
+}
+
+fn main() {
+    greet_word()
+    return 0
+}

--- a/tests/fixtures/compiler/error_undefined_method.ai
+++ b/tests/fixtures/compiler/error_undefined_method.ai
@@ -1,0 +1,22 @@
+// Undefined method via a parenthesized receiver: `(p).grety()` parses as a
+// MethodCall (the dotted-identifier shortcut only fires on bare identifiers),
+// triggering the type checker's method-undefined path with a "did you mean
+// 'greet'?" suggestion. #40.
+
+struct Person {
+    name: i64,
+}
+
+impl Person {
+    pub fn greet(self) -> i64 {
+        io.println("hi")
+        return 0
+    }
+}
+
+fn main() {
+    let p = Person { name: 1 }
+    let v = (p).greeb()
+    io.println(v)
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,13 @@ fn run_aion_test(path: &str) -> String {
     let root = project_root();
 
     let output = Command::new("cargo")
-        .args(["run", "--quiet", "--", "run", &format!("tests/fixtures/{}.ai", path)])
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "run",
+            &format!("tests/fixtures/{}.ai", path),
+        ])
         .current_dir(&root)
         .timeout(std::time::Duration::from_secs(60))
         .output()
@@ -47,178 +53,358 @@ fn run_aion_test(path: &str) -> String {
 // --- Language Tests ---
 
 #[test]
-fn test_hello() { assert_snapshot!(run_aion_test("language/hello")); }
+fn test_hello() {
+    assert_snapshot!(run_aion_test("language/hello"));
+}
 #[test]
-fn test_duration_literal() { assert_snapshot!(run_aion_test("language/duration_literal")); }
+fn test_duration_literal() {
+    assert_snapshot!(run_aion_test("language/duration_literal"));
+}
 #[test]
-fn test_pipeline_operator() { assert_snapshot!(run_aion_test("language/pipeline_operator")); }
+fn test_pipeline_operator() {
+    assert_snapshot!(run_aion_test("language/pipeline_operator"));
+}
 #[test]
-fn test_date_arithmetic() { assert_snapshot!(run_aion_test("language/date_arithmetic")); }
+fn test_date_arithmetic() {
+    assert_snapshot!(run_aion_test("language/date_arithmetic"));
+}
 #[test]
-fn test_unsafe_check_fail() { assert_snapshot!(run_aion_test("language/unsafe_check_fail")); }
+fn test_unsafe_check_fail() {
+    assert_snapshot!(run_aion_test("language/unsafe_check_fail"));
+}
 #[test]
-fn test_fstring_interpolation() { assert_snapshot!(run_aion_test("language/fstring_interpolation")); }
+fn test_fstring_interpolation() {
+    assert_snapshot!(run_aion_test("language/fstring_interpolation"));
+}
 #[test]
-fn test_fstring_edge() { assert_snapshot!(run_aion_test("language/fstring_edge")); }
+fn test_fstring_edge() {
+    assert_snapshot!(run_aion_test("language/fstring_edge"));
+}
 #[test]
-fn test_fstring_exprs() { assert_snapshot!(run_aion_test("language/fstring_exprs")); }
+fn test_fstring_exprs() {
+    assert_snapshot!(run_aion_test("language/fstring_exprs"));
+}
 #[test]
-fn test_fstring_nested_braces() { assert_snapshot!(run_aion_test("language/fstring_nested_braces")); }
+fn test_fstring_nested_braces() {
+    assert_snapshot!(run_aion_test("language/fstring_nested_braces"));
+}
 #[test]
-fn test_operators() { assert_snapshot!(run_aion_test("language/operators")); }
+fn test_operators() {
+    assert_snapshot!(run_aion_test("language/operators"));
+}
 #[test]
-fn test_unsafe_block() { assert_snapshot!(run_aion_test("language/unsafe_block")); }
+fn test_unsafe_block() {
+    assert_snapshot!(run_aion_test("language/unsafe_block"));
+}
 #[test]
-fn test_complex_pipeline() { assert_snapshot!(run_aion_test("language/complex_pipeline")); }
+fn test_complex_pipeline() {
+    assert_snapshot!(run_aion_test("language/complex_pipeline"));
+}
 #[test]
-fn test_string_operations() { assert_snapshot!(run_aion_test("language/string_operations")); }
+fn test_string_operations() {
+    assert_snapshot!(run_aion_test("language/string_operations"));
+}
 #[test]
-fn test_enum_match() { assert_snapshot!(run_aion_test("language/enum_match")); }
+fn test_enum_match() {
+    assert_snapshot!(run_aion_test("language/enum_match"));
+}
 #[test]
-fn test_generics_basic() { assert_snapshot!(run_aion_test("language/generics_basic")); }
+fn test_generics_basic() {
+    assert_snapshot!(run_aion_test("language/generics_basic"));
+}
 #[test]
-fn test_generics_result() { assert_snapshot!(run_aion_test("language/generics_result")); }
+fn test_generics_result() {
+    assert_snapshot!(run_aion_test("language/generics_result"));
+}
 #[test]
-fn test_struct_name_resolution() { assert_snapshot!(run_aion_test("language/struct_name_resolution")); }
+fn test_struct_name_resolution() {
+    assert_snapshot!(run_aion_test("language/struct_name_resolution"));
+}
 #[test]
-fn test_simple_expression() { assert_snapshot!(run_aion_test("language/simple_expression")); }
+fn test_simple_expression() {
+    assert_snapshot!(run_aion_test("language/simple_expression"));
+}
 #[test]
-fn test_generics_local() { assert_snapshot!(run_aion_test("language/generics_local")); }
+fn test_generics_local() {
+    assert_snapshot!(run_aion_test("language/generics_local"));
+}
 #[test]
-fn test_generics_substring() { assert_snapshot!(run_aion_test("language/generics_substring")); }
+fn test_generics_substring() {
+    assert_snapshot!(run_aion_test("language/generics_substring"));
+}
 #[test]
-fn test_generics_multi_arg() { assert_snapshot!(run_aion_test("language/generics_multi_arg")); }
+fn test_generics_multi_arg() {
+    assert_snapshot!(run_aion_test("language/generics_multi_arg"));
+}
 #[test]
-fn test_generics_multi_arg_err() { assert_snapshot!(run_aion_test("language/generics_multi_arg_err")); }
+fn test_generics_multi_arg_err() {
+    assert_snapshot!(run_aion_test("language/generics_multi_arg_err"));
+}
 #[test]
-fn test_let_type_annotation() { assert_snapshot!(run_aion_test("language/let_type_annotation")); }
+fn test_let_type_annotation() {
+    assert_snapshot!(run_aion_test("language/let_type_annotation"));
+}
 #[test]
-fn test_method_chaining() { assert_snapshot!(run_aion_test("language/method_chaining")); }
+fn test_method_chaining() {
+    assert_snapshot!(run_aion_test("language/method_chaining"));
+}
 #[test]
-fn test_short_circuit() { assert_snapshot!(run_aion_test("language/short_circuit")); }
+fn test_short_circuit() {
+    assert_snapshot!(run_aion_test("language/short_circuit"));
+}
 #[test]
-fn test_result_basic() { assert_snapshot!(run_aion_test("language/result_basic")); }
+fn test_result_basic() {
+    assert_snapshot!(run_aion_test("language/result_basic"));
+}
 #[test]
-fn test_result_methods() { assert_snapshot!(run_aion_test("language/result_methods")); }
+fn test_result_methods() {
+    assert_snapshot!(run_aion_test("language/result_methods"));
+}
 #[test]
-fn test_primitive_methods() { assert_snapshot!(run_aion_test("language/primitive_methods")); }
+fn test_primitive_methods() {
+    assert_snapshot!(run_aion_test("language/primitive_methods"));
+}
 #[test]
-fn test_struct_return() { assert_snapshot!(run_aion_test("language/struct_return")); }
+fn test_struct_return() {
+    assert_snapshot!(run_aion_test("language/struct_return"));
+}
 #[test]
-fn test_parse_result() { assert_snapshot!(run_aion_test("language/parse_result")); }
+fn test_parse_result() {
+    assert_snapshot!(run_aion_test("language/parse_result"));
+}
 #[test]
-fn test_char_literal() { assert_snapshot!(run_aion_test("language/char_literal")); }
+fn test_char_literal() {
+    assert_snapshot!(run_aion_test("language/char_literal"));
+}
 #[test]
-fn test_string_match() { assert_snapshot!(run_aion_test("language/string_match")); }
+fn test_string_match() {
+    assert_snapshot!(run_aion_test("language/string_match"));
+}
 #[test]
-fn test_recursion_deep() { assert_snapshot!(run_aion_test("language/recursion_deep")); }
+fn test_recursion_deep() {
+    assert_snapshot!(run_aion_test("language/recursion_deep"));
+}
 #[test]
-fn test_string_escapes() { assert_snapshot!(run_aion_test("language/string_escapes")); }
+fn test_string_escapes() {
+    assert_snapshot!(run_aion_test("language/string_escapes"));
+}
 #[test]
-fn test_break_continue() { assert_snapshot!(run_aion_test("language/break_continue")); }
+fn test_break_continue() {
+    assert_snapshot!(run_aion_test("language/break_continue"));
+}
 #[test]
-fn test_string_methods() { assert_snapshot!(run_aion_test("stdlib/string_methods")); }
+fn test_string_methods() {
+    assert_snapshot!(run_aion_test("stdlib/string_methods"));
+}
 #[test]
-fn test_loop_basic() { assert_snapshot!(run_aion_test("language/loop_basic")); }
+fn test_loop_basic() {
+    assert_snapshot!(run_aion_test("language/loop_basic"));
+}
 #[test]
-fn test_function_types() { assert_snapshot!(run_aion_test("language/function_types")); }
+fn test_function_types() {
+    assert_snapshot!(run_aion_test("language/function_types"));
+}
 #[test]
-fn test_match_expression() { assert_snapshot!(run_aion_test("language/match_expression")); }
+fn test_match_expression() {
+    assert_snapshot!(run_aion_test("language/match_expression"));
+}
 #[test]
-fn test_option_result_methods() { assert_snapshot!(run_aion_test("language/option_result_methods")); }
+fn test_option_result_methods() {
+    assert_snapshot!(run_aion_test("language/option_result_methods"));
+}
 #[test]
-fn test_sizeof_variables() { assert_snapshot!(run_aion_test("language/sizeof_variables")); }
+fn test_sizeof_variables() {
+    assert_snapshot!(run_aion_test("language/sizeof_variables"));
+}
 
 // --- Stdlib Tests ---
 
 #[test]
-fn test_sql_transpile() { assert_snapshot!(run_aion_test("stdlib/sql_transpile")); }
+fn test_sql_transpile() {
+    assert_snapshot!(run_aion_test("stdlib/sql_transpile"));
+}
 #[test]
-fn test_fs_write_read() { assert_snapshot!(run_aion_test("stdlib/fs_write_read")); }
+fn test_fs_write_read() {
+    assert_snapshot!(run_aion_test("stdlib/fs_write_read"));
+}
 #[test]
-fn test_env_args() { assert_snapshot!(run_aion_test("stdlib/env_args")); }
+fn test_env_args() {
+    assert_snapshot!(run_aion_test("stdlib/env_args"));
+}
 #[test]
-fn test_fs_result_error() { assert_snapshot!(run_aion_test("stdlib/fs_result_error")); }
+fn test_fs_result_error() {
+    assert_snapshot!(run_aion_test("stdlib/fs_result_error"));
+}
 #[test]
-fn test_std_fs_read_write() { assert_snapshot!(run_aion_test("stdlib/std_fs_read_write")); }
+fn test_std_fs_read_write() {
+    assert_snapshot!(run_aion_test("stdlib/std_fs_read_write"));
+}
 #[test]
-fn test_env_var() { assert_snapshot!(run_aion_test("stdlib/env_var")); }
+fn test_env_var() {
+    assert_snapshot!(run_aion_test("stdlib/env_var"));
+}
 #[test]
-fn test_env_args_cli() { assert_snapshot!(run_aion_test("stdlib/env_args_cli")); }
+fn test_env_args_cli() {
+    assert_snapshot!(run_aion_test("stdlib/env_args_cli"));
+}
 #[test]
-fn test_vector_basic() { assert_snapshot!(run_aion_test("stdlib/vector_basic")); }
+fn test_vector_basic() {
+    assert_snapshot!(run_aion_test("stdlib/vector_basic"));
+}
 #[test]
-fn test_env_vector_args() { assert_snapshot!(run_aion_test("stdlib/env_vector_args")); }
+fn test_env_vector_args() {
+    assert_snapshot!(run_aion_test("stdlib/env_vector_args"));
+}
 #[test]
-fn test_vector_generic() { assert_snapshot!(run_aion_test("stdlib/vector_generic")); }
+fn test_vector_generic() {
+    assert_snapshot!(run_aion_test("stdlib/vector_generic"));
+}
 #[test]
-fn test_vector_push_pop() { assert_snapshot!(run_aion_test("stdlib/vector_push_pop")); }
+fn test_vector_push_pop() {
+    assert_snapshot!(run_aion_test("stdlib/vector_push_pop"));
+}
 #[test]
-fn test_vector_utils() { assert_snapshot!(run_aion_test("stdlib/vector_utils")); }
+fn test_vector_utils() {
+    assert_snapshot!(run_aion_test("stdlib/vector_utils"));
+}
 #[test]
-fn test_vector_contains() { assert_snapshot!(run_aion_test("stdlib/vector_contains")); }
+fn test_vector_contains() {
+    assert_snapshot!(run_aion_test("stdlib/vector_contains"));
+}
 #[test]
-fn test_vector_edge() { assert_snapshot!(run_aion_test("stdlib/vector_edge")); }
+fn test_vector_edge() {
+    assert_snapshot!(run_aion_test("stdlib/vector_edge"));
+}
 #[test]
-fn test_hashmap_basic() { assert_snapshot!(run_aion_test("stdlib/hashmap_basic")); }
+fn test_hashmap_basic() {
+    assert_snapshot!(run_aion_test("stdlib/hashmap_basic"));
+}
 #[test]
-fn test_hashmap_resize_hashset() { assert_snapshot!(run_aion_test("stdlib/hashmap_resize_hashset")); }
+fn test_hashmap_resize_hashset() {
+    assert_snapshot!(run_aion_test("stdlib/hashmap_resize_hashset"));
+}
 #[test]
-fn test_hashmap_utils() { assert_snapshot!(run_aion_test("stdlib/hashmap_utils")); }
+fn test_hashmap_utils() {
+    assert_snapshot!(run_aion_test("stdlib/hashmap_utils"));
+}
 #[test]
-fn test_tensor_basic() { assert_snapshot!(run_aion_test("stdlib/tensor_basic")); }
+fn test_tensor_basic() {
+    assert_snapshot!(run_aion_test("stdlib/tensor_basic"));
+}
 #[test]
-fn test_fmt_format() { assert_snapshot!(run_aion_test("stdlib/fmt_format")); }
+fn test_fmt_format() {
+    assert_snapshot!(run_aion_test("stdlib/fmt_format"));
+}
 #[test]
-fn test_path_operations() { assert_snapshot!(run_aion_test("stdlib/path_operations")); }
+fn test_path_operations() {
+    assert_snapshot!(run_aion_test("stdlib/path_operations"));
+}
 #[test]
-fn test_dataframe_basic() { assert_snapshot!(run_aion_test("stdlib/dataframe_basic")); }
+fn test_dataframe_basic() {
+    assert_snapshot!(run_aion_test("stdlib/dataframe_basic"));
+}
 #[test]
-fn test_sql_advanced() { assert_snapshot!(run_aion_test("stdlib/sql_advanced")); }
+fn test_sql_advanced() {
+    assert_snapshot!(run_aion_test("stdlib/sql_advanced"));
+}
 #[test]
-fn test_json_parse_basic() { assert_snapshot!(run_aion_test("stdlib/json_parse_basic")); }
+fn test_json_parse_basic() {
+    assert_snapshot!(run_aion_test("stdlib/json_parse_basic"));
+}
 #[test]
-fn test_memzero_struct() { assert_snapshot!(run_aion_test("stdlib/memzero_struct")); }
+fn test_memzero_struct() {
+    assert_snapshot!(run_aion_test("stdlib/memzero_struct"));
+}
 #[test]
-fn test_memzero_typed() { assert_snapshot!(run_aion_test("stdlib/memzero_typed")); }
+fn test_memzero_typed() {
+    assert_snapshot!(run_aion_test("stdlib/memzero_typed"));
+}
 #[test]
-fn test_ptr_deref_member() { assert_snapshot!(run_aion_test("stdlib/ptr_deref_member")); }
+fn test_ptr_deref_member() {
+    assert_snapshot!(run_aion_test("stdlib/ptr_deref_member"));
+}
 #[test]
-fn test_ptr_deref_member_err() { assert_snapshot!(run_aion_test("stdlib/ptr_deref_member_err")); }
+fn test_ptr_deref_member_err() {
+    assert_snapshot!(run_aion_test("stdlib/ptr_deref_member_err"));
+}
 #[test]
-fn test_ptr_memzero_field() { assert_snapshot!(run_aion_test("stdlib/ptr_memzero_field")); }
+fn test_ptr_memzero_field() {
+    assert_snapshot!(run_aion_test("stdlib/ptr_memzero_field"));
+}
 
 // --- Compiler Tests ---
 
 #[test]
-fn test_debug_output() { assert_snapshot!(run_aion_test("compiler/debug_output")); }
+fn test_debug_output() {
+    assert_snapshot!(run_aion_test("compiler/debug_output"));
+}
 #[test]
-fn test_malloc_test() { assert_snapshot!(run_aion_test("compiler/malloc_test")); }
+fn test_malloc_test() {
+    assert_snapshot!(run_aion_test("compiler/malloc_test"));
+}
 #[test]
-fn test_gc_leak_test() { assert_snapshot!(run_aion_test("compiler/gc_leak_test")); }
+fn test_gc_leak_test() {
+    assert_snapshot!(run_aion_test("compiler/gc_leak_test"));
+}
 #[test]
-fn test_extern_ffi() { assert_snapshot!(run_aion_test("compiler/extern_ffi")); }
+fn test_extern_ffi() {
+    assert_snapshot!(run_aion_test("compiler/extern_ffi"));
+}
 #[test]
-fn test_self_lexer() { assert_snapshot!(run_aion_test("compiler/self_lexer")); }
+fn test_self_lexer() {
+    assert_snapshot!(run_aion_test("compiler/self_lexer"));
+}
 #[test]
-fn test_optimization_check() { assert_snapshot!(run_aion_test("compiler/optimization_check")); }
+fn test_optimization_check() {
+    assert_snapshot!(run_aion_test("compiler/optimization_check"));
+}
 #[test]
-fn test_self_lexer_loop() { assert_snapshot!(run_aion_test("compiler/self_lexer_loop")); }
+fn test_self_lexer_loop() {
+    assert_snapshot!(run_aion_test("compiler/self_lexer_loop"));
+}
 #[test]
-fn test_self_parser() { assert_snapshot!(run_aion_test("compiler/self_parser")); }
+fn test_self_parser() {
+    assert_snapshot!(run_aion_test("compiler/self_parser"));
+}
+#[test]
+fn test_error_undefined_function() {
+    assert_snapshot!(run_aion_test("compiler/error_undefined_function"));
+}
+#[test]
+fn test_error_undefined_field() {
+    assert_snapshot!(run_aion_test("compiler/error_undefined_field"));
+}
+#[test]
+fn test_error_undefined_method() {
+    assert_snapshot!(run_aion_test("compiler/error_undefined_method"));
+}
+#[test]
+fn test_error_internal() {
+    assert_snapshot!(run_aion_test("compiler/error_internal"));
+}
 
 // --- Example Tests ---
 
 #[test]
-fn test_example_hello() { assert_snapshot!(run_aion_test("examples/hello")); }
+fn test_example_hello() {
+    assert_snapshot!(run_aion_test("examples/hello"));
+}
 #[test]
-fn test_example_types() { assert_snapshot!(run_aion_test("examples/types")); }
+fn test_example_types() {
+    assert_snapshot!(run_aion_test("examples/types"));
+}
 #[test]
-fn test_example_logic() { assert_snapshot!(run_aion_test("examples/logic")); }
+fn test_example_logic() {
+    assert_snapshot!(run_aion_test("examples/logic"));
+}
 #[test]
-fn test_example_generics() { assert_snapshot!(run_aion_test("examples/generics")); }
+fn test_example_generics() {
+    assert_snapshot!(run_aion_test("examples/generics"));
+}
 #[test]
-fn test_example_interface_impl() { assert_snapshot!(run_aion_test("examples/interface_impl")); }
+fn test_example_interface_impl() {
+    assert_snapshot!(run_aion_test("examples/interface_impl"));
+}
 
 // --- Doc Generation Tests ---
 
@@ -246,4 +432,6 @@ fn run_aion_doc(path: &str) -> String {
 }
 
 #[test]
-fn test_doc_gen() { assert_snapshot!(run_aion_doc("compiler/doc_gen")); }
+fn test_doc_gen() {
+    assert_snapshot!(run_aion_doc("compiler/doc_gen"));
+}

--- a/tests/snapshots/integration__error_internal.snap
+++ b/tests/snapshots/integration__error_internal.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/error_internal\")"
+---
+internal compiler error: Struct type 'NoSuchStruct' not found in StructInst

--- a/tests/snapshots/integration__error_undefined_field.snap
+++ b/tests/snapshots/integration__error_undefined_field.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/error_undefined_field\")"
+---
+Not Found: field 'nme' is not defined (did you mean 'name'?)

--- a/tests/snapshots/integration__error_undefined_function.snap
+++ b/tests/snapshots/integration__error_undefined_function.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/error_undefined_function\")"
+---
+Not Found: function 'greet_word' is not defined (did you mean 'greet_world'?)

--- a/tests/snapshots/integration__error_undefined_method.snap
+++ b/tests/snapshots/integration__error_undefined_method.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/error_undefined_method\")"
+---
+Not Found: method 'greeb' is not defined (did you mean 'greet'?)


### PR DESCRIPTION
## Summary

Every `CompileError` variant now carries `line`/`col`/`snippet`, `Internal` is visually separated from user errors, `NotFound` errors emit a Levenshtein-closest "did you mean X?" suggestion, and a non-fatal `Warning` variant is introduced for future lints. Unblocks #10 (LSP diagnostics) which needs structured errors.

## Changes

- **error.rs**: struct variants for `Inkwell` / `Io` / `Import` / `Internal` / `Warning` with `line`/`col`/`snippet`; ctor helpers (`internal`, `io`, `import`, `warning`, `not_found`); `with_snippet`/`col` cover all variants; `is_warning()`; `levenshtein` + `suggest_closest` (threshold = `max(1, len/3)` AND ≤ 3 edits) with unit tests.
- **analysis/checker.rs**: `suggest_function` / `suggest_field` / `suggest_method`; undefined-function/-field/-method paths emit `CompileError::not_found` with the suggestion.
- **analysis/environment.rs**: `visible_names()` helper for future scope-aware suggestions.
- **codegen/compiler.rs**, **lib.rs**: migrate all `CompileError::Internal/Io/Import(String)` call-sites to the typed ctors.
- **docs/SPEC.md**: document the new error model.
- **style**: `cargo fmt` applied to files that were not fmt-clean before this branch.

## Tests

- [x] `tests/fixtures/compiler/error_internal.ai` — internal error prefixed `internal compiler error:`
- [x] `tests/fixtures/compiler/error_undefined_function.ai` — `did you mean 'greet_world'?`
- [x] `tests/fixtures/compiler/error_undefined_field.ai` — `did you mean 'name'?`
- [x] `tests/fixtures/compiler/error_undefined_method.ai` — `did you mean 'greet'?`
- [x] Unit tests for `levenshtein` / `suggest_closest` (`cargo test --lib`)
- [x] Full suite: 87 integration + 9 lib tests pass (`cargo test -- --test-threads=1`)
- [x] `cargo fmt --check` clean
- [x] Regression: existing `unsafe_check_fail` fixture still passes

## Docs

- [x] `docs/SPEC.md` updated (error model, `Warning` variant, suggestion semantics, ICE prefix)

Closes #40