### PR TITLE
feat(compiler): link aion binaries with lld-15 instead of gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,9 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /workspace
 COPY . .
 
+# Pre-compile the C runtime to LLVM bitcode at build time so the `aion run`
+# link step can use lld-15 (via clang-15 -fuse-ld=lld) instead of gcc. #73.
+RUN clang-15 -c -emit-llvm -O2 -I/usr/include src/runtime.c -o /opt/aion_runtime.bc
+ENV AION_RUNTIME_BC=/opt/aion_runtime.bc
+
 CMD ["cargo", "run"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ editors/          — Editor integrations (vscode/)
 
 **Compiler pipeline**: `compile_file()` in `src/lib.rs` runs: imports resolution → TypeChecker → LLVM Compiler → optimization passes (FPM + MPM) → writes `.ll` file.
 
-**`./aion run` flow**: compiles to temp `.ll` → `llc-15` to `.o` (PIC) → `gcc` links with `src/runtime.c` → executes binary → cleans up temp files.
+**`./aion run` flow**: compiles to temp `.ll` → `llc-15` to `.o` (PIC) → `clang-15 -fuse-ld=lld` links the object with the pre-compiled runtime bitcode (`/opt/aion_runtime.bc` in the Docker image, env `AION_RUNTIME_BC`) + `-lpthread -lgc` → executes binary → cleans up temp files. The link path is gcc-free (lld-15 driven by clang-15, both LLVM tools); a legacy `gcc` fallback is used only when `clang-15` is absent (non-Docker dev without the LLVM toolchain). #73.
 
 ## Architectural Invariants
 
@@ -61,6 +61,7 @@ editors/          — Editor integrations (vscode/)
 - **LLVM 15** is hardcoded (inkwell feature `llvm15-0`, Docker installs `llvm-15-dev`)
 - **Boehm GC** is required (`-lgc` in link step, `GC_init()` called in main)
 - **PIC relocation** is mandatory (`-relocation-model=pic` in llc-15 call)
+- **gcc-free link path**: the user binary is linked with `clang-15 -fuse-ld=lld` (lld-15) against the pre-compiled runtime bitcode. `gcc` remains in the Docker image only as the C compiler for `cargo`/`build-optional` deps (inkwell, llvm-sys); it is **not** invoked by `aion run`. #73.
 - **Rust edition 2024** (see `Cargo.toml`)
 - Import resolution: `compiler.*` → project root, everything else → `stdlib/`
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -83,3 +83,5 @@ If tests fail with linker errors (`undefined reference`, `file in wrong format`,
 ```bash
 docker rmi aion-compiler && docker volume rm aion-target-cache aion-cargo-cache && docker build -t aion-compiler .
 ```
+
+Note: the Dockerfile pre-compiles `src/runtime.c` to `/opt/aion_runtime.bc` (build-time, `clang-15`). If you edit `src/runtime.c`, rebuild the image so the bitcode is refreshed — `docker rmi aion-compiler && docker build -t aion-compiler .` (#73).

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,14 @@ fn main() {
                 Ok(()) => {}
                 Err(LinkError::GccFallback) => {
                     let gcc_status = Command::new("gcc")
-                        .args([&obj_file, "src/runtime.c", "-o", &bin_file, "-lpthread", "-lgc"])
+                        .args([
+                            &obj_file,
+                            "src/runtime.c",
+                            "-o",
+                            &bin_file,
+                            "-lpthread",
+                            "-lgc",
+                        ])
                         .status();
                     if let Err(e) = gcc_status {
                         eprintln!("error: gcc failed: {}", e);
@@ -198,7 +205,15 @@ fn link_with_lld(obj_file: &str, bin_file: &str, _args: &[String]) -> Result<(),
             // scoped to this run so concurrent runs don't clobber each other.
             let tmp = format!("aion_runtime_{}.bc", std::process::id());
             let status = Command::new(&clang)
-                .args(["-c", "-emit-llvm", "-O2", "-I/usr/include", "src/runtime.c", "-o", &tmp])
+                .args([
+                    "-c",
+                    "-emit-llvm",
+                    "-O2",
+                    "-I/usr/include",
+                    "src/runtime.c",
+                    "-o",
+                    &tmp,
+                ])
                 .status()
                 .map_err(|e| LinkError::Failed(format!("clang bitcode compile: {}", e)))?;
             if !status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,23 +89,29 @@ fn main() {
                 std::process::exit(1);
             }
 
-            let gcc_status = Command::new("gcc")
-                .args([
-                    &obj_file,
-                    "src/runtime.c",
-                    "-o",
-                    &bin_file,
-                    "-lpthread",
-                    "-lgc",
-                ])
-                .status();
-
-            if let Err(e) = gcc_status {
-                eprintln!("error: gcc failed: {}", e);
-                std::process::exit(1);
-            } else if !gcc_status.unwrap().success() {
-                eprintln!("error: gcc failed with non-zero exit");
-                std::process::exit(1);
+            // Link the object with the pre-compiled C runtime bitcode using
+            // lld-15 (driven by clang-15, an LLVM tool — no gcc in the link
+            // path). Falls back to the legacy gcc link if clang-15 is absent
+            // (e.g. bare-metal dev without the LLVM toolchain). #73.
+            let link_ok = link_with_lld(&obj_file, &bin_file, &args);
+            match link_ok {
+                Ok(()) => {}
+                Err(LinkError::GccFallback) => {
+                    let gcc_status = Command::new("gcc")
+                        .args([&obj_file, "src/runtime.c", "-o", &bin_file, "-lpthread", "-lgc"])
+                        .status();
+                    if let Err(e) = gcc_status {
+                        eprintln!("error: gcc failed: {}", e);
+                        std::process::exit(1);
+                    } else if !gcc_status.unwrap().success() {
+                        eprintln!("error: gcc failed with non-zero exit");
+                        std::process::exit(1);
+                    }
+                }
+                Err(LinkError::Failed(e)) => {
+                    eprintln!("error: link failed: {}", e);
+                    std::process::exit(1);
+                }
             }
 
             println!("-------------------------------");
@@ -151,4 +157,91 @@ fn main() {
             }
         }
     }
+}
+
+/// Outcome of the lld link attempt. `GccFallback` signals that clang-15 is
+/// unavailable and the caller should retry with the legacy gcc link path. #73.
+enum LinkError {
+    GccFallback,
+    Failed(String),
+}
+
+/// Link `obj_file` + the C runtime bitcode into `bin_file` using lld-15
+/// (driven by `clang-15 -fuse-ld=lld`). The runtime bitcode is resolved as:
+/// `AION_RUNTIME_BC` env → `/opt/aion_runtime.bc` (Docker image) → on-the-fly
+/// compile of `src/runtime.c`. Returns `GccFallback` if clang-15 is missing
+/// so the caller can fall back to the gcc path. #73.
+fn link_with_lld(obj_file: &str, bin_file: &str, _args: &[String]) -> Result<(), LinkError> {
+    let clang = which("clang-15").or_else(|| which("clang"));
+    let clang = match clang {
+        Some(c) => c,
+        None => return Err(LinkError::GccFallback),
+    };
+
+    // Resolve the pre-compiled runtime bitcode.
+    let runtime_bc = std::env::var("AION_RUNTIME_BC")
+        .ok()
+        .filter(|p| std::path::Path::new(p).exists())
+        .or_else(|| {
+            let opt = std::path::Path::new("/opt/aion_runtime.bc");
+            if opt.exists() {
+                Some(opt.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        });
+
+    let runtime_bc = match runtime_bc {
+        Some(p) => p,
+        None => {
+            // On-the-fly bitcode compile (non-Docker dev). Use a temp file
+            // scoped to this run so concurrent runs don't clobber each other.
+            let tmp = format!("aion_runtime_{}.bc", std::process::id());
+            let status = Command::new(&clang)
+                .args(["-c", "-emit-llvm", "-O2", "-I/usr/include", "src/runtime.c", "-o", &tmp])
+                .status()
+                .map_err(|e| LinkError::Failed(format!("clang bitcode compile: {}", e)))?;
+            if !status.success() {
+                return Err(LinkError::Failed(format!(
+                    "clang bitcode compile exited with {}",
+                    status.code().unwrap_or(-1)
+                )));
+            }
+            tmp
+        }
+    };
+
+    let status = Command::new(&clang)
+        .args([
+            "-fuse-ld=lld",
+            obj_file,
+            &runtime_bc,
+            "-o",
+            bin_file,
+            "-lpthread",
+            "-lgc",
+        ])
+        .status()
+        .map_err(|e| LinkError::Failed(format!("lld link: {}", e)))?;
+
+    if !status.success() {
+        return Err(LinkError::Failed(format!(
+            "lld link exited with {}",
+            status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(())
+}
+
+/// Minimal `which` lookup — returns the first PATH hit for `name`. We avoid
+/// pulling in the `which` crate for a one-shot PATH scan. #73.
+fn which(name: &str) -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+    }
+    None
 }


### PR DESCRIPTION
## Summary

The `aion run` link step used `gcc obj.o src/runtime.c -lpthread -lgc`. This PR removes gcc from the user-binary link path: `src/runtime.c` is pre-compiled to LLVM bitcode at Docker build time, and the link is done with `clang-15 -fuse-ld=lld` (lld-15, an LLVM tool). A gcc fallback is kept only for non-Docker dev environments where clang-15 is absent. This is the key enabler for self-hosting — when Aion compiles itself, it no longer depends on gcc to produce executables.

**Scope**: link path only (per discussion). The strict acceptance `which gcc returns nothing` is **not** fully met: `gcc` remains in the Docker image because `cargo` needs a C compiler to build aionc and its deps (inkwell, llvm-sys). A follow-up issue will cover the full image toolchain refactor (clang-15 as cargo `CC`, `llvm-ar`, lld as default linker, removing `build-essential`). See "Follow-up" below.

## Changes

- **`Dockerfile`**: new build step `clang-15 -c -emit-llvm -O2 -I/usr/include src/runtime.c -o /opt/aion_runtime.bc`, exposed via `AION_RUNTIME_BC` env. Rebuild the image after editing `src/runtime.c` (documented in `docs/workflow.md`).
- **`src/main.rs`**: new `link_with_lld()` helper + `LinkError` enum + minimal `which()` lookup. Resolves the runtime bitcode as `AION_RUNTIME_BC` env → `/opt/aion_runtime.bc` → on-the-fly `clang-15` compile, then links with `clang-15 -fuse-ld=lld obj.o runtime.bc -lpthread -lgc`. Falls back to the legacy `gcc` link if `clang-15` is not on PATH.
- **`docs/architecture.md`**: updated `./aion run` flow description + new invariant "gcc-free link path".
- **`docs/workflow.md`**: note about rebuilding the image when `src/runtime.c` changes (bitcode freshness).

## Tests

- [x] Nominal: `./aion run examples/hello.ai` outputs `Hello, Aion!` / `Total Score: 52` (verified end-to-end in the rebuilt Docker image).
- [x] Edge cases: all 88 integration fixtures pass — each runs the full `aion run` flow (compile → `llc-15` → `clang-15 -fuse-ld=lld` link → execute), so the new link path is regression-covered for every language/stdlib/compiler feature tested.
- [x] Error cases: `gcc` fallback path preserved for non-Docker dev (not exercised in CI, but the code path is straightforward).
- [x] Full suite: 88 integration + 9 lib tests pass (`cargo test -- --test-threads=1`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] `which gcc` returns nothing — **NOT MET** (deferred to follow-up issue; gcc remains for `cargo` build).

## Docs

- [x] `docs/architecture.md` — `./aion run` flow + new "gcc-free link path" invariant.
- [x] `docs/workflow.md` — bitcode rebuild note in the Docker Cache Gotcha section.

## Follow-up

A new issue will track the full image toolchain refactor to make `which gcc` return nothing: replace `build-essential` with `clang-15` + `make` + `llvm-ar-15` symlinked as `ar`, set `CC=clang-15` for cargo, use lld as the default linker. Riskier (could break the cargo build of inkwell/llvm-sys) and out of scope for this PR.

Closes #73 (link-path scope; image cleanup tracked in follow-up)