### PR TITLE
feat(type-system): add fixed-size Array type [T; N] with bounds checking

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -76,6 +76,14 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
   passed by pointer (same convention as `StructInst`). Nested tuples
   `(i64, (String, bool))` are supported; the element type is recovered
   via depth-aware type-name parsing.
+- **Arrays**: `[T; N]` — homogeneous fixed-size sequences (#54). Array
+  literals `[1, 2, 3]`, index reads `arr[i]`, index writes `arr[i] = v`,
+  and passing arrays to functions are supported. All elements must share
+  the same type. Arrays are stack-allocated as LLVM `[N x T]` types and
+  passed by pointer. Indexing is bounds-checked at runtime; an
+  out-of-bounds access calls the `aion_array_oob(idx, len)` trap
+  (stderr message + `exit(1)`) instead of producing undefined behavior.
+  `@sizeof([T; N])` returns `N * sizeof(T)`.
 - **Fuzzy resolution**: if a simple name is not found, the compiler
   searches for qualified names ending with that suffix (e.g. `args` →
   `std.env.args`). Avoids complex AST rewriting for imports.

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -1138,14 +1138,22 @@ impl TypeChecker {
                         elem_ty = t;
                     } else if elem_ty != t {
                         return Err(self.err(
-                            format!("array literal has mixed element types {} and {}", elem_ty.name(), t.name()),
+                            format!(
+                                "array literal has mixed element types {} and {}",
+                                elem_ty.name(),
+                                t.name()
+                            ),
                             e,
                         ));
                     }
                 }
                 Ok(Type::Array(Box::new(elem_ty), elements.len() as u64))
             }
-            Expression::Index { target, index, span } => {
+            Expression::Index {
+                target,
+                index,
+                span,
+            } => {
                 let t = self.check_expression(target)?;
                 let idx_t = self.check_expression(index)?;
                 if !idx_t.is_integer() {

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -1128,6 +1128,50 @@ impl TypeChecker {
                     )),
                 }
             }
