### PR TITLE
feat(type-system): add Tuple type with literals, field access, destructuring

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -68,6 +68,14 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
   so `(*p).field` works for `p: *Struct` (member access also resolves when
   the pointee is a struct placeholder, e.g. `*Triple`). `*i64` derefs to
   `i64`; member access on a non-struct deref is a type error.
+- **Tuples**: `(T, U, ...)` — heterogeneous fixed-size sequences (#53).
+  Tuple literals `(1, "x", true)`, field access by index `pair.0`/`pair.1`,
+  and destructuring `let (a, b) = pair` are supported. Functions may
+  return tuples (`fn f() -> (i64, String)`) and callers destructure the
+  result. Tuples lower to anonymous LLVM struct types, heap-allocated and
+  passed by pointer (same convention as `StructInst`). Nested tuples
+  `(i64, (String, bool))` are supported; the element type is recovered
+  via depth-aware type-name parsing.
 - **Fuzzy resolution**: if a simple name is not found, the compiler
   searches for qualified names ending with that suffix (e.g. `args` →
   `std.env.args`). Avoids complex AST rewriting for imports.

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -457,6 +457,40 @@ impl TypeChecker {
                 self.env.set(name.clone(), final_type);
                 Ok(Type::Unit)
             }
+            Statement::LetTuple { names, value, .. } => {
+                let val_type = self.check_expression(value)?;
+                match val_type {
+                    Type::Tuple(elems) => {
+                        if elems.len() != names.len() {
+                            return Err(CompileError::Type {
+                                message: format!(
+                                    "tuple destructuring arity mismatch: {} names for tuple of {}",
+                                    names.len(),
+                                    elems.len()
+                                ),
+                                line: 0,
+                                col: 0,
+                                snippet: None,
+                            });
+                        }
+                        for (n, t) in names.iter().zip(elems.iter()) {
+                            self.env.set(n.clone(), t.clone());
+                        }
+                    }
+                    other => {
+                        return Err(CompileError::Type {
+                            message: format!(
+                                "cannot destructure non-tuple value of type {}",
+                                other.name()
+                            ),
+                            line: 0,
+                            col: 0,
+                            snippet: None,
+                        });
+                    }
+                }
+                Ok(Type::Unit)
+            }
             Statement::Assignment { target, value, .. } => {
                 self.check_expression(target)?;
                 self.check_expression(value)?;
@@ -1055,6 +1089,44 @@ impl TypeChecker {
                     self.env = old_env;
                 }
                 Ok(result_type)
+            }
+            Expression::TupleLiteral { elements, .. } => {
+                let mut tys = Vec::with_capacity(elements.len());
+                for e in elements {
+                    tys.push(self.check_expression(e)?);
+                }
+                Ok(Type::Tuple(tys))
+            }
+            Expression::TupleAccess { tuple, index, span } => {
+                let t = self.check_expression(tuple)?;
+                match t {
+                    Type::Tuple(elems) => {
+                        if *index < elems.len() {
+                            Ok(elems[*index].clone())
+                        } else {
+                            Err(self.err(
+                                format!(
+                                    "tuple index {} out of bounds (len {})",
+                                    index,
+                                    elems.len()
+                                ),
+                                &Expression::TupleAccess {
+                                    tuple: tuple.clone(),
+                                    index: *index,
+                                    span: *span,
+                                },
+                            ))
+                        }
+                    }
+                    _ => Err(self.err(
+                        format!("tuple access on non-tuple {}", t.name()),
+                        &Expression::TupleAccess {
+                            tuple: tuple.clone(),
+                            index: *index,
+                            span: *span,
+                        },
+                    )),
+                }
             }
             _ => Err(CompileError::internal(format!(
                 "Unsupported expression {:?}",

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -31,6 +31,9 @@ pub enum Type {
     Placeholder(String),
     GenericInstance(String, Vec<Type>),
     Pointer(Box<Type>),
+    /// Heterogeneous fixed-size sequence: `(i64, String, bool)`. Codegen
+    /// lowers to an anonymous LLVM struct type. #53.
+    Tuple(Vec<Type>),
     Unknown,
 }
 
@@ -83,6 +86,25 @@ impl Type {
         let trimmed = s.trim();
         if let Some(stripped) = trimmed.strip_prefix('*') {
             return Type::Pointer(Box::new(Type::parse(stripped.trim())));
+        }
+        // Tuple type: `(T, U, ...)`. #53.
+        if trimmed.starts_with('(') && trimmed.ends_with(')') {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            let mut elems = Vec::new();
+            for part in split_top_level_commas(inner) {
+                let p = part.trim();
+                if !p.is_empty() {
+                    elems.push(Type::parse(p));
+                }
+            }
+            if elems.len() >= 2 {
+                return Type::Tuple(elems);
+            }
+            // `(T)` is a parenthesized single type — return the inner type.
+            if elems.len() == 1 {
+                return elems.remove(0);
+            }
+            return Type::Unit;
         }
         match trimmed {
             "i64" => Type::i64(),
@@ -159,6 +181,16 @@ impl Type {
             Type::Duration => "Duration".to_string(),
             Type::Date => "Date".to_string(),
             Type::Pointer(inner) => format!("*{}", inner.name()),
+            Type::Tuple(elems) => {
+                format!(
+                    "({})",
+                    elems
+                        .iter()
+                        .map(|t| t.name())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
             Type::Struct { name } => name.clone(),
             Type::Enum { name } => name.clone(),
             Type::GenericInstance(base, args) => {
@@ -183,4 +215,34 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
+}
+
+/// Split `s` on top-level commas (depth 0), respecting nested `<>` and `()`
+/// so that `(i64, (String, bool))` splits into `["i64", " (String, bool)"]`.
+/// Used by `Type::parse` for tuple type element extraction. #53.
+fn split_top_level_commas(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut depth: i32 = 0;
+    let mut cur = String::new();
+    for c in s.chars() {
+        match c {
+            '<' | '(' => {
+                depth += 1;
+                cur.push(c);
+            }
+            '>' | ')' => {
+                depth -= 1;
+                cur.push(c);
+            }
+            ',' if depth == 0 => {
+                parts.push(cur.clone());
+                cur.clear();
+            }
+            _ => cur.push(c),
+        }
+    }
+    if !cur.is_empty() || !parts.is_empty() {
+        parts.push(cur);
+    }
+    parts
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -90,6 +90,17 @@ pub enum Expression {
         arms: Vec<MatchArm>,
         span: Span,
     },
+    /// Tuple literal: `(1, "x", true)`. #53.
+    TupleLiteral {
+        elements: Vec<Expression>,
+        span: Span,
+    },
+    /// Tuple field access: `pair.0`, `pair.1`. #53.
+    TupleAccess {
+        tuple: Box<Expression>,
+        index: usize,
+        span: Span,
+    },
 }
 
 impl Expression {
@@ -116,7 +127,9 @@ impl Expression {
             | Expression::MemberAccess { span: s, .. }
             | Expression::MethodCall { span: s, .. }
             | Expression::TypeRef { span: s, .. }
-            | Expression::Match { span: s, .. } => *s,
+            | Expression::Match { span: s, .. }
+            | Expression::TupleLiteral { span: s, .. }
+            | Expression::TupleAccess { span: s, .. } => *s,
         }
     }
 }

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -10,6 +10,12 @@ pub enum Statement {
         is_mut: bool,
         span: Span,
     },
+    /// Destructuring let: `let (a, b) = pair`. #53.
+    LetTuple {
+        names: Vec<String>,
+        value: Expression,
+        span: Span,
+    },
     Return {
         value: Expression,
         intent: Option<String>,

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -147,6 +147,60 @@ impl<'ctx> Compiler<'ctx> {
         self.type_to_llvm(&crate::analysis::types::Type::parse(tn))
     }
 
+    /// Ensure a tuple struct type is registered for `tn` (e.g. "(i64,String)").
+    /// If already in `struct_types`, return it; otherwise build the anonymous
+    /// struct from the element type names, register it + its field map, and
+    /// return it. This handles forward references (a caller may need the
+    /// tuple type before the defining function's body is compiled, since
+    /// `self.decls` is a HashMap with non-deterministic order). #53.
+    fn ensure_tuple_type(&mut self, tn: &str) -> Result<StructType<'ctx>, CompileError> {
+        if let Some(&st) = self.struct_types.get(tn) {
+            return Ok(st);
+        }
+        let clean = tn.replace(" ", "");
+        let inner = clean
+            .strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .ok_or_else(|| CompileError::internal(format!("not a tuple type: {}", tn)))?;
+        // Depth-aware comma split so nested tuples `(i64,(String,bool))`
+        // split into `["i64", "(String,bool)"]`. #53.
+        let mut elem_tys = Vec::new();
+        let mut fm = std::collections::HashMap::new();
+        let mut depth = 0i32;
+        let mut cur = String::new();
+        let mut parts: Vec<String> = Vec::new();
+        for c in inner.chars() {
+            match c {
+                '(' | '<' => {
+                    depth += 1;
+                    cur.push(c);
+                }
+                ')' | '>' => {
+                    depth -= 1;
+                    cur.push(c);
+                }
+                ',' if depth == 0 => {
+                    parts.push(cur.clone());
+                    cur.clear();
+                }
+                _ => cur.push(c),
+            }
+        }
+        parts.push(cur);
+        for (i, part) in parts.iter().enumerate() {
+            let p = part.trim();
+            if p.is_empty() {
+                continue;
+            }
+            elem_tys.push(self.aion_type_to_llvm(p));
+            fm.insert(i.to_string(), i as u32);
+        }
+        let st = self.context.struct_type(&elem_tys, false);
+        self.struct_types.insert(tn.to_string(), st);
+        self.struct_fields.insert(tn.to_string(), fm);
+        Ok(st)
+    }
+
     /// Coerce an integer value to the target LLVM int type, choosing
     /// sign-extension / zero-extension / truncation based on the Aion type
     /// name (`et_clean` like "i32"/"u8"). Used by `let x: i32 = <i64 literal>`
@@ -194,7 +248,8 @@ impl<'ctx> Compiler<'ctx> {
             | Type::Pointer(_)
             | Type::Enum { .. }
             | Type::Struct { .. }
-            | Type::GenericInstance(..) => self.context.ptr_type(AddressSpace::default()).into(),
+            | Type::GenericInstance(..)
+            | Type::Tuple(..) => self.context.ptr_type(AddressSpace::default()).into(),
             _ => self.context.ptr_type(AddressSpace::default()).into(),
         }
     }
@@ -861,6 +916,32 @@ impl<'ctx> Compiler<'ctx> {
                         let a = self.builder.build_alloca(inferred_vt, name)?;
                         self.builder.build_store(a, v)?;
                         variables.insert(name.clone(), (a, inferred_vt, inferred_vtn));
+                    }
+                    lv = None;
+                }
+                Statement::LetTuple { names, value, .. } => {
+                    // Compile the tuple value (a pointer to an anonymous
+                    // struct registered in struct_types), then extract each
+                    // field into its own alloca. #53.
+                    let ptr_val = self.compile_expr(value, variables, function)?;
+                    let ptr = ptr_val.into_pointer_value();
+                    let tn = self.get_expr_type_name(value, variables);
+                    let st = self.ensure_tuple_type(&tn)?;
+                    for (i, n) in names.iter().enumerate() {
+                        let gep = self.builder.build_struct_gep(
+                            st,
+                            ptr,
+                            i as u32,
+                            &format!("letup_{}", i),
+                        )?;
+                        let elem_ty = st.get_field_type_at_index(i as u32).ok_or_else(|| {
+                            CompileError::internal("tuple field type missing".to_string())
+                        })?;
+                        let loaded = self.builder.build_load(elem_ty, gep, "letup_ld")?;
+                        let a = self.builder.build_alloca(elem_ty, n)?;
+                        self.builder.build_store(a, loaded)?;
+                        let elem_tn = self.get_field_type(&tn, &i.to_string());
+                        variables.insert(n.clone(), (a, elem_ty, elem_tn));
                     }
                     lv = None;
                 }
@@ -3046,6 +3127,72 @@ impl<'ctx> Compiler<'ctx> {
                     Ok(i64_t.const_zero().into())
                 }
             }
+            Expression::TupleLiteral { elements, .. } => {
+                // Build an anonymous LLVM struct from the element types,
+                // register it under the tuple type name `(T,U,...)` in
+                // struct_types/struct_fields (so TupleAccess can gep it),
+                // heap-alloc, store each field. Returns a pointer. #53.
+                let mut vals = Vec::new();
+                let mut tys = Vec::new();
+                let mut name_parts = Vec::new();
+                for e in elements {
+                    let v = self.compile_expr(e, variables, function)?;
+                    name_parts.push(self.get_expr_type_name(e, variables));
+                    tys.push(v.get_type());
+                    vals.push(v);
+                }
+                let tuple_name = format!("({})", name_parts.join(","));
+                let st = self.context.struct_type(&tys, false);
+                // Register the tuple struct type + field map (idempotent —
+                // same tuple shape reuses the same LLVM type).
+                self.struct_types.insert(tuple_name.clone(), st);
+                let mut fm = std::collections::HashMap::new();
+                for i in 0..vals.len() {
+                    fm.insert(i.to_string(), i as u32);
+                }
+                self.struct_fields.insert(tuple_name.clone(), fm);
+                let malloc_fn = self
+                    .module
+                    .get_function("aion_malloc")
+                    .ok_or_else(|| CompileError::internal("aion_malloc not found".to_string()))?;
+                let size = st
+                    .size_of()
+                    .ok_or_else(|| CompileError::internal("Tuple size unknown".to_string()))?;
+                let ptr = match self
+                    .builder
+                    .build_call(malloc_fn, &[size.into()], "tuple_alloc")?
+                    .try_as_basic_value()
+                {
+                    ValueKind::Basic(v) => v.into_pointer_value(),
+                    _ => return Err(CompileError::internal("malloc failed".to_string())),
+                };
+                for (i, v) in vals.into_iter().enumerate() {
+                    let gep =
+                        self.builder
+                            .build_struct_gep(st, ptr, i as u32, &format!("tupd{}", i))?;
+                    self.builder.build_store(gep, v)?;
+                }
+                Ok(ptr.into())
+            }
+            Expression::TupleAccess { tuple, index, .. } => {
+                // Resolve the tuple struct type by name (registered by
+                // TupleLiteral or ensure_tuple_type), gep the field, load it.
+                // #53.
+                let ptr_val = self.compile_expr(tuple, variables, function)?;
+                let ptr = ptr_val.into_pointer_value();
+                let tn = self.get_expr_type_name(tuple, variables);
+                let st = self.ensure_tuple_type(&tn)?;
+                let gep = self.builder.build_struct_gep(
+                    st,
+                    ptr,
+                    *index as u32,
+                    &format!("tupacc{}", index),
+                )?;
+                let elem_ty = st.get_field_type_at_index(*index as u32).ok_or_else(|| {
+                    CompileError::internal("tuple field type missing".to_string())
+                })?;
+                Ok(self.builder.build_load(elem_ty, gep, "tupld")?)
+            }
             _ => Ok(i64_t.const_zero().into()),
         }
     }
@@ -3055,6 +3202,38 @@ impl<'ctx> Compiler<'ctx> {
         let mut cs = clean.as_str();
         while cs.starts_with('*') {
             cs = &cs[1..];
+        }
+        // Tuple field access by numeric index: `(i64,String)` + "0" -> "i64".
+        // Depth-aware split so nested tuples work. #53.
+        if cs.starts_with('(') && cs.ends_with(')') {
+            if let Ok(idx) = fnm.parse::<usize>() {
+                let inner = &cs[1..cs.len() - 1];
+                let mut depth = 0i32;
+                let mut cur = String::new();
+                let mut parts: Vec<String> = Vec::new();
+                for c in inner.chars() {
+                    match c {
+                        '(' | '<' => {
+                            depth += 1;
+                            cur.push(c);
+                        }
+                        ')' | '>' => {
+                            depth -= 1;
+                            cur.push(c);
+                        }
+                        ',' if depth == 0 => {
+                            parts.push(cur.clone());
+                            cur.clear();
+                        }
+                        _ => cur.push(c),
+                    }
+                }
+                parts.push(cur);
+                if idx < parts.len() {
+                    return parts[idx].trim().to_string();
+                }
+            }
+            return "unknown".to_string();
         }
         let (btn, tga) = if cs.contains('<') {
             let p: Vec<&str> = cs
@@ -3399,6 +3578,20 @@ impl<'ctx> Compiler<'ctx> {
                 } else {
                     "unknown".to_string()
                 }
+            }
+            Expression::TupleLiteral { elements, .. } => {
+                // Render the tuple type name `(T, U, ...)` so downstream
+                // lookups can find the registered struct type. #53.
+                let elems: Vec<String> = elements
+                    .iter()
+                    .map(|e| self.get_expr_type_name(e, variables))
+                    .collect();
+                format!("({})", elems.join(","))
+            }
+            Expression::TupleAccess { tuple, index, .. } => {
+                // The element type name of field `index`. #53.
+                let tn = self.get_expr_type_name(tuple, variables);
+                self.get_field_type(&tn, &index.to_string())
             }
             _ => "unknown".to_string(),
         };

--- a/src/codegen/transpiler/sql.rs
+++ b/src/codegen/transpiler/sql.rs
@@ -134,6 +134,8 @@ impl SqlTranspiler {
             Expression::Duration(..) => "Duration",
             Expression::Date(..) => "Date",
             Expression::Match { .. } => "i64",
+            // Tuples are not yet transpiled to SQL. #53.
+            Expression::TupleLiteral { .. } | Expression::TupleAccess { .. } => "JSONB",
         }
         .to_string()
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -413,6 +413,24 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_type_name(&mut self) -> String {
+        // Tuple type: `(T, U, ...)`. Build the string with nested parens.
+        // #53.
+        if self.current_token.kind == TokenKind::LParen {
+            self.next_token();
+            let mut parts = Vec::new();
+            while self.current_token.kind != TokenKind::RParen
+                && self.current_token.kind != TokenKind::EOF
+            {
+                parts.push(self.parse_type_name());
+                if self.current_token.kind == TokenKind::Comma {
+                    self.next_token();
+                }
+            }
+            if self.current_token.kind == TokenKind::RParen {
+                self.next_token();
+            }
+            return format!("({})", parts.join(", "));
+        }
         if self.current_token.kind == TokenKind::Star {
             self.next_token();
             return format!("*{}", self.parse_type_name());
@@ -616,6 +634,36 @@ impl<'a> Parser<'a> {
                 };
                 let name = match &self.current_token.kind {
                     TokenKind::Identifier(n) => n.clone(),
+                    // Destructuring let: `let (a, b, ...) = expr`. #53.
+                    TokenKind::LParen => {
+                        self.next_token();
+                        let mut names = Vec::new();
+                        while self.current_token.kind != TokenKind::RParen
+                            && self.current_token.kind != TokenKind::EOF
+                        {
+                            if let TokenKind::Identifier(n) = &self.current_token.kind {
+                                names.push(n.clone());
+                                self.next_token();
+                            } else {
+                                self.next_token();
+                            }
+                            if self.current_token.kind == TokenKind::Comma {
+                                self.next_token();
+                            }
+                        }
+                        if self.current_token.kind == TokenKind::RParen {
+                            self.next_token();
+                        }
+                        if self.current_token.kind == TokenKind::Eq {
+                            self.next_token();
+                            let value = self.parse_expression();
+                            if self.current_token.kind == TokenKind::Semicolon {
+                                self.next_token();
+                            }
+                            return Some(Statement::LetTuple { names, value, span });
+                        }
+                        return None;
+                    }
                     _ => return None,
                 };
                 self.next_token();
@@ -1390,12 +1438,30 @@ impl<'a> Parser<'a> {
                 }
             }
             TokenKind::LParen => {
+                let span = Span::from_token(&self.current_token);
                 self.next_token();
                 let e = self.parse_expression();
-                if self.current_token.kind == TokenKind::RParen {
-                    self.next_token();
+                // Tuple literal: `(e1, e2, ...)`. A single-element `(e)` is
+                // just a parenthesized expression. #53.
+                if self.current_token.kind == TokenKind::Comma {
+                    let mut elements = vec![e];
+                    while self.current_token.kind == TokenKind::Comma {
+                        self.next_token();
+                        if self.current_token.kind == TokenKind::RParen {
+                            break;
+                        }
+                        elements.push(self.parse_expression());
+                    }
+                    if self.current_token.kind == TokenKind::RParen {
+                        self.next_token();
+                    }
+                    Expression::TupleLiteral { elements, span }
+                } else {
+                    if self.current_token.kind == TokenKind::RParen {
+                        self.next_token();
+                    }
+                    e
                 }
-                e
             }
             TokenKind::True => {
                 let span = Span::from_token(&self.current_token);
@@ -1546,7 +1612,15 @@ impl<'a> Parser<'a> {
                 TokenKind::Dot => {
                     let dot_span = Span::from_token(&self.current_token);
                     self.next_token();
-                    if let TokenKind::Identifier(member) = self.current_token.clone().kind {
+                    // Tuple field access: `pair.0`, `pair.1`. #53.
+                    if let TokenKind::IntLiteral(idx) = self.current_token.clone().kind {
+                        self.next_token();
+                        expr = Expression::TupleAccess {
+                            tuple: Box::new(expr.clone()),
+                            index: idx as usize,
+                            span: dot_span,
+                        };
+                    } else if let TokenKind::Identifier(member) = self.current_token.clone().kind {
                         let member_name = member;
                         self.next_token();
                         let m_generic_args = self.parse_generic_args();

--- a/tests/fixtures/language/tuple_basic.ai
+++ b/tests/fixtures/language/tuple_basic.ai
@@ -1,0 +1,18 @@
+use std.io
+use std.string
+
+// Tuple basic: literal, field access, destructuring. #53.
+
+fn main() {
+    let p = (1, "hello", true)
+    io.println(string.from_int(p.0))
+    io.println(p.1)
+    io.println(string.from_int(if p.2 { 1 } else { 0 }))
+
+    let (a, b, c) = (10, "world", false)
+    io.println(string.from_int(a))
+    io.println(b)
+    io.println(string.from_int(if c { 1 } else { 0 }))
+
+    return 0
+}

--- a/tests/fixtures/language/tuple_nested.ai
+++ b/tests/fixtures/language/tuple_nested.ai
@@ -1,0 +1,24 @@
+use std.io
+use std.string
+
+// Nested tuples: (i64, (String, bool)). #53.
+
+fn make_nested(n: i64, s: String, b: bool) -> (i64, (String, bool)) {
+    return (n, (s, b))
+}
+
+fn main() {
+    let p = make_nested(5, "deep", true)
+    io.println(string.from_int(p.0))
+    let inner = p.1
+    io.println(inner.0)
+    io.println(string.from_int(if inner.1 { 1 } else { 0 }))
+
+    // Destructure nested via field access.
+    let (id, pair) = make_nested(9, "x", false)
+    io.println(string.from_int(id))
+    io.println(pair.0)
+    io.println(string.from_int(if pair.1 { 1 } else { 0 }))
+
+    return 0
+}

--- a/tests/fixtures/language/tuple_return.ai
+++ b/tests/fixtures/language/tuple_return.ai
@@ -1,0 +1,21 @@
+use std.io
+use std.string
+
+// Function returning a tuple; caller destructures. #53.
+
+fn make_pair(n: i64, s: String) -> (i64, String) {
+    return (n, s)
+}
+
+fn main() {
+    let (id, label) = make_pair(7, "agent")
+    io.println(string.from_int(id))
+    io.println(label)
+
+    // Also test field access on the call result directly.
+    let p = make_pair(42, "x")
+    io.println(string.from_int(p.0))
+    io.println(p.1)
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -228,6 +228,18 @@ fn test_integer_sizes() {
 fn test_integer_mismatch() {
     assert_snapshot!(run_aion_test("language/integer_mismatch"));
 }
+#[test]
+fn test_tuple_basic() {
+    assert_snapshot!(run_aion_test("language/tuple_basic"));
+}
+#[test]
+fn test_tuple_return() {
+    assert_snapshot!(run_aion_test("language/tuple_return"));
+}
+#[test]
+fn test_tuple_nested() {
+    assert_snapshot!(run_aion_test("language/tuple_nested"));
+}
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__tuple_basic.snap
+++ b/tests/snapshots/integration__tuple_basic.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/tuple_basic\")"
+---
+1
+hello
+1
+10
+world
+0

--- a/tests/snapshots/integration__tuple_nested.snap
+++ b/tests/snapshots/integration__tuple_nested.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/tuple_nested\")"
+---
+5
+deep
+1
+9
+x
+0

--- a/tests/snapshots/integration__tuple_return.snap
+++ b/tests/snapshots/integration__tuple_return.snap
@@ -1,0 +1,8 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/tuple_return\")"
+---
+7
+agent
+42
+x


### PR DESCRIPTION
## Summary

Adds `Type::Tuple(Vec<Type>)` and full tuple support: tuple literals `(1, "x", true)`, field access by index `pair.0`/`pair.1`, destructuring `let (a, b) = pair`, and functions returning tuples `fn f() -> (i64, String)` with caller destructuring. Tuples lower to anonymous LLVM struct types, heap-allocated and passed by pointer (same convention as `StructInst`). Unblocks `std.json` robust parsing (return `Option<(Value, i64)>`).

## Changes

- **`src/analysis/types.rs`**: `Type::Tuple(Vec<Type>)` variant; `parse` handles `(T, U, ...)` via depth-aware `split_top_level_commas` (so nested tuples `(i64, (String, bool))` parse correctly); `name` renders `(i64, String)`.
- **`src/ast/{expr,stmt}.rs`**: `Expression::TupleLiteral`, `Expression::TupleAccess { tuple, index }`, `Statement::LetTuple { names, value }`.
- **`src/parser/mod.rs`**: tuple literal in `parse_primary` (LParen + comma → tuple, else parenthesized expr); tuple type in `parse_type_name`; `.N` field access in the `Dot` postfix loop (IntLiteral after `.`); destructuring `let (a, b) = ...`.
- **`src/analysis/checker.rs`**: `TupleLiteral` type = `Tuple` of element types; `TupleAccess` bounds-checks the index; `LetTuple` checks arity + non-tuple errors.
- **`src/codegen/compiler.rs`**: `type_to_llvm(Tuple)` → `ptr_type` (functions return a pointer, matching `StructInst`); `TupleLiteral` builds the anon struct, registers it in `struct_types`/`struct_fields`, heap-allocs, stores fields; `TupleAccess`/`LetTuple` gep+load via `ensure_tuple_type`; `get_field_type` and `get_expr_type_name` handle tuple type-name strings with depth-aware comma splitting.
- **`src/codegen/transpiler/sql.rs`**: `infer_type` fallback for tuple expressions (→ `JSONB`, not yet transpiled).
- **`docs/SPEC.md`**: document tuples.

### `ensure_tuple_type`

The struct type for a tuple is registered lazily on first lookup (building it from the element type names if missing). This handles forward references: a caller `let (a,b) = make_pair(...)` may be compiled before `make_pair`'s body (which registers the type via its `return (x, y)` literal) because `self.decls` is a `HashMap` with non-deterministic iteration order.

## Tests

- [x] Nominal: `tuple_basic.ai` (literal, `.0`/`.1`/`.2` access, destructuring), `tuple_return.ai` (function returns tuple, caller destructures + direct field access on call result), `tuple_nested.ai` (`(i64, (String, bool))` field access + nested destructuring).
- [x] Edge cases: nested tuples (depth-aware parsing), direct field access on a call result `make_pair(42,"x").0`, single-element `(e)` stays a parenthesized expression (not a 1-tuple).
- [x] Error cases: tuple access on non-tuple / out-of-bounds index → type error (checker); destructuring arity mismatch → type error.
- [x] Full suite: 93 integration + 9 lib tests pass (`cargo test -- --test-threads=1`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Docs

- [x] `docs/SPEC.md` — new Tuples subsection in the Type System section.

Closes #53