### PR TITLE
docs: mark std.ai.tensor as [partial] (closes #110)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -179,8 +179,10 @@ First-class `Duration` and `Date` literals (see `docs/SPEC_TIME.md`).
 - **Threading**: 1:1 via `pthread`. `spawn { ... }` creates detached
   threads. `aion_spawn` is currently a C runtime builtin — rewriting it
   in Aion is a ROADMAP item (Self-Runtime).
-- **AI Tensors**: first-class `std.ai.tensor` with `zeros`, `ones`,
-  `rand`, `matmul`, `backward` (autograd), `to(device)`.
+- **AI Tensors**: first-class `std.ai.tensor`. Constructors `zeros`,
+  `ones`, `rand` are functional; `matmul`, `add` and `backward` (autograd)
+  are runtime placeholders, not yet implemented (see `docs/STDLIB.md` and
+  `src/runtime.c:220-235`).
 - **Intents**: `::intent "..."` syntax for AI-guided compilation hints.
   Handled as a `NoOp` statement (not an expression).
 - **Short-circuiting**: `&&` and `||` use lazy evaluation via

--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -124,12 +124,14 @@ Native Clustering.
 
 ## 6. Artificial Intelligence (Native)
 
-### `std.ai.tensor` **[stable]**
-The core of Aion.
-- `Tensor`: N-dimensional array.
-- `matmul`, `add`: Accelerated math.
-- `backward()`: Automatic differentiation (Autograd).
-- `to(device)`: GPU/TPU support.
+### `std.ai.tensor` **[partial]**
+The core of Aion. Only the constructors are functional today; the math ops
+and autograd are runtime placeholders (see `src/runtime.c:220-235`).
+- `tensor_zeros`, `tensor_ones`, `tensor_rand`: Working constructors.
+- `tensor_move`: Device transfer stub (currently a no-op string swap, not real GPU/TPU).
+- `matmul`, `add`: **Not implemented** — `aion_ai_tensor_matmul` / `aion_ai_tensor_add` return a zero tensor regardless of input (`// Placeholder: return zeros for now`).
+- `backward()`: **Not implemented** — `aion_ai_tensor_backward` only prints to stdout, no gradient is computed.
+- `to(device)`: See `tensor_move` above; no real device support yet.
 
 ### `std.media`
 - **`image`** **[skeleton]** — Load/Save images, convert to Tensor.


### PR DESCRIPTION
## Summary

`std.ai.tensor` was advertised as **[stable]** with `matmul` / `add` ("Accelerated math") and `backward()` ("Automatic differentiation (Autograd)"), but the corresponding C runtime functions in `src/runtime.c:220-235` are explicitly commented placeholders. This is the highest-impact doc drift in the repo — it is the headline AI-native feature, and it directly violates the `AGENTS.md` "Doc Freshness" rule that agents rely on to decide what to build next.

## Changes

- **docs/STDLIB.md** (§6): `std.ai.tensor` `[stable]` → `[partial]`. Bullets now list the actually-working constructors (`zeros`, `ones`, `rand`, `move`) separately from the placeholder ops (`matmul`, `add`, `backward`), with a pointer to `src/runtime.c:220-235`.
- **docs/SPEC.md** (§17, "AI Tensors"): dropped the assertion that `matmul` and `backward` (autograd) are shipped; now states they are runtime placeholders.

No code change in this PR — the runtime is left as-is; this is a documentation alignment. A follow-up issue is implied for either implementing the math ops or for extending `scripts/docs-check.sh` to flag `[stable]` modules whose `@intrinsic` names are unresolvable side the Rust compiler (audit recommendation #3).

## Tests

- [x] Nominal: N/A — documentation-only change.
- [x] Edge cases: `scripts/docs-check.sh` re-run locally → exit 0 (SPEC/ROADMAP versions match, STDLIB legend present, README clean).
- [x] Error cases: N/A.

## Docs

- [x] `docs/STDLIB.md` updated.
- [x] `docs/SPEC.md` updated.
- [x] No `docs/architecture.md` change required (no pipeline invariant touched).

## Closes

Closes #110.