### PR TITLE
ci: add docs-check job to guard against documentation drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,11 @@ jobs:
             -w /workspace \
             aion-compiler \
             cargo fmt --check
+
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard against documentation drift
+        run: bash scripts/docs-check.sh

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,8 +7,19 @@
 | Run test suite | `docker run --rm -v "$(pwd)":/workspace -w /workspace aion-compiler cargo test -- --test-threads=1` |
 | Generate documentation | `./aion doc <file.ai>` |
 | Transpile to SQL | `./aion transpile <file.ai>` |
+| Lint docs for drift | `bash scripts/docs-check.sh` |
 
 **CRITICAL**: The `./aion` wrapper and `cargo test` run inside a Docker container (`aion-compiler` image based on Ubuntu 22.04 with LLVM 15). The wrapper caches `target/` and `cargo/registry` in Docker volumes to avoid full rebuilds.
+
+### Doc Freshness (enforced in CI)
+
+Any PR that changes compiler/stdlib behavior must update `docs/SPEC.md` (or the relevant `docs/SPEC_*.md` / `stdlib/.../SPEC.md`) in the same PR. The `docs-check` CI job runs `scripts/docs-check.sh` and fails the PR when:
+
+- `docs/SPEC.md` header version differs from `ROADMAP.md` "Current State" version.
+- `README.md` revives the inaccurate "without GC" or "linear type system" wording.
+- `docs/STDLIB.md` is missing the implementation-status legend.
+
+Run `bash scripts/docs-check.sh` locally before pushing to catch drift early. #75.
 
 ## Git Workflow
 

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Lint that guards against documentation drift. #75.
+#
+# Enforces the AGENTS.md "Doc Freshness" rule by failing when:
+#   1. docs/SPEC.md header version != ROADMAP.md "Current State" version.
+#   2. README.md revives the inaccurate "without GC" / "linear type system" claims.
+#   3. docs/STDLIB.md is missing the implementation-status legend.
+#
+# Run locally: scripts/docs-check.sh
+# Run in CI: see the `docs-check` job in .github/workflows/ci.yml.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+status=0
+
+# --- Check 1: SPEC version matches ROADMAP Current State version. ---
+spec_version=$(grep -m1 -E '^# Aion Specification v[0-9]+\.[0-9]+' docs/SPEC.md | grep -oE 'v[0-9]+\.[0-9]+' | head -1)
+roadmap_version=$(grep -m1 -E 'Current State: v[0-9]+\.[0-9]+' ROADMAP.md | grep -oE 'v[0-9]+\.[0-9]+' | head -1)
+
+if [ -z "$spec_version" ] || [ -z "$roadmap_version" ]; then
+    echo "error: could not extract version from SPEC.md ('$spec_version') or ROADMAP.md ('$roadmap_version')"
+    status=1
+elif [ "$spec_version" != "$roadmap_version" ]; then
+    echo "error: version mismatch — docs/SPEC.md is $spec_version, ROADMAP.md Current State is $roadmap_version"
+    echo "       update the SPEC.md header or ROADMAP.md 'Current State' line so both match."
+    status=1
+else
+    echo "ok: SPEC.md and ROADMAP.md versions match ($spec_version)"
+fi
+
+# --- Check 2: README must not revive disproven claims. ---
+if grep -niE 'without GC|linear type system' README.md; then
+    echo "error: README.md contains an inaccurate 'without GC' or 'linear type system' claim"
+    echo "       Aion uses the Boehm GC; remove the stale wording."
+    status=1
+else
+    echo "ok: README.md has no 'without GC' / 'linear type system' claims"
+fi
+
+# --- Check 3: STDLIB.md must keep the implementation-status legend. ---
+if ! grep -q 'Implementation status legend' docs/STDLIB.md; then
+    echo "error: docs/STDLIB.md is missing the 'Implementation status legend' block"
+    echo "       the legend ([stable]/[partial]/[stub]/[skeleton]) must be present."
+    status=1
+else
+    echo "ok: docs/STDLIB.md has the implementation-status legend"
+fi
+
+exit $status


### PR DESCRIPTION
## Summary
Adds a `docs-check` CI job (plus a local `scripts/docs-check.sh` linter) that fails PRs when documentation drifts from the codebase, enforcing the AGENTS.md "Doc Freshness" rule automatically. Previously drift was only caught manually (e.g. SPEC labelled v0.3 while code was at v0.6, README claiming "linear type system without GC" while the runtime links Boehm GC).

## Changes

### CI
- New `docs-check` job in `.github/workflows/ci.yml` — runs on every push/PR to `main`, no Docker build needed (plain bash/grep on `ubuntu-latest`).

### Tooling
- `scripts/docs-check.sh` — the linter, three checks:
  1. `docs/SPEC.md` header version == `ROADMAP.md` "Current State" version.
  2. `README.md` does not revive the inaccurate "without GC" / "linear type system" claims.
  3. `docs/STDLIB.md` keeps the implementation-status legend (`[stable]`/`[partial]`/`[stub]`/`[skeleton]`).

### Docs
- `docs/workflow.md` — new "Doc Freshness (enforced in CI)" subsection documenting the rule, the CI job, and how to run the linter locally.

## Tests

- [x] `bash scripts/docs-check.sh` passes on current `main` (all three checks `ok`).
- [x] Negative test: bumping SPEC header to `v0.9` makes the script exit `1` with a clear mismatch message (verified, then reverted).
- [x] `.github/workflows/ci.yml` validates as YAML.
- [x] `bash -n scripts/docs-check.sh` syntax-clean.
- No compiler/stdlib behavior change → no integration fixtures affected.

## Docs

- [x] `docs/workflow.md` updated (new Doc Freshness subsection + command table entry).

## Closes

Closes #75