### PR TITLE
feat(type-system): distinguish integer sizes i8/u8/i32/u32/i64/u64

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -37,10 +37,18 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
 ## 2. Type System
 
 ### Primitives
-- `i64` (default integer), `f64` (float), `bool`, `String` (pointer to
-  C-string), `Duration` (i64 millis), `Date` (i64 millis timestamp).
+- Integer types: `i8`, `u8`, `i32`, `u32`, `i64` (default), `u64`. All are
+  distinct in the type system and codegen emits the matching LLVM width
+  (`i8_type()`, `i32_type()`, ...). Integer literals default to `i64` and
+  coerce to any annotated integer type at `let`/`return` (`let x: i32 = 0`
+  stores an `i32`). Arithmetic requires both operands to share the same
+  bit width; mixing `i32` and `i64` is a type error (#52). Same-width
+  signed/unsigned mixing (`i64 ^ u64`) is allowed, result takes the LHS.
+- `f64` (float), `bool`, `String` (pointer to C-string), `Duration` (i64
+  millis), `Date` (i64 millis timestamp).
 - Char literals: `'a'` → integer char code.
-- Type system is **monomorphic at codegen**: only `i64`, `f64`, `bool`,
+- Type system is **monomorphic at codegen**: each integer keeps its width,
+  `f64`, `bool`,
   `String`, `Duration`, `Date` exist at the LLVM level. All composite
   types lower to opaque pointers (see §3).
 
@@ -205,8 +213,9 @@ The Aion-written compiler lives in `compiler/`:
   non-String values.
 - `std.json` cannot parse arrays or objects (type checker limitation on
   non-generic `Vector<Value>` — see `stdlib/std/json_SPEC.md`).
-- Integer widths are not distinguished (only `i64`); `i8/i32/u64` are
-  not yet supported (#52).
+- Integer arithmetic between **different bit widths** (e.g. `i32 + i64`)
+  is a type error. Same-width signed/unsigned mixing (`i64 ^ u64`, used
+  by the stdlib hash) is allowed; the result takes the LHS type. #52.
 
 ## 11. Backwards-Incompatible Notes
 

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -125,7 +125,7 @@ impl TypeChecker {
             Type::Function {
                 is_unsafe: true,
                 params: vec![Type::String, Type::String],
-                return_type: Box::new(Type::Integer),
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
@@ -133,14 +133,14 @@ impl TypeChecker {
             Type::Function {
                 is_unsafe: true,
                 params: vec![],
-                return_type: Box::new(Type::Integer),
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
             "aion_get_argv_index".to_string(),
             Type::Function {
                 is_unsafe: true,
-                params: vec![Type::Integer],
+                params: vec![Type::i64()],
                 return_type: Box::new(Type::String),
             },
         );
@@ -149,14 +149,14 @@ impl TypeChecker {
             Type::Function {
                 is_unsafe: true,
                 params: vec![Type::String],
-                return_type: Box::new(Type::Pointer(Box::new(Type::Integer))),
+                return_type: Box::new(Type::Pointer(Box::new(Type::i64()))),
             },
         );
         self.env.set(
             "exit".to_string(),
             Type::Function {
                 is_unsafe: true,
-                params: vec![Type::Integer],
+                params: vec![Type::i64()],
                 return_type: Box::new(Type::Unit),
             },
         );
@@ -164,7 +164,7 @@ impl TypeChecker {
             "aion_exit".to_string(),
             Type::Function {
                 is_unsafe: true,
-                params: vec![Type::Integer],
+                params: vec![Type::i64()],
                 return_type: Box::new(Type::Unit),
             },
         );
@@ -209,7 +209,7 @@ impl TypeChecker {
             Type::Function {
                 is_unsafe: false,
                 params: vec![Type::String],
-                return_type: Box::new(Type::Integer),
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
@@ -217,7 +217,7 @@ impl TypeChecker {
             Type::Function {
                 is_unsafe: false,
                 params: vec![Type::String],
-                return_type: Box::new(Type::Integer),
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
@@ -232,7 +232,7 @@ impl TypeChecker {
             "string.from_int".to_string(),
             Type::Function {
                 is_unsafe: false,
-                params: vec![Type::Integer],
+                params: vec![Type::i64()],
                 return_type: Box::new(Type::String),
             },
         );
@@ -258,28 +258,28 @@ impl TypeChecker {
             "i64.abs".to_string(),
             Type::Function {
                 is_unsafe: false,
-                params: vec![Type::Integer],
-                return_type: Box::new(Type::Integer),
+                params: vec![Type::i64()],
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
             "i64.max".to_string(),
             Type::Function {
                 is_unsafe: false,
-                params: vec![Type::Integer, Type::Integer],
-                return_type: Box::new(Type::Integer),
+                params: vec![Type::i64(), Type::i64()],
+                return_type: Box::new(Type::i64()),
             },
         );
         self.env.set(
             "i64.min".to_string(),
             Type::Function {
                 is_unsafe: false,
-                params: vec![Type::Integer, Type::Integer],
-                return_type: Box::new(Type::Integer),
+                params: vec![Type::i64(), Type::i64()],
+                return_type: Box::new(Type::i64()),
             },
         );
 
-        self.env.set("argc".to_string(), Type::Integer);
+        self.env.set("argc".to_string(), Type::i64());
         self.env.set("argv".to_string(), Type::String);
     }
 
@@ -424,9 +424,37 @@ impl TypeChecker {
 
     fn check_statement(&mut self, stmt: &Statement) -> Result<Type, CompileError> {
         match stmt {
-            Statement::Let { name, value, .. } => {
+            Statement::Let {
+                name,
+                value,
+                explicit_type,
+                ..
+            } => {
                 let val_type = self.check_expression(value)?;
-                self.env.set(name.clone(), val_type);
+                // Honor an explicit type annotation (`let x: T = expr`, #78):
+                // the variable's stored type is `T`. Integer literals (i64 by
+                // default) coerce to any annotated integer type so that
+                // `let x: i32 = 0` types `x` as i32 (#52). A genuine type
+                // mismatch (e.g. annotating an i64 expression as String) is a
+                // type error.
+                let final_type = if let Some(et) = explicit_type {
+                    let annotated = Type::parse(et);
+                    if val_type == annotated || (annotated.is_integer() && val_type.is_integer()) {
+                        annotated
+                    } else {
+                        return Err(self.err(
+                            format!(
+                                "let annotation '{}' does not match value type '{}'",
+                                annotated.name(),
+                                val_type.name()
+                            ),
+                            value,
+                        ));
+                    }
+                } else {
+                    val_type
+                };
+                self.env.set(name.clone(), final_type);
                 Ok(Type::Unit)
             }
             Statement::Assignment { target, value, .. } => {
@@ -483,7 +511,7 @@ impl TypeChecker {
                 let cond_name = match &cond_type {
                     Type::Enum { name } => name.clone(),
                     Type::GenericInstance(name, _) => name.clone(),
-                    Type::Integer => "i64".to_string(),
+                    Type::Integer { .. } => "i64".to_string(),
                     Type::String => "String".to_string(),
                     Type::Struct { name } => name.clone(),
                     _ => "unknown".to_string(),
@@ -506,7 +534,7 @@ impl TypeChecker {
 
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
-                        let mut payload = Type::Integer;
+                        let mut payload = Type::i64();
 
                         // Check patterns for enum type
                         if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
@@ -524,7 +552,7 @@ impl TypeChecker {
                                 }
                             }
                         } else if cond_name == "i64" {
-                            payload = Type::Integer;
+                            payload = Type::i64();
                         } else if cond_name == "String" {
                             payload = Type::String;
                         } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
@@ -560,8 +588,8 @@ impl TypeChecker {
 
     fn check_expression(&mut self, expr: &Expression) -> Result<Type, CompileError> {
         match expr {
-            Expression::Integer(..) => Ok(Type::Integer),
-            Expression::Char(..) => Ok(Type::Integer),
+            Expression::Integer(..) => Ok(Type::i64()),
+            Expression::Char(..) => Ok(Type::i64()),
             Expression::Float(..) => Ok(Type::Float),
             Expression::Boolean(..) => Ok(Type::Boolean),
             Expression::String(..) => Ok(Type::String),
@@ -638,7 +666,7 @@ impl TypeChecker {
                                 Type::GenericInstance(ref n, _)
                                 | Type::Struct { name: ref n }
                                 | Type::Enum { name: ref n } => n.clone(),
-                                Type::Integer => "i64".to_string(),
+                                Type::Integer { .. } => "i64".to_string(),
                                 Type::String => "String".to_string(),
                                 _ => "".to_string(),
                             };
@@ -724,7 +752,7 @@ impl TypeChecker {
                     | Type::Placeholder(ref n) => n.clone(),
                     _ => {
                         return Err(CompileError::new(
-                            format!("member access on {:?}", rt),
+                            format!("member access on {}", rt.name()),
                             span.line,
                             span.col,
                         )
@@ -763,7 +791,7 @@ impl TypeChecker {
                     // Check argument is integer
                     if !arguments.is_empty() {
                         let arg_type = self.check_expression(&arguments[0])?;
-                        if arg_type != Type::Integer {
+                        if !arg_type.is_integer() {
                             return Err(
                                 self.err("offset argument must be an integer", &method_expr)
                             );
@@ -776,9 +804,11 @@ impl TypeChecker {
                     Type::GenericInstance(ref n, _)
                     | Type::Struct { name: ref n }
                     | Type::Enum { name: ref n } => n.clone(),
-                    Type::Integer => "i64".to_string(),
+                    Type::Integer { .. } => "i64".to_string(),
                     Type::String => "String".to_string(),
-                    _ => return Err(self.err(format!("method call on {:?}", rt), &method_expr)),
+                    _ => {
+                        return Err(self.err(format!("method call on {}", rt.name()), &method_expr));
+                    }
                 };
 
                 let full = self.resolve_fuzzy_name(&self.decls, &tn).unwrap_or(tn);
@@ -861,7 +891,7 @@ impl TypeChecker {
                 if let Type::Pointer(t) = rt {
                     Ok(*t)
                 } else {
-                    Ok(Type::Integer)
+                    Ok(Type::i64())
                 }
             }
             Expression::Intrinsic {
@@ -884,7 +914,7 @@ impl TypeChecker {
                     || actual_name == "fs_write"
                     || actual_name == "fs_append"
                 {
-                    Ok(Type::Integer)
+                    Ok(Type::i64())
                 } else if actual_name == "str_concat"
                     || actual_name == "fs_read_to_string"
                     || actual_name == "int_to_str"
@@ -894,7 +924,7 @@ impl TypeChecker {
                 {
                     Ok(Type::String)
                 } else if actual_name == "str_ptr" {
-                    Ok(Type::Pointer(Box::new(Type::Integer)))
+                    Ok(Type::Pointer(Box::new(Type::i64())))
                 } else if actual_name == "mem_is_null" {
                     Ok(Type::Boolean)
                 } else if actual_name == "mem_zero" && !args.is_empty() {
@@ -905,20 +935,20 @@ impl TypeChecker {
                         Expression::Identifier(s, _) | Expression::TypeRef { name: s, .. } => {
                             s.clone()
                         }
-                        _ => return Ok(Type::Integer),
+                        _ => return Ok(Type::i64()),
                     };
                     let full = self.resolve_fuzzy_name(&self.decls, &tnm).unwrap_or(tnm);
                     match self.decls.get(&full) {
                         Some(Declaration::Struct(_)) => Ok(Type::Struct { name: full }),
                         Some(Declaration::Enum(_)) => Ok(Type::Enum { name: full }),
-                        _ => Ok(Type::Integer),
+                        _ => Ok(Type::i64()),
                     }
                 } else if actual_name.starts_with("ai_tensor_") {
                     Ok(Type::Struct {
                         name: "std.ai.tensor.Tensor".to_string(),
                     })
                 } else {
-                    Ok(Type::Integer)
+                    Ok(Type::i64())
                 }
             }
             Expression::If {
@@ -964,7 +994,7 @@ impl TypeChecker {
                 let cond_name = match &cond_type {
                     Type::Enum { name } => name.clone(),
                     Type::GenericInstance(name, _) => name.clone(),
-                    Type::Integer => "i64".to_string(),
+                    Type::Integer { .. } => "i64".to_string(),
                     Type::String => "String".to_string(),
                     Type::Struct { name } => name.clone(),
                     _ => "unknown".to_string(),
@@ -981,7 +1011,7 @@ impl TypeChecker {
 
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
-                        let mut payload = Type::Integer;
+                        let mut payload = Type::i64();
 
                         if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
                             for pat in &all_patterns {
@@ -998,7 +1028,7 @@ impl TypeChecker {
                                 }
                             }
                         } else if cond_name == "i64" {
-                            payload = Type::Integer;
+                            payload = Type::i64();
                         } else if cond_name == "String" {
                             payload = Type::String;
                         } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
@@ -1035,33 +1065,51 @@ impl TypeChecker {
 
     fn check_compatibility(&self, t1: Type, t2: Type, op: &Token) -> Result<Type, CompileError> {
         match t1 {
-            Type::Integer => {
-                if t2 == Type::Integer {
-                    if matches!(
-                        op.kind,
-                        TokenKind::Plus
-                            | TokenKind::Minus
-                            | TokenKind::Star
-                            | TokenKind::Slash
-                            | TokenKind::Percent
-                            | TokenKind::And
-                            | TokenKind::Or
-                            | TokenKind::Caret
-                    ) {
-                        return Ok(Type::Integer);
+            Type::Integer { bits: b1, .. } => {
+                // Integer arithmetic requires both operands to share the same
+                // bit width; mixing i*/u* of the same width is allowed (the
+                // stdlib hash mixes i64 and u64). Different widths (e.g.
+                // i32 + i64) are a type error. #52.
+                if let Type::Integer { bits: b2, .. } = &t2 {
+                    if b1 == *b2 {
+                        if matches!(
+                            op.kind,
+                            TokenKind::Plus
+                                | TokenKind::Minus
+                                | TokenKind::Star
+                                | TokenKind::Slash
+                                | TokenKind::Percent
+                                | TokenKind::And
+                                | TokenKind::Or
+                                | TokenKind::Caret
+                        ) {
+                            return Ok(t1.clone());
+                        }
+                        if matches!(
+                            op.kind,
+                            TokenKind::EqEq
+                                | TokenKind::NotEq
+                                | TokenKind::Lt
+                                | TokenKind::Gt
+                                | TokenKind::LtEq
+                                | TokenKind::GtEq
+                        ) {
+                            return Ok(Type::Boolean);
+                        }
+                        return Ok(t1.clone());
                     }
-                    if matches!(
-                        op.kind,
-                        TokenKind::EqEq
-                            | TokenKind::NotEq
-                            | TokenKind::Lt
-                            | TokenKind::Gt
-                            | TokenKind::LtEq
-                            | TokenKind::GtEq
-                    ) {
-                        return Ok(Type::Boolean);
-                    }
-                    return Ok(Type::Integer);
+                    // Different bit widths: type error.
+                    return Err(CompileError::Type {
+                        message: format!(
+                            "cannot apply '{:?}' to mismatched integer types {} and {}",
+                            op.kind,
+                            t1.name(),
+                            t2.name()
+                        ),
+                        line: op.line,
+                        col: op.col,
+                        snippet: None,
+                    });
                 }
             }
             Type::Float => {
@@ -1098,7 +1146,7 @@ impl TypeChecker {
                 }
             }
             Type::String => {
-                if (t2 == Type::String || t2 == Type::Integer) && op.kind == TokenKind::Plus {
+                if (t2 == Type::String || t2.is_integer()) && op.kind == TokenKind::Plus {
                     return Ok(Type::String);
                 }
                 if t2 == Type::String && matches!(op.kind, TokenKind::EqEq | TokenKind::NotEq) {

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -3,7 +3,15 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
     Unit,
-    Integer,
+    /// Sized integer. `signed` distinguishes i*/u*; `bits` is 8/16/32/64.
+    /// All integer arithmetic requires both operands to share the same
+    /// `(signed, bits)`; mismatched sizes are a type error (#52). Integer
+    /// literals default to i64 (`signed: true, bits: 64`) for backward
+    /// compatibility, and coerce to any integer type at `let`/`return`.
+    Integer {
+        signed: bool,
+        bits: u8,
+    },
     Float,
     Boolean,
     String,
@@ -27,13 +35,64 @@ pub enum Type {
 }
 
 impl Type {
+    /// i64 — the default integer type for literals and unannotated bindings.
+    /// Every existing `i64` program keeps this type. #52.
+    pub fn i64() -> Self {
+        Type::Integer {
+            signed: true,
+            bits: 64,
+        }
+    }
+    pub fn u64() -> Self {
+        Type::Integer {
+            signed: false,
+            bits: 64,
+        }
+    }
+    pub fn i32() -> Self {
+        Type::Integer {
+            signed: true,
+            bits: 32,
+        }
+    }
+    pub fn u32() -> Self {
+        Type::Integer {
+            signed: false,
+            bits: 32,
+        }
+    }
+    pub fn i8() -> Self {
+        Type::Integer {
+            signed: true,
+            bits: 8,
+        }
+    }
+    pub fn u8() -> Self {
+        Type::Integer {
+            signed: false,
+            bits: 8,
+        }
+    }
+
+    /// True for any `Type::Integer { .. }` regardless of signedness/width. #52.
+    pub fn is_integer(&self) -> bool {
+        matches!(self, Type::Integer { .. })
+    }
+
     pub fn parse(s: &str) -> Self {
         let trimmed = s.trim();
         if let Some(stripped) = trimmed.strip_prefix('*') {
             return Type::Pointer(Box::new(Type::parse(stripped.trim())));
         }
         match trimmed {
-            "i64" | "u64" | "i32" | "u32" | "i8" | "u8" => Type::Integer,
+            "i64" => Type::i64(),
+            "u64" => Type::u64(),
+            "i32" => Type::i32(),
+            "u32" => Type::u32(),
+            "i8" => Type::i8(),
+            "u8" => Type::u8(),
+            // Legacy aliases that previously collapsed to Type::Integer.
+            "int" | "Integer" => Type::i64(),
             "f64" => Type::Float,
             "bool" => Type::Boolean,
             "String" => Type::String,
@@ -64,7 +123,36 @@ impl Type {
     pub fn name(&self) -> String {
         match self {
             Type::Unit => "void".to_string(),
-            Type::Integer => "i64".to_string(),
+            Type::Integer {
+                signed: true,
+                bits: 64,
+            } => "i64".to_string(),
+            Type::Integer {
+                signed: false,
+                bits: 64,
+            } => "u64".to_string(),
+            Type::Integer {
+                signed: true,
+                bits: 32,
+            } => "i32".to_string(),
+            Type::Integer {
+                signed: false,
+                bits: 32,
+            } => "u32".to_string(),
+            Type::Integer {
+                signed: true,
+                bits: 8,
+            } => "i8".to_string(),
+            Type::Integer {
+                signed: false,
+                bits: 8,
+            } => "u8".to_string(),
+            // Other widths render generically.
+            Type::Integer { signed: true, bits } => format!("i{}", bits),
+            Type::Integer {
+                signed: false,
+                bits,
+            } => format!("u{}", bits),
             Type::Float => "f64".to_string(),
             Type::Boolean => "bool".to_string(),
             Type::String => "String".to_string(),

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -147,10 +147,46 @@ impl<'ctx> Compiler<'ctx> {
         self.type_to_llvm(&crate::analysis::types::Type::parse(tn))
     }
 
+    /// Coerce an integer value to the target LLVM int type, choosing
+    /// sign-extension / zero-extension / truncation based on the Aion type
+    /// name (`et_clean` like "i32"/"u8"). Used by `let x: i32 = <i64 literal>`
+    /// and similar widening/narrowing sites. #52.
+    fn coerce_int_width(
+        &self,
+        v: inkwell::values::IntValue<'ctx>,
+        target: inkwell::types::IntType<'ctx>,
+        et_clean: &str,
+    ) -> Result<inkwell::values::IntValue<'ctx>, CompileError> {
+        let from_bits = v.get_type().get_bit_width();
+        let to_bits = target.get_bit_width();
+        if from_bits == to_bits {
+            return Ok(v);
+        }
+        // Signedness from the Aion type name (i* signed, u* unsigned).
+        let signed = et_clean.starts_with('i');
+        if to_bits > from_bits {
+            if signed {
+                Ok(self.builder.build_int_s_extend(v, target, "let_sext")?)
+            } else {
+                Ok(self.builder.build_int_z_extend(v, target, "let_zext")?)
+            }
+        } else {
+            Ok(self.builder.build_int_truncate(v, target, "let_trunc")?)
+        }
+    }
+
     fn type_to_llvm(&self, ty: &crate::analysis::types::Type) -> BasicTypeEnum<'ctx> {
         use crate::analysis::types::Type;
         match ty {
-            Type::Integer | Type::Boolean | Type::Date | Type::Duration | Type::Unit => {
+            // Emit the correctly-sized LLVM integer type so that `@sizeof`
+            // and FFI layouts respect i8/i32/i64. #52.
+            Type::Integer { bits, .. } => match bits {
+                8 => self.context.i8_type().into(),
+                16 => self.context.i16_type().into(),
+                32 => self.context.i32_type().into(),
+                _ => self.context.i64_type().into(),
+            },
+            Type::Boolean | Type::Date | Type::Duration | Type::Unit => {
                 self.context.i64_type().into()
             }
             Type::Float => self.context.f64_type().into(),
@@ -801,6 +837,17 @@ impl<'ctx> Compiler<'ctx> {
                                         "let_coerce",
                                     )?
                                     .into()
+                            } else if llvm_t.is_int_type() && v.is_int_value() {
+                                // Integer width coercion: widen (zext/sext) or
+                                // narrow (trunc) the literal/value to the
+                                // annotated integer type. Lets `let x: i32 = 42`
+                                // store an i64 literal into an i32 slot. #52.
+                                self.coerce_int_width(
+                                    v.into_int_value(),
+                                    llvm_t.into_int_type(),
+                                    &et_clean,
+                                )?
+                                .into()
                             } else {
                                 v
                             }

--- a/tests/fixtures/language/integer_mismatch.ai
+++ b/tests/fixtures/language/integer_mismatch.ai
@@ -1,0 +1,8 @@
+// Mismatched integer sizes must produce a type error. #52.
+
+fn main() {
+    let a: i32 = 1
+    let b: i64 = 2
+    let c = a + b
+    return c
+}

--- a/tests/fixtures/language/integer_sizes.ai
+++ b/tests/fixtures/language/integer_sizes.ai
@@ -1,0 +1,21 @@
+use std.io
+use std.string
+
+// Verify that annotated integer types get distinct LLVM sizes via @sizeof.
+// #52 — integer sizes (i8/u8/i32/u32/i64/u64).
+
+fn main() {
+    let a: i32 = 0
+    let b: u8 = 0
+    let c: i64 = 0
+    let d: u32 = 0
+    let e: i8 = 0
+
+    io.println(string.from_int(@sizeof(a))) // 4
+    io.println(string.from_int(@sizeof(b))) // 1
+    io.println(string.from_int(@sizeof(c))) // 8
+    io.println(string.from_int(@sizeof(d))) // 4
+    io.println(string.from_int(@sizeof(e))) // 1
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -220,6 +220,14 @@ fn test_option_result_methods() {
 fn test_sizeof_variables() {
     assert_snapshot!(run_aion_test("language/sizeof_variables"));
 }
+#[test]
+fn test_integer_sizes() {
+    assert_snapshot!(run_aion_test("language/integer_sizes"));
+}
+#[test]
+fn test_integer_mismatch() {
+    assert_snapshot!(run_aion_test("language/integer_mismatch"));
+}
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__hashmap_resize_hashset.snap
+++ b/tests/snapshots/integration__hashmap_resize_hashset.snap
@@ -8,7 +8,7 @@ Len after: 2
 Success: b removed
 Testing HashMap resize...
 Len after many inserts: 22
-Error: key_5 not found
+key_5 value: 5
 Testing HashSet...
 Set contains apple
 Success: apple removed from set

--- a/tests/snapshots/integration__integer_mismatch.snap
+++ b/tests/snapshots/integration__integer_mismatch.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/integer_mismatch\")"
+---
+Type Error: cannot apply 'Plus' to mismatched integer types i32 and i64

--- a/tests/snapshots/integration__integer_sizes.snap
+++ b/tests/snapshots/integration__integer_sizes.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/integer_sizes\")"
+---
+4
+1
+8
+4
+1

--- a/tests/snapshots/integration__ptr_deref_member_err.snap
+++ b/tests/snapshots/integration__ptr_deref_member_err.snap
@@ -2,4 +2,4 @@
 source: tests/integration.rs
 expression: "run_aion_test(\"stdlib/ptr_deref_member_err\")"
 ---
-Type Error: member access on Integer
+Type Error: member access on i64


### PR DESCRIPTION
## Summary

`Type::Integer` was a unit variant — `i8`/`u8`/`i32`/`u32`/`i64`/`u64` all collapsed to the same type, so FFI interop and overflow detection were unsound and the SPEC's claim of distinct sizes was a lie. This refactor makes `Type::Integer` a struct variant `{ signed: bool, bits: u8 }`, emits correctly-sized LLVM integer types, and enforces that arithmetic between different bit widths is a type error. Integer literals default to `i64` (backward compatible) and coerce to any annotated integer type at `let`.

**Side-effect: fixes a latent hashmap bug.** The stdlib `hash.ai` mixes `i64` and `u64`; under the old single-`i64` type the hash computation was subtly wrong, causing `hashmap_resize_hashset` to lose the `key_5` entry on resize (`Error: key_5 not found` → `key_5 value: 5`). With distinct `u64` hashing the lookup now succeeds.

## Changes

- **`src/analysis/types.rs`**: `Type::Integer { signed: bool, bits: u8 }` struct variant + convenience ctors (`Type::i64()`/`i32()`/`u8()`/...) + `is_integer()` helper. `parse` maps each token to the right variant; `name` renders `'i64'`/`'i32'`/`'u8'`/...
- **`src/analysis/checker.rs`**:
  - Honor `let` type annotations (`let x: i32 = 0` now types `x` as `i32` — #78 annotations were parsed but previously ignored).
  - Integer arithmetic requires same bit width; `i32 + i64` is a type error. Same-width signed/unsigned mixing (`i64 ^ u64`) is allowed, result takes the LHS type.
  - `is_integer()` for the offset-argument check; `.name()` instead of `{:?}` in member/method-access errors.
- **`src/codegen/compiler.rs`**: `type_to_llvm` emits `i8_type()`/`i32_type()`/`i64_type()` so `@sizeof` and FFI layouts respect the width. New `coerce_int_width` (sext/zext/trunc) at `let` for integer width coercion (`let x: i32 = <i64 literal>` truncates).
- **`docs/SPEC.md`**: document distinct integer types + the same-width arithmetic rule.
- **`tests`**:
  - `integer_sizes.ai` (new) — `@sizeof` returns 4/1/8/4/1 for `i32`/`u8`/`i64`/`u32`/`i8`.
  - `integer_mismatch.ai` (new) — `i32 + i64` produces `Type Error: cannot apply 'Plus' to mismatched integer types i32 and i64`.
  - Updated `hashmap_resize_hashset` snapshot (bug fix) and `ptr_deref_member_err` snapshot (improved error message: `on i64` instead of `on Integer`).

## Tests

- [x] Nominal: `integer_sizes.ai` verifies `@sizeof` for each width; `integer_mismatch.ai` verifies the type error.
- [x] Edge cases: same-width signed/unsigned mixing (`i64 ^ u64`) exercised by the stdlib hash (covered by `hashmap_basic`/`hashmap_resize_hashset`).
- [x] Error cases: `integer_mismatch.ai` snapshots the mismatch error; `ptr_deref_member_err` regression.
- [x] Full suite: 90 integration + 9 lib tests pass (`cargo test -- --test-threads=1`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Backward compat: all existing `i64` code unchanged (literals default to `i64`).

## Docs

- [x] `docs/SPEC.md` — Primitives section + Known Limitations updated with the distinct integer types and the same-width arithmetic rule.

Closes #52