+            Expression::ArrayLiteral { elements, .. } => {
+                // `[e1, e2, ...]` → `Array(elem_type, len)`. All elements
+                // must share the same type. #54.
+                let mut elem_ty = Type::Unknown;
+                for e in elements {
+                    let t = self.check_expression(e)?;
+                    if elem_ty == Type::Unknown {
+                        elem_ty = t;
+                    } else if elem_ty != t {
+                        return Err(self.err(
+                            format!("array literal has mixed element types {} and {}", elem_ty.name(), t.name()),
+                            e,
+                        ));
+                    }
+                }
+                Ok(Type::Array(Box::new(elem_ty), elements.len() as u64))
+            }
+            Expression::Index { target, index, span } => {
+                let t = self.check_expression(target)?;
+                let idx_t = self.check_expression(index)?;
+                if !idx_t.is_integer() {
+                    return Err(self.err(
+                        format!("array index must be an integer, got {}", idx_t.name()),
+                        &Expression::Index {
+                            target: target.clone(),
+                            index: index.clone(),
+                            span: *span,
+                        },
+                    ));
+                }
+                match t {
+                    Type::Array(elem, _) => Ok(*elem),
+                    // Pointer indexing stays an unsafe op (existing behavior).
+                    Type::Pointer(inner) => Ok(*inner),
+                    _ => Err(self.err(
+                        format!("cannot index into {}", t.name()),
+                        &Expression::Index {
+                            target: target.clone(),
+                            index: index.clone(),
+                            span: *span,
+                        },
+                    )),
+                }
+            }
             _ => Err(CompileError::internal(format!(
                 "Unsupported expression {:?}",
                 expr

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -34,6 +34,10 @@ pub enum Type {
     /// Heterogeneous fixed-size sequence: `(i64, String, bool)`. Codegen
     /// lowers to an anonymous LLVM struct type. #53.
     Tuple(Vec<Type>),
+    /// Fixed-size homogeneous array: `[i64; 10]`. Codegen lowers to an LLVM
+    /// array type `[N x elem]`, stack-allocated. Indexing is bounds-checked
+    /// at runtime. #54.
+    Array(Box<Type>, u64),
     Unknown,
 }
 
@@ -105,6 +109,32 @@ impl Type {
                 return elems.remove(0);
             }
             return Type::Unit;
+        }
+        // Array type: `[T; N]`. #54.
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            // Split on the top-level ';' separating element type and size.
+            let mut depth = 0i32;
+            let mut split_at = None;
+            for (i, c) in inner.chars().enumerate() {
+                match c {
+                    '[' | '(' | '<' => depth += 1,
+                    ']' | ')' | '>' => depth -= 1,
+                    ';' if depth == 0 => {
+                        split_at = Some(i);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(i) = split_at {
+                let elem_str = inner[..i].trim();
+                let size_str = inner[i + 1..].trim();
+                if let Ok(n) = size_str.parse::<u64>() {
+                    return Type::Array(Box::new(Type::parse(elem_str)), n);
+                }
+            }
+            return Type::Unknown;
         }
         match trimmed {
             "i64" => Type::i64(),
@@ -191,6 +221,7 @@ impl Type {
                         .join(", ")
                 )
             }
+            Type::Array(elem, n) => format!("[{}; {}]", elem.name(), n),
             Type::Struct { name } => name.clone(),
             Type::Enum { name } => name.clone(),
             Type::GenericInstance(base, args) => {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -101,6 +101,17 @@ pub enum Expression {
         index: usize,
         span: Span,
     },
+    /// Array literal: `[1, 2, 3]`. #54.
+    ArrayLiteral {
+        elements: Vec<Expression>,
+        span: Span,
+    },
+    /// Array index: `arr[i]`. #54.
+    Index {
+        target: Box<Expression>,
+        index: Box<Expression>,
+        span: Span,
+    },
 }
 
 impl Expression {
@@ -129,7 +140,9 @@ impl Expression {
             | Expression::TypeRef { span: s, .. }
             | Expression::Match { span: s, .. }
             | Expression::TupleLiteral { span: s, .. }
-            | Expression::TupleAccess { span: s, .. } => *s,
+            | Expression::TupleAccess { span: s, .. }
+            | Expression::ArrayLiteral { span: s, .. }
+            | Expression::Index { span: s, .. } => *s,
         }
     }
 }

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -151,9 +151,7 @@ impl<'ctx> Compiler<'ctx> {
     /// and the count. Returns None if `tn` is not an array type-name. #54.
     fn parse_array_type_name(&self, tn: &str) -> Option<(BasicTypeEnum<'ctx>, u64)> {
         let clean = tn.replace(" ", "");
-        let inner = clean
-            .strip_prefix('[')
-            .and_then(|s| s.strip_suffix(']'))?;
+        let inner = clean.strip_prefix('[').and_then(|s| s.strip_suffix(']'))?;
         // Top-level ';' split.
         let mut depth = 0i32;
         let mut split_at = None;
@@ -1716,9 +1714,7 @@ impl<'ctx> Compiler<'ctx> {
                 };
                 Ok((p, et))
             }
-            Expression::Index {
-                target, index, ..
-            } => {
+            Expression::Index { target, index, .. } => {
                 // `arr[i] = v` lvalue with the same runtime bounds check as
                 // the read path. Returns the element slot pointer. #54.
                 let i64_t = self.context.i64_type();
@@ -1726,24 +1722,34 @@ impl<'ctx> Compiler<'ctx> {
                 let idx_val = self.compile_expr(index, variables, function)?;
                 let idx = idx_val.into_int_value();
                 let tn = self.get_expr_type_name(target, variables);
-                let (elem_llvm, n) = self
-                    .parse_array_type_name(&tn)
-                    .ok_or_else(|| CompileError::internal(format!("array type '{}' not parseable", tn)))?;
+                let (elem_llvm, n) = self.parse_array_type_name(&tn).ok_or_else(|| {
+                    CompileError::internal(format!("array type '{}' not parseable", tn))
+                })?;
                 let arr_ty = elem_llvm.array_type(n as u32);
                 let arr_ptr = arr_val.into_pointer_value();
                 let in_bounds = self.builder.build_and(
-                    self.builder.build_int_compare(IntPredicate::SGE, idx, i64_t.const_zero(), "arr_lo")?,
-                    self.builder.build_int_compare(IntPredicate::SLT, idx, i64_t.const_int(n, false), "arr_hi")?,
+                    self.builder.build_int_compare(
+                        IntPredicate::SGE,
+                        idx,
+                        i64_t.const_zero(),
+                        "arr_lo",
+                    )?,
+                    self.builder.build_int_compare(
+                        IntPredicate::SLT,
+                        idx,
+                        i64_t.const_int(n, false),
+                        "arr_hi",
+                    )?,
                     "arr_inb",
                 )?;
                 let oob_bb = self.context.append_basic_block(function, "arr_oob");
                 let ok_bb = self.context.append_basic_block(function, "arr_ok");
-                self.builder.build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
+                self.builder
+                    .build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
                 self.builder.position_at_end(oob_bb);
-                let oob_fn = self
-                    .module
-                    .get_function("aion_array_oob")
-                    .ok_or_else(|| CompileError::internal("aion_array_oob not found".to_string()))?;
+                let oob_fn = self.module.get_function("aion_array_oob").ok_or_else(|| {
+                    CompileError::internal("aion_array_oob not found".to_string())
+                })?;
                 self.builder.build_call(
                     oob_fn,
                     &[idx.into(), i64_t.const_int(n, false).into()],
@@ -2686,7 +2692,9 @@ impl<'ctx> Compiler<'ctx> {
                         let arr_ty = elem_llvm.array_type(n as u32);
                         return Ok(arr_ty
                             .size_of()
-                            .ok_or_else(|| CompileError::internal("Array size unknown".to_string()))?
+                            .ok_or_else(|| {
+                                CompileError::internal("Array size unknown".to_string())
+                            })?
                             .into());
                     }
                     let lt = self.aion_type_to_llvm(&tnm);
@@ -3302,10 +3310,7 @@ impl<'ctx> Compiler<'ctx> {
                         self.builder.build_in_bounds_gep(
                             arr_ty,
                             arr_ptr,
-                            &[
-                                i64_t.const_int(0, false),
-                                i64_t.const_int(i as u64, false),
-                            ],
+                            &[i64_t.const_int(0, false), i64_t.const_int(i as u64, false)],
                             &format!("arr_set{}", i),
                         )?
                     };
@@ -3321,26 +3326,36 @@ impl<'ctx> Compiler<'ctx> {
                 let idx_val = self.compile_expr(index, variables, function)?;
                 let idx = idx_val.into_int_value();
                 let tn = self.get_expr_type_name(target, variables);
-                let (elem_llvm, n) = self
-                    .parse_array_type_name(&tn)
-                    .ok_or_else(|| CompileError::internal(format!("array type '{}' not parseable", tn)))?;
+                let (elem_llvm, n) = self.parse_array_type_name(&tn).ok_or_else(|| {
+                    CompileError::internal(format!("array type '{}' not parseable", tn))
+                })?;
                 let arr_ty = elem_llvm.array_type(n as u32);
                 let arr_ptr = arr_val.into_pointer_value();
                 // Bounds check: idx >= 0 && idx < n, else exit.
                 let in_bounds = self.builder.build_and(
-                    self.builder.build_int_compare(IntPredicate::SGE, idx, i64_t.const_zero(), "arr_lo")?,
-                    self.builder.build_int_compare(IntPredicate::SLT, idx, i64_t.const_int(n, false), "arr_hi")?,
+                    self.builder.build_int_compare(
+                        IntPredicate::SGE,
+                        idx,
+                        i64_t.const_zero(),
+                        "arr_lo",
+                    )?,
+                    self.builder.build_int_compare(
+                        IntPredicate::SLT,
+                        idx,
+                        i64_t.const_int(n, false),
+                        "arr_hi",
+                    )?,
                     "arr_inb",
                 )?;
                 let oob_bb = self.context.append_basic_block(function, "arr_oob");
                 let ok_bb = self.context.append_basic_block(function, "arr_ok");
-                self.builder.build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
+                self.builder
+                    .build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
                 // OOB: call the runtime trap aion_array_oob(idx, len).
                 self.builder.position_at_end(oob_bb);
-                let oob_fn = self
-                    .module
-                    .get_function("aion_array_oob")
-                    .ok_or_else(|| CompileError::internal("aion_array_oob not found".to_string()))?;
+                let oob_fn = self.module.get_function("aion_array_oob").ok_or_else(|| {
+                    CompileError::internal("aion_array_oob not found".to_string())
+                })?;
                 self.builder.build_call(
                     oob_fn,
                     &[idx.into(), i64_t.const_int(n, false).into()],

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -147,6 +147,34 @@ impl<'ctx> Compiler<'ctx> {
         self.type_to_llvm(&crate::analysis::types::Type::parse(tn))
     }
 
+    /// Parse an array type-name string `[T; N]` into the element LLVM type
+    /// and the count. Returns None if `tn` is not an array type-name. #54.
+    fn parse_array_type_name(&self, tn: &str) -> Option<(BasicTypeEnum<'ctx>, u64)> {
+        let clean = tn.replace(" ", "");
+        let inner = clean
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))?;
+        // Top-level ';' split.
+        let mut depth = 0i32;
+        let mut split_at = None;
+        for (i, c) in inner.chars().enumerate() {
+            match c {
+                '[' | '(' | '<' => depth += 1,
+                ']' | ')' | '>' => depth -= 1,
+                ';' if depth == 0 => {
+                    split_at = Some(i);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let i = split_at?;
+        let elem_str = inner[..i].trim();
+        let size_str = inner[i + 1..].trim();
+        let n = size_str.parse::<u64>().ok()?;
+        Some((self.aion_type_to_llvm(elem_str), n))
+    }
+
     /// Ensure a tuple struct type is registered for `tn` (e.g. "(i64,String)").
     /// If already in `struct_types`, return it; otherwise build the anonymous
     /// struct from the element type names, register it + its field map, and
@@ -249,7 +277,8 @@ impl<'ctx> Compiler<'ctx> {
             | Type::Enum { .. }
             | Type::Struct { .. }
             | Type::GenericInstance(..)
-            | Type::Tuple(..) => self.context.ptr_type(AddressSpace::default()).into(),
+            | Type::Tuple(..)
+            | Type::Array(..) => self.context.ptr_type(AddressSpace::default()).into(),
             _ => self.context.ptr_type(AddressSpace::default()).into(),
         }
     }
@@ -747,6 +776,13 @@ impl<'ctx> Compiler<'ctx> {
         self.module.add_function(
             "aion_ai_tensor_move",
             pt.fn_type(&[pt.into(), pt.into()], false),
+            None,
+        );
+        self.module.add_function(
+            "aion_array_oob",
+            self.context
+                .void_type()
+                .fn_type(&[i64_t.into(), i64_t.into()], false),
             None,
         );
 
@@ -1680,6 +1716,51 @@ impl<'ctx> Compiler<'ctx> {
                 };
                 Ok((p, et))
             }
+            Expression::Index {
+                target, index, ..
+            } => {
+                // `arr[i] = v` lvalue with the same runtime bounds check as
+                // the read path. Returns the element slot pointer. #54.
+                let i64_t = self.context.i64_type();
+                let arr_val = self.compile_expr(target, variables, function)?;
+                let idx_val = self.compile_expr(index, variables, function)?;
+                let idx = idx_val.into_int_value();
+                let tn = self.get_expr_type_name(target, variables);
+                let (elem_llvm, n) = self
+                    .parse_array_type_name(&tn)
+                    .ok_or_else(|| CompileError::internal(format!("array type '{}' not parseable", tn)))?;
+                let arr_ty = elem_llvm.array_type(n as u32);
+                let arr_ptr = arr_val.into_pointer_value();
+                let in_bounds = self.builder.build_and(
+                    self.builder.build_int_compare(IntPredicate::SGE, idx, i64_t.const_zero(), "arr_lo")?,
+                    self.builder.build_int_compare(IntPredicate::SLT, idx, i64_t.const_int(n, false), "arr_hi")?,
+                    "arr_inb",
+                )?;
+                let oob_bb = self.context.append_basic_block(function, "arr_oob");
+                let ok_bb = self.context.append_basic_block(function, "arr_ok");
+                self.builder.build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
+                self.builder.position_at_end(oob_bb);
+                let oob_fn = self
+                    .module
+                    .get_function("aion_array_oob")
+                    .ok_or_else(|| CompileError::internal("aion_array_oob not found".to_string()))?;
+                self.builder.build_call(
+                    oob_fn,
+                    &[idx.into(), i64_t.const_int(n, false).into()],
+                    "oob_call",
+                )?;
+                self.builder.build_unreachable()?;
+                self.builder.position_at_end(ok_bb);
+                let gep = unsafe {
+                    self.builder.build_in_bounds_gep(
+                        arr_ty,
+                        arr_ptr,
+                        &[i64_t.const_zero(), idx],
+                        "arr_setp",
+                    )?
+                };
+                Ok((gep, elem_llvm))
+            }
             _ => Err(CompileError::internal(format!("Not an lvalue: {:?}", e))),
         }
     }
@@ -2598,6 +2679,16 @@ impl<'ctx> Compiler<'ctx> {
                             .ok_or_else(|| CompileError::internal("Enum size unknown".to_string()))?
                             .into());
                     }
+                    // Array type `[T; N]`: size = N * sizeof(T). The
+                    // generic lowering maps arrays to pointers, so compute
+                    // the real array size here. #54.
+                    if let Some((elem_llvm, n)) = self.parse_array_type_name(&clean) {
+                        let arr_ty = elem_llvm.array_type(n as u32);
+                        return Ok(arr_ty
+                            .size_of()
+                            .ok_or_else(|| CompileError::internal("Array size unknown".to_string()))?
+                            .into());
+                    }
                     let lt = self.aion_type_to_llvm(&tnm);
                     let res = if lt.is_pointer_type() {
                         i64_t.const_int(8, false).into()
@@ -3193,6 +3284,81 @@ impl<'ctx> Compiler<'ctx> {
                 })?;
                 Ok(self.builder.build_load(elem_ty, gep, "tupld")?)
             }
+            Expression::ArrayLiteral { elements, .. } => {
+                // Stack-allocated LLVM array `[N x elem]`. The variable
+                // slot holds a pointer to the alloca (uniform with the
+                // Tuple/Struct convention). #54.
+                let elem_llvm = if elements.is_empty() {
+                    self.context.i64_type().into()
+                } else {
+                    let v0 = self.compile_expr(&elements[0], variables, function)?;
+                    v0.get_type()
+                };
+                let arr_ty = elem_llvm.array_type(elements.len() as u32);
+                let arr_ptr = self.builder.build_alloca(arr_ty, "arr_alloc")?;
+                for (i, e) in elements.iter().enumerate() {
+                    let v = self.compile_expr(e, variables, function)?;
+                    let gep = unsafe {
+                        self.builder.build_in_bounds_gep(
+                            arr_ty,
+                            arr_ptr,
+                            &[
+                                i64_t.const_int(0, false),
+                                i64_t.const_int(i as u64, false),
+                            ],
+                            &format!("arr_set{}", i),
+                        )?
+                    };
+                    self.builder.build_store(gep, v)?;
+                }
+                Ok(arr_ptr.into())
+            }
+            Expression::Index { target, index, .. } => {
+                // `arr[i]` with runtime bounds check. The array pointer is
+                // loaded from the variable slot; the array type is parsed
+                // from the variable's stored type-name `[T; N]`. #54.
+                let arr_val = self.compile_expr(target, variables, function)?;
+                let idx_val = self.compile_expr(index, variables, function)?;
+                let idx = idx_val.into_int_value();
+                let tn = self.get_expr_type_name(target, variables);
+                let (elem_llvm, n) = self
+                    .parse_array_type_name(&tn)
+                    .ok_or_else(|| CompileError::internal(format!("array type '{}' not parseable", tn)))?;
+                let arr_ty = elem_llvm.array_type(n as u32);
+                let arr_ptr = arr_val.into_pointer_value();
+                // Bounds check: idx >= 0 && idx < n, else exit.
+                let in_bounds = self.builder.build_and(
+                    self.builder.build_int_compare(IntPredicate::SGE, idx, i64_t.const_zero(), "arr_lo")?,
+                    self.builder.build_int_compare(IntPredicate::SLT, idx, i64_t.const_int(n, false), "arr_hi")?,
+                    "arr_inb",
+                )?;
+                let oob_bb = self.context.append_basic_block(function, "arr_oob");
+                let ok_bb = self.context.append_basic_block(function, "arr_ok");
+                self.builder.build_conditional_branch(in_bounds, ok_bb, oob_bb)?;
+                // OOB: call the runtime trap aion_array_oob(idx, len).
+                self.builder.position_at_end(oob_bb);
+                let oob_fn = self
+                    .module
+                    .get_function("aion_array_oob")
+                    .ok_or_else(|| CompileError::internal("aion_array_oob not found".to_string()))?;
+                self.builder.build_call(
+                    oob_fn,
+                    &[idx.into(), i64_t.const_int(n, false).into()],
+                    "oob_call",
+                )?;
+                self.builder.build_unreachable()?;
+                // OK: gep + load.
+                self.builder.position_at_end(ok_bb);
+                let gep = unsafe {
+                    self.builder.build_in_bounds_gep(
+                        arr_ty,
+                        arr_ptr,
+                        &[i64_t.const_zero(), idx],
+                        "arr_get",
+                    )?
+                };
+                Ok(self.builder.build_load(elem_llvm, gep, "arr_ld")?)
+            }
             _ => Ok(i64_t.const_zero().into()),
         }
     }
@@ -3592,6 +3758,16 @@ impl<'ctx> Compiler<'ctx> {
                 // The element type name of field `index`. #53.
                 let tn = self.get_expr_type_name(tuple, variables);
                 self.get_field_type(&tn, &index.to_string())
+            }
+            Expression::ArrayLiteral { elements, .. } => {
+                // Render `[T; N]` from the first element's type so that
+                // downstream `arr[i]` codegen can parse the array type. #54.
+                let elem_tn = if elements.is_empty() {
+                    "i64".to_string()
+                } else {
+                    self.get_expr_type_name(&elements[0], variables)
+                };
+                format!("[{}; {}]", elem_tn, elements.len())
             }
             _ => "unknown".to_string(),
         };

--- a/src/codegen/transpiler/sql.rs
+++ b/src/codegen/transpiler/sql.rs
@@ -136,6 +136,8 @@ impl SqlTranspiler {
             Expression::Match { .. } => "i64",
             // Tuples are not yet transpiled to SQL. #53.
             Expression::TupleLiteral { .. } | Expression::TupleAccess { .. } => "JSONB",
+            // Arrays are not yet transpiled to SQL. #54.
+            Expression::ArrayLiteral { .. } | Expression::Index { .. } => "JSONB",
         }
         .to_string()
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -431,6 +431,26 @@ impl<'a> Parser<'a> {
             }
             return format!("({})", parts.join(", "));
         }
+        // Array type: `[T; N]`. #54.
+        if self.current_token.kind == TokenKind::LBracket {
+            self.next_token();
+            let elem = self.parse_type_name();
+            let size = if self.current_token.kind == TokenKind::Semicolon {
+                self.next_token();
+                if let TokenKind::IntLiteral(n) = self.current_token.kind {
+                    self.next_token();
+                    n.to_string()
+                } else {
+                    "0".to_string()
+                }
+            } else {
+                "0".to_string()
+            };
+            if self.current_token.kind == TokenKind::RBracket {
+                self.next_token();
+            }
+            return format!("[{}; {}]", elem, size);
+        }
         if self.current_token.kind == TokenKind::Star {
             self.next_token();
             return format!("*{}", self.parse_type_name());
@@ -1473,6 +1493,24 @@ impl<'a> Parser<'a> {
                 self.next_token();
                 Expression::Boolean(false, span)
             }
+            TokenKind::LBracket => {
+                // Array literal: `[e1, e2, ...]`. #54.
+                let span = Span::from_token(&self.current_token);
+                self.next_token();
+                let mut elements = Vec::new();
+                while self.current_token.kind != TokenKind::RBracket
+                    && self.current_token.kind != TokenKind::EOF
+                {
+                    elements.push(self.parse_expression());
+                    if self.current_token.kind == TokenKind::Comma {
+                        self.next_token();
+                    }
+                }
+                if self.current_token.kind == TokenKind::RBracket {
+                    self.next_token();
+                }
+                Expression::ArrayLiteral { elements, span }
+            }
             TokenKind::Minus => {
                 let span = Span::from_token(&self.current_token);
                 self.next_token();
@@ -1541,7 +1579,20 @@ impl<'a> Parser<'a> {
                         while self.current_token.kind != TokenKind::RParen
                             && self.current_token.kind != TokenKind::EOF
                         {
-                            args.push(self.parse_expression());
+                            // `@sizeof`/`@mem_zero` take type arguments, so a
+                            // `[T; N]` array type-name is parsed as a TypeRef
+                            // rather than an array literal. #54.
+                            if self.current_token.kind == TokenKind::LBracket {
+                                let tspan = Span::from_token(&self.current_token);
+                                let tn = self.parse_type_name();
+                                args.push(Expression::TypeRef {
+                                    name: tn,
+                                    generic_args: vec![],
+                                    span: tspan,
+                                });
+                            } else {
+                                args.push(self.parse_expression());
+                            }
                             if self.current_token.kind == TokenKind::Comma {
                                 self.next_token();
                             }
@@ -1609,6 +1660,20 @@ impl<'a> Parser<'a> {
 
         loop {
             match self.current_token.kind {
+                TokenKind::LBracket => {
+                    // Array index: `arr[i]`. #54.
+                    let span = Span::from_token(&self.current_token);
+                    self.next_token();
+                    let index = self.parse_expression();
+                    if self.current_token.kind == TokenKind::RBracket {
+                        self.next_token();
+                    }
+                    expr = Expression::Index {
+                        target: Box::new(expr.clone()),
+                        index: Box::new(index),
+                        span,
+                    };
+                }
                 TokenKind::Dot => {
                     let dot_span = Span::from_token(&self.current_token);
                     self.next_token();

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -16,6 +16,12 @@ void aion_spawn(void* func_ptr) {
     pthread_create(&thread, NULL, spark_entry_point, func_ptr);
 }
 
+/* Runtime bounds-check trap for array indexing. #54. */
+void aion_array_oob(long long idx, long long len) {
+    fprintf(stderr, "error: array index %lld out of bounds (len %lld)\n", idx, len);
+    exit(1);
+}
+
 void* aion_malloc(size_t size) {
     return GC_malloc(size);
 }

--- a/tests/fixtures/language/array_as_param.ai
+++ b/tests/fixtures/language/array_as_param.ai
@@ -1,0 +1,21 @@
+use std.io
+use std.string
+
+// Array passed to a function: the array pointer is forwarded, the callee
+// indexes it with the same bounds-checked lowering. #54.
+
+fn sum(arr: [i64; 4]) -> i64 {
+    let mut total = 0
+    let mut i = 0
+    while i < 4 {
+        total = total + arr[i]
+        i = i + 1
+    }
+    return total
+}
+
+fn main() {
+    let b: [i64; 4] = [1, 2, 3, 4]
+    io.println(string.from_int(sum(b)))
+    return 0
+}

--- a/tests/fixtures/language/array_basic.ai
+++ b/tests/fixtures/language/array_basic.ai
@@ -1,0 +1,28 @@
+use std.io
+use std.string
+
+// Array basic: literal, index read/write, iterate, type annotation. #54.
+
+fn main() {
+    let a = [10, 20, 30]
+    io.println(string.from_int(a[0]))
+    io.println(string.from_int(a[1]))
+    io.println(string.from_int(a[2]))
+
+    a[1] = 99
+    io.println(string.from_int(a[1]))
+
+    let b: [i64; 4] = [1, 2, 3, 4]
+    let mut sum = 0
+    let mut i = 0
+    while i < 4 {
+        sum = sum + b[i]
+        i = i + 1
+    }
+    io.println(string.from_int(sum))
+
+    // @sizeof on an array type returns N * sizeof(elem) = 10 * 8 = 80. #54.
+    io.println(string.from_int(@sizeof([i64; 10])))
+
+    return 0
+}

--- a/tests/fixtures/language/array_bounds.ai
+++ b/tests/fixtures/language/array_bounds.ai
@@ -1,0 +1,10 @@
+use std.io
+use std.string
+
+// Array out-of-bounds access must produce a runtime error (not UB). #54.
+
+fn main() {
+    let a = [10, 20, 30]
+    io.println(string.from_int(a[5]))
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -47,7 +47,16 @@ fn run_aion_test(path: &str) -> String {
         }
     }
 
-    between.join("\n").trim().to_string()
+    let extracted = between.join("\n").trim().to_string();
+
+    // Runtime crashes (e.g. array OOB trap) print to stderr and produce no
+    // stdout between the dashes — fall back to stderr so the error is
+    // captured. #54.
+    if extracted.is_empty() && !stderr.trim().is_empty() {
+        return stderr.trim().to_string();
+    }
+
+    extracted
 }
 
 // --- Language Tests ---
@@ -239,6 +248,18 @@ fn test_tuple_return() {
 #[test]
 fn test_tuple_nested() {
     assert_snapshot!(run_aion_test("language/tuple_nested"));
+}
+#[test]
+fn test_array_basic() {
+    assert_snapshot!(run_aion_test("language/array_basic"));
+}
+#[test]
+fn test_array_bounds() {
+    assert_snapshot!(run_aion_test("language/array_bounds"));
+}
+#[test]
+fn test_array_as_param() {
+    assert_snapshot!(run_aion_test("language/array_as_param"));
 }
 
 // --- Stdlib Tests ---

--- a/tests/snapshots/integration__array_as_param.snap
+++ b/tests/snapshots/integration__array_as_param.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/array_as_param\")"
+---
+10

--- a/tests/snapshots/integration__array_basic.snap
+++ b/tests/snapshots/integration__array_basic.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/array_basic\")"
+---
+10
+20
+30
+99
+10
+80

--- a/tests/snapshots/integration__array_bounds.snap
+++ b/tests/snapshots/integration__array_bounds.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/array_bounds\")"
+---
+error: array index 5 out of bounds (len 3)
+error: process exited with code: 1


### PR DESCRIPTION
## Summary
Adds a fixed-size, homogeneous, stack-allocated array type `[T; N]` to the Aion type system, with array literals, index reads/writes, runtime bounds checking, passing arrays to functions, and `@sizeof` support. Previously only `*T` pointers existed — there was no safe fixed-size array; this closes that gap (#54).

## Changes

### AST / Types
- `Type::Array(Box<Type>, u64)` variant (`src/analysis/types.rs`); `Type::parse` and `Type::name` handle `[T; N]` with depth-aware `;` splitting.

### Parser
- `[T; N]` type-name parsing (`src/parser/mod.rs`).
- Array literal `[e1, e2, ...]` and postfix index `arr[i]` parsing.
- `@intrinsic(...)` argument parser now parses `[T; N]` as a `TypeRef` (so `@sizeof([i64; 10])` works).

### Checker
- `Expression::ArrayLiteral` infers `Array(elem, len)` and enforces homogeneous element types.
- `Expression::Index` type-checks the index is an integer and returns the element type (array or pointer indexing).

### Codegen
- `Expression::ArrayLiteral` lowers to a stack `alloca` of `[N x elem]` with element stores via two-index in-bounds GEP.
- `Expression::Index` (read) lowers to a runtime bounds-checked load (`aion_array_oob` trap on OOB, then `unreachable`).
- `Expression::Index` (write, via `compile_lvalue`) mirrors the read path's bounds check and returns the element slot pointer.
- `get_expr_type_name` handles `ArrayLiteral` so the variable carries `[T; N]` for downstream indexing.
- `@sizeof([T; N])` returns `N * sizeof(T)` (array type is normally lowered to `ptr`, so sizeof is computed from the real LLVM array type).
- SQL transpiler marks `ArrayLiteral`/`Index` as `JSONB` (not yet transpiled).

### Runtime
- `aion_array_oob(long long idx, long long len)` trap in `src/runtime.c` (stderr message + `exit(1)`); declared in the module and baked into `/opt/aion_runtime.bc`.

### Tests
- Test runner (`tests/integration.rs`) gains a stderr fallback: when a program crashes with no stdout between the dashes (e.g. OOB trap), the stderr is snapshotted.

## Tests

- [x] Fixture added: `tests/fixtures/language/array_basic.ai` — literal, index read, index write, iterate, `@sizeof`
- [x] Fixture added: `tests/fixtures/language/array_bounds.ai` — out-of-bounds produces runtime error
- [x] Fixture added: `tests/fixtures/language/array_as_param.ai` — pass array to function
- [x] All tests pass: `cargo test --test integration` (96 passed, 0 failed)
- [x] `cargo clippy -D warnings` clean
- [x] Snapshots reviewed (contents verified: `10 20 30 99 10 80`, OOB error message, `10`)

## Docs

- [x] `docs/SPEC.md` updated (new "Arrays" subsection under Types)

## Closes

Closes #54