### PR TITLE
fix(type-system): reject returning stack-allocated arrays (#107)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -83,7 +83,12 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
   passed by pointer. Indexing is bounds-checked at runtime; an
   out-of-bounds access calls the `aion_array_oob(idx, len)` trap
   (stderr message + `exit(1)`) instead of producing undefined behavior.
-  `@sizeof([T; N])` returns `N * sizeof(T)`.
+  `@sizeof([T; N])` returns `N * sizeof(T)`. Because arrays are stack
+  alloca in the callee frame and there is no heap array path yet,
+  returning an `Array`-typed value from a function is a **compile error**
+  ("cannot return stack-allocated array ... it does not outlive the call"),
+  preventing dangling-pointer use-after-scope (#107). Heap-allocated
+  arrays are a planned follow-up.
 - **Fuzzy resolution**: if a simple name is not found, the compiler
   searches for qualified names ending with that suffix (e.g. `args` →
   `std.env.args`). Avoids complex AST rewriting for imports.

--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -496,8 +496,25 @@ impl TypeChecker {
                 self.check_expression(value)?;
                 Ok(Type::Unit)
             }
-            Statement::Return { value, .. } => {
-                self.check_expression(value)?;
+            Statement::Return { value, span, .. } => {
+                let ty = self.check_expression(value)?;
+                // Arrays lower to a stack alloca in the callee frame; returning
+                // one yields a dangling pointer. No heap array path yet —
+                // reject until direction 2 (heap-allocated arrays) lands. #107.
+                if let Type::Array(elem, n) = &ty {
+                    return Err(CompileError::new(
+                        format!(
+                            "cannot return stack-allocated array `[{}; {}]` \
+                             — it does not outlive the call (arrays are not \
+                             heap-allocated yet)",
+                            elem.name(),
+                            n,
+                        ),
+                        span.line,
+                        span.col,
+                    )
+                    .with_snippet(&self.source));
+                }
                 Ok(Type::Unit)
             }
             Statement::ExpressionStmt(expr, _) => self.check_expression(expr),

--- a/tests/fixtures/language/array_return_error.ai
+++ b/tests/fixtures/language/array_return_error.ai
@@ -1,0 +1,16 @@
+use std.io
+use std.string
+
+// Returning a stack-allocated array is a compile error: the alloca does not
+// outlive the call. Direction 1 stopgap until heap-allocated arrays land. #107.
+
+fn make() -> [i64; 3] {
+    let a = [1, 2, 3]
+    return a
+}
+
+fn main() {
+    let b = make()
+    io.println(string.from_int(b[0]))
+    return 0
+}

--- a/tests/fixtures/language/array_return_literal.ai
+++ b/tests/fixtures/language/array_return_literal.ai
@@ -1,0 +1,10 @@
+// Returning an array literal directly hits the same dangling-pointer hole:
+// the literal lowers to a stack alloca in the callee frame. #107.
+
+fn make() -> [i64; 2] {
+    return [10, 20]
+}
+
+fn main() {
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -261,6 +261,16 @@ fn test_array_bounds() {
 fn test_array_as_param() {
     assert_snapshot!(run_aion_test("language/array_as_param"));
 }
+#[test]
+fn test_array_return_error() {
+    // #107 — returning a stack-allocated local array is a compile error.
+    assert_snapshot!(run_aion_test("language/array_return_error"));
+}
+#[test]
+fn test_array_return_literal() {
+    // #107 — returning an array literal directly is the same dangling hole.
+    assert_snapshot!(run_aion_test("language/array_return_literal"));
+}
 
 // --- Stdlib Tests ---
 

--- a/tests/snapshots/integration__array_return_error.snap
+++ b/tests/snapshots/integration__array_return_error.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/array_return_error\")"
+---
+Type Error: cannot return stack-allocated array `[i64; 3]` — it does not outlive the call (arrays are not heap-allocated yet)

--- a/tests/snapshots/integration__array_return_literal.snap
+++ b/tests/snapshots/integration__array_return_literal.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/array_return_literal\")"
+---
+Type Error: cannot return stack-allocated array `[i64; 2]` — it does not outlive the call (arrays are not heap-allocated yet)


### PR DESCRIPTION
## Summary

Array literals and array-typed locals lower to a stack `alloca` in the callee frame (`src/codegen/compiler.rs`, `ArrayLiteral` arm), so returning one handed the caller a dangling pointer once the frame was released — a use-after-scope bug the GC + `unsafe` boundary exists to rule out. This PR closes the safety hole with **direction 1** from the issue: the type checker rejects any `return` whose inferred type is `Type::Array(_, _)`, since there is no heap array path yet. Heap-allocated arrays (direction 2) remain a planned follow-up.

## Changes

- **src/analysis/checker.rs** (`Statement::Return` arm): capture the return expression's inferred type and emit `Type Error: cannot return stack-allocated array \`[T; N]\` — it does not outlive the call (arrays are not heap-allocated yet)` when it is `Type::Array`. Span/snippet reported via the existing helper.
- **docs/SPEC.md** (§2 Arrays): document the new compile error and the reason (stack alloca + no heap path), per the AGENTS.md Doc Freshness rule.
- **tests/fixtures/language/array_return_error.ai**: the issue's exact repro — `fn make() -> [i64; 3]` returning a local binding (exercises the `Identifier` inference path).
- **tests/fixtures/language/array_return_literal.ai**: returning an array literal directly (exercises the `ArrayLiteral` inference path).
- **tests/integration.rs**: two new snapshot tests.
- Snapshots committed: `integration__array_return_error.snap`, `integration__array_return_literal.snap`.

## Tests

- [x] Nominal: non-escaping arrays still compile — `array_basic`, `array_bounds`, `array_as_param` green (no array is returned).
- [x] Edge: returning a local binding vs returning a literal directly both error (two distinct inference paths).
- [x] Error: both return-rejected fixtures snapshot the documented "cannot return stack-allocated array" stderr.
- [x] No regression: 98 tests green (96 existing + 2 new); no existing fixture returned an array, so no behavior change elsewhere.
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `scripts/docs-check.sh` clean.

## Docs

- [x] `docs/SPEC.md` updated (new compile error documented).
- [x] No `docs/STDLIB.md` change (stdlib surface unchanged).

## Closes

Closes #107.