### PR TITLE
fix(compiler): propagate child exit code from aion run (#106)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,24 +124,30 @@ fn main() {
             println!("-------------------------------");
             let output = Command::new(&bin_file).args(&args).output();
 
+            // Propagate the child exit code so shell/CI callers detect
+            // runtime failures (OOB traps, non-zero returns). #106.
+            let child_code: i32;
             match output {
                 Ok(out) => {
                     print!("{}", String::from_utf8_lossy(&out.stdout));
                     eprint!("{}", String::from_utf8_lossy(&out.stderr));
+                    child_code = out.status.code().unwrap_or(1);
                     if !out.status.success() {
-                        eprintln!(
-                            "error: process exited with code: {}",
-                            out.status.code().unwrap_or(-1)
-                        );
+                        eprintln!("error: process exited with code: {}", child_code);
                     }
                 }
-                Err(e) => eprintln!("error: execution failed: {}", e),
+                Err(e) => {
+                    eprintln!("error: execution failed: {}", e);
+                    child_code = 1;
+                }
             }
             println!("-------------------------------");
 
             let _ = fs::remove_file(ir_file);
             let _ = fs::remove_file(obj_file);
             let _ = fs::remove_file(bin_file);
+
+            std::process::exit(child_code);
         }
         Commands::Transpile {
             input,

--- a/tests/fixtures/language/run_exit_code.ai
+++ b/tests/fixtures/language/run_exit_code.ai
@@ -1,0 +1,3 @@
+fn main() {
+    return 42
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,10 +25,10 @@ fn run_aion_test(path: &str) -> String {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    if !output.status.success() && !stderr.is_empty() {
-        return stderr.trim().to_string();
-    }
-
+    // Always extract program output from between the dashes first, even when
+    // `aion run` propagated a non-zero child exit code (#106). Compile
+    // failures (no dashes, empty stdout) fall through to the stderr fallback
+    // below; runtime crashes (OOB trap) hit the same fallback.
     let full = format!("{}\n{}", stdout, stderr);
     let lines: Vec<&str> = full.lines().collect();
     let mut between = Vec::new();
@@ -60,6 +60,72 @@ fn run_aion_test(path: &str) -> String {
 }
 
 // --- Language Tests ---
+
+#[test]
+fn test_run_exit_code_propagation() {
+    // #106 — `aion run` must propagate the child process exit code so
+    // shell/CI callers detect runtime failures and explicit return codes.
+    let root = project_root();
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "run",
+            "tests/fixtures/language/run_exit_code.ai",
+        ])
+        .current_dir(&root)
+        .timeout(std::time::Duration::from_secs(60))
+        .output()
+        .expect("failed to execute cargo run");
+    assert_eq!(
+        output.status.code(),
+        Some(42),
+        "aion run should exit with the program's return code, not 0"
+    );
+}
+
+#[test]
+fn test_run_exit_code_runtime_crash() {
+    // #106 — a runtime trap (OOB) must surface as a non-zero `aion run` exit.
+    let root = project_root();
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "run",
+            "tests/fixtures/language/array_bounds.ai",
+        ])
+        .current_dir(&root)
+        .timeout(std::time::Duration::from_secs(60))
+        .output()
+        .expect("failed to execute cargo run");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "aion run should exit non-zero when the program crashes at runtime"
+    );
+}
+
+#[test]
+fn test_run_exit_code_success() {
+    // #106 — nominal: hello.ai returns 0 → `aion run` exits 0.
+    let root = project_root();
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "run",
+            "tests/fixtures/language/hello.ai",
+        ])
+        .current_dir(&root)
+        .timeout(std::time::Duration::from_secs(60))
+        .output()
+        .expect("failed to execute cargo run");
+    assert_eq!(output.status.code(), Some(0));
+}
 
 #[test]
 fn test_hello() {


### PR DESCRIPTION
## Summary

`aion run` captured the executed Aion program's exit status but always let `aionc` itself exit `0`, so shell/CI callers silently missed runtime crashes (OOB trap, `exit(1)`) and explicit non-zero returns. This broke `./aion run x.ai || fail` and `set -e`, and forced `run_aion_test` to grow a fragile stderr-fallback hack. This PR propagates the child exit code end-to-end.

## Changes

- **src/main.rs** (`Commands::Run`): capture `out.status.code()` into `child_code`, then `std::process::exit(child_code)` after the closing dashes + cleanup. Runtime failures now surface as `aion run` non-zero.
- **tests/integration.rs** (`run_aion_test`): drop the early `!output.status.success() && !stderr.is_empty()` short-circuit so between-the-dashes stdout is always extracted first. Compile failures (no dashes) fall through to the existing stderr fallback (#54); the 7 fixtures that intentionally return non-zero keep their snapshots because their program stdout is what the snapshots capture.
- **tests/fixtures/language/run_exit_code.ai**: new fixture (`fn main() { return 42 }`).
- **Three direct-assertion tests**: `return 42 -> exit 42`, runtime OOB trap -> non-zero, `hello.ai -> 0`.

## Tests

- [x] Nominal: `hello.ai` exits 0 (`test_run_exit_code_success`).
- [x] Edge: `return 42` propagates as exit 42 (`test_run_exit_code_propagation`).
- [x] Error: runtime OOB trap produces non-zero exit (`test_run_exit_code_runtime_crash`); `test_array_bounds` snapshot unchanged.
- [x] No regression: 96 existing tests green, the 7 warned fixtures unchanged (operators, string_operations, complex_pipeline, generics_basic, fstring_interpolation, sql_transpile, interface_impl).
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `scripts/docs-check.sh` clean.

## Docs

- [x] No SPEC/STDLIB change needed (behavior matches the documented "exit code propagation" expectation).
- [x] `docs/architecture.md` unchanged (no pipeline invariant touched).

## Closes

Closes #106.