### PR TITLE
fix(parser): stop leaking f-string interpolation sources via Box::leak

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1842,8 +1842,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_fstring_expr(&mut self, src: &str, _span: Span) -> Expression {
-        let leaked: &'static str = Box::leak(src.to_string().into_boxed_str());
-        let lexer = Lexer::new(leaked);
+        // The sub-lexer borrows a locally owned String. Expression is fully
+        // owned (no lifetime parameter), so the returned value outlives the
+        // borrow with no Box::leak needed. #80.
+        let owned = src.to_string();
+        let lexer = Lexer::new(&owned);
         let mut sub = Parser::new(lexer);
         sub.parse_expression()
     }

--- a/tests/fixtures/language/fstring_many_interpolations.ai
+++ b/tests/fixtures/language/fstring_many_interpolations.ai
@@ -1,0 +1,30 @@
+// Regression guard for #80: every `{expr}` segment in every f-string used to
+// leak its source string via Box::leak. This fixture exercises many f-strings
+// each with multiple interpolations (incl. nested expressions) to keep the
+// no-leak parse path covered. Non-String values are explicitly converted via
+// std.string helpers (f-strings are syntax sugar for concatenation). Snapshot
+// asserts the compiled program output.
+
+fn add(a: i64, b: i64) -> i64 {
+    return a + b
+}
+
+fn main() {
+    let x = 10
+    let y = 20
+    let name = "Aion"
+
+    let a = f"{string.from_int(x)} + {string.from_int(y)} = {string.from_int(add(x, y))}"
+    io.println(a)
+
+    let b = f"hello {name}, sum={string.from_int(add(x, y))}, diff={string.from_int(add(y, -x))}"
+    io.println(b)
+
+    let c = f"{string.from_int(1)} {string.from_int(2)} {string.from_int(3)} {string.from_int(4)} {string.from_int(5)} {string.from_int(x)} {string.from_int(y)}"
+    io.println(c)
+
+    let d = f"name={name} len={string.from_int(string.len(name))}"
+    io.println(d)
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -89,6 +89,10 @@ fn test_fstring_nested_braces() {
     assert_snapshot!(run_aion_test("language/fstring_nested_braces"));
 }
 #[test]
+fn test_fstring_many_interpolations() {
+    assert_snapshot!(run_aion_test("language/fstring_many_interpolations"));
+}
+#[test]
 fn test_operators() {
     assert_snapshot!(run_aion_test("language/operators"));
 }

--- a/tests/snapshots/integration__fstring_many_interpolations.snap
+++ b/tests/snapshots/integration__fstring_many_interpolations.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/fstring_many_interpolations\")"
+---
+10 + 20 = 30
+hello Aion, sum=30, diff=10
+1 2 3 4 5 10 20
+name=Aion len=4


### PR DESCRIPTION
## Summary

`parse_fstring_expr` used `Box::leak(src.to_string().into_boxed_str())` to hand a `&'static str` to a sub-`Lexer`. Every `{expr}` segment in every f-string leaked its source string, unboundedly — a problem for long-running processes (LSP #10, watch mode). The leak was unnecessary: `Expression` is fully owned (no lifetime parameter), so a locally owned `String` + a sub-`Parser` with a shorter borrow lifetime suffices, and the borrow checker accepts it because the returned `Expression` does not borrow from the sub-Lexer's input.

## Changes

- **`src/parser/mod.rs`**: `parse_fstring_expr` now uses a local `String` instead of `Box::leak`. No arena, no `unsafe`, no lifetime gymnastics.
- **`tests/fixtures/language/fstring_many_interpolations.ai`** (new): regression guard exercising many f-strings each with multiple `{expr}` segments (nested function calls, `string.from_int` conversions).
- **`tests/snapshots/integration__fstring_many_interpolations.snap`** (new): expected program output.

## Tests

- [x] Nominal: `fstring_many_interpolations.ai` — 4 f-strings × multiple interpolations, asserts compiled output.
- [x] Edge cases: existing `fstring_edge`, `fstring_exprs`, `fstring_interpolation`, `fstring_nested_braces` still pass (regression).
- [x] Error cases: N/A — pure memory fix, no behavior change. Existing error fixtures unchanged.
- [x] Full suite: 88 integration + 9 lib tests pass (`cargo test -- --test-threads=1`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] valgrind/heaptrack verification of no-growth (issue acceptance) — not run in CI; the leak source is removed by inspection (single `Box::leak` call site, now gone).

## Docs

- [x] N/A — no spec or behavior change (pure memory fix). Issue #80 acceptance did not require doc updates.

Closes #80