### PR TITLE
feat(ci): flag [stable] stdlib modules with unimplemented intrinsics (#112)

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -232,8 +232,16 @@ Universally Unique Identifiers.
 
 ## 11. Time & Date
 
-### `std.time` **[stable]**
-Duration and Date types with arithmetic operations.
+### `std.time` **[partial]**
+Duration works (constructors, `as_secs`/`as_millis`, arithmetic — exercised by
+`duration_literal`). `now()` and `sleep()` are **not implemented**: their
+`@intrinsic("time_now")` / `@intrinsic("time_sleep")` resolve to
+`aion_time_now` / `aion_time_sleep`, which are absent from `src/runtime.c`.
+Add the runtime symbols before re-promoting to [stable].
 
-### `std.date` **[stable]**
-Date utilities and formatting.
+### `std.date` **[partial]**
+The `Date` struct and date-literal arithmetic work (exercised by
+`date_arithmetic`). `DateTime::now()` is **not implemented**: its
+`date_year`/`date_month`/`date_day`/`date_hour`/`date_min`/`date_sec`
+intrinsics resolve to `aion_date_*` symbols absent from `src/runtime.c`.
+Add the runtime symbols before re-promoting to [stable].

--- a/scripts/docs-check-intrinsics.sh
+++ b/scripts/docs-check-intrinsics.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Guard against stdlib/doc drift: a [stable] module in docs/STDLIB.md must
+# not reference an @intrinsic whose C runtime function is missing or a known
+# placeholder. #112.
+#
+# For every module tagged [stable] in docs/STDLIB.md, collect the
+# @intrinsic(...) references in its source file, classify each as a
+# declaration decorator (form 1 — attribute value is the C function name) or
+# an expression call (form 2 — normalize via the rules in Expression::Intrinsic
+# in src/codegen/compiler.rs), then verify the resolved C function is defined
+# and non-placeholder in src/runtime.c (or is a recognized libc/inline intrinsic).
+#
+# Run locally: scripts/docs-check-intrinsics.sh
+# Invoked by scripts/docs-check.sh (see the `docs-check` CI job).
+
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+stdlib="docs/STDLIB.md"
+runtime="src/runtime.c"
+
+# Intrinsics handled inline by codegen (no C call): no runtime.c symbol needed.
+inline_set="sizeof mem_is_null mem_zero str_ptr"
+
+# C symbols provided by libc / the linked C runtime, not by src/runtime.c.
+# Extended as new libc-backed intrinsics are added.
+external_set="strlen exit memcpy memset memcmp strcmp strncmp strcpy strncpy time localtime malloc free printf sprintf snprintf"
+
+errors=()
+
+is_in_set() { # $1 = value, $2 = space-separated set
+    local v="$1"
+    local e
+    for e in $2; do [ "$e" = "$v" ] && return 0; done
+    return 1
+}
+
+# Normalize an @intrinsic expression name to its C resolution.
+# Echoes "inline", "external <name>", or "runtime <name>".
+normalize_expr() { # $1 = intrinsic name as written in the .ai
+    local an="$1"
+    if is_in_set "$an" "$inline_set"; then echo "inline"; return; fi
+    case "$an" in
+        str_len)            echo "external strlen" ;;
+        exit)               echo "external exit" ;;
+        fs_read_to_string)  echo "runtime aion_read_file" ;;
+        fs_write)           echo "runtime aion_write_file" ;;
+        fs_append)          echo "runtime aion_append_file" ;;
+        mem_zero_ptr)       echo "runtime aion_memzero" ;;
+        libc.*)             echo "external ${an#libc.}" ;;
+        *)                  echo "runtime aion_${an}" ;;
+    esac
+}
+
+# Normalize a declaration-decorator @intrinsic name (attribute value is the C
+# function name directly, e.g. "aion_malloc"). libc.* still strips.
+normalize_decl() { # $1 = intrinsic name as written in the .ai
+    local an="$1"
+    case "$an" in
+        libc.*) echo "external ${an#libc.}" ;;
+        *)      echo "runtime ${an}" ;;
+    esac
+}
+
+defined_in_runtime() { # $1 = C function name
+    grep -nE "^[A-Za-z_][A-Za-z_0-9 *]*[[:space:]]+[*]*\b$1\b *\(" "$runtime" \
+        | grep -v ';' >/dev/null
+}
+
+runtime_body() { # $1 = C function name -> echoes body lines
+    awk -v fn="$1" '
+        $0 !~ /;/ && $0 ~ ("[^A-Za-z_0-9]" fn "[[:space:]]*\\(") { printing=1 }
+        printing { print }
+        printing && $0 ~ /^}/ { exit }
+    ' "$runtime"
+}
+
+add_error() { errors+=("$1"); }
+
+# --- 1. Parse docs/STDLIB.md for [stable] modules, map each to a file. ------
+# Output: "<module_dotted_path>\t<file_path>".
+mapfile -t stable_records < <(
+    awk '
+        function emit(path,    file) {
+            file = "stdlib/" path; gsub(/\./, "/", file); file = file ".ai"
+            print path "\t" file
+        }
+        /^### / {
+            # A heading can list several `name` [status] segments split by "&".
+            # The FIRST segment anchors sub-bullets even if the heading line
+            # itself carries no [stable] mark (e.g. `### std.collections` where
+            # the status lives on the `- **vector**` sub-bullets).
+            head = $0
+            nb = split(head, segs, "&")
+            lastbase = ""
+            for (i=1;i<=nb;i++) {
+                seg = segs[i]
+                if (match(seg, /`[^`]+`/)) {
+                    nm = substr(seg, RSTART+1, RLENGTH-2)
+                    if (lastbase == "") lastbase = nm
+                    if (seg ~ /\[stable\]/) emit(nm)
+                }
+            }
+            next
+        }
+        /^- \*\*`[^`]+`\*\*/ {
+            line = $0
+            if (!match(line, /`[^`]+`/)) next
+            nm = substr(line, RSTART+1, RLENGTH-2)
+            if (line ~ /\[stable\]/ && lastbase != "") emit(lastbase "." nm)
+        }
+    ' "$stdlib"
+)
+
+# --- 2. For each [stable] module file, emit "cname\tform" records. -----------
+validate_records=()
+for rec in "${stable_records[@]}"; do
+    IFS=$'\t' read -r mod file <<< "$rec"
+    if [ ! -f "$file" ]; then
+        add_error "$mod: source file $file not found"
+        continue
+    fi
+    while IFS=$'\t' read -r cname form; do
+        [ -z "$cname" ] && continue
+        validate_records+=("$mod"$'\t'"$cname"$'\t'"$form")
+    done < <(
+        awk '
+            { lines[NR]=$0 }
+            END {
+                for (i=1;i<=NR;i++) {
+                    line = lines[i]
+                    if (!match(line, /@intrinsic[[:space:]]*\(/)) continue
+                    rest = substr(line, RSTART+RLENGTH)
+                    if (!match(rest, /"[^"]*"/)) continue
+                    an = substr(rest, RSTART+1, RLENGTH-2)
+                    nxt = ""
+                    for (j=i+1;j<=NR;j++) {
+                        if (lines[j] ~ /^[[:space:]]*$/) continue
+                        nxt = lines[j]; break
+                    }
+                    hasargs = (rest ~ /,[[:space:]]*[^)]/)?1:0
+                    # form 2 with args is always expression form; form 1 has no
+                    # args and is followed by a `fn` declaration.
+                    if (!hasargs && nxt ~ /^[[:space:]]*(pub[[:space:]]+)?(unsafe[[:space:]]+)?fn[[:space:]]/)
+                        print an "\tdecl"
+                    else
+                        print an "\texpr"
+                }
+            }
+        ' "$file"
+    )
+done
+
+# --- 3. Validate each intrinsic reference. -----------------------------------
+for rec in "${validate_records[@]}"; do
+    IFS=$'\t' read -r mod cname form <<< "$rec"
+    if [ "$form" = "decl" ]; then norm="$(normalize_decl "$cname")"
+    else norm="$(normalize_expr "$cname")"; fi
+    kind="${norm%% *}"
+    name="${norm#* }"
+    if [ "$kind" = "inline" ]; then
+        continue
+    fi
+    if [ "$kind" = "external" ]; then
+        if ! is_in_set "$name" "$external_set"; then
+            add_error "$mod: @intrinsic(\"$cname\") -> external symbol '$name' not in the libc allowlist (scripts/docs-check-intrinsics.sh:external_set)"
+        fi
+        continue
+    fi
+    if ! defined_in_runtime "$name"; then
+        add_error "$mod: @intrinsic(\"$cname\") -> C function '$name' NOT defined in src/runtime.c (downgrade the module to [partial]/[stub] in docs/STDLIB.md OR add the runtime impl)"
+        continue
+    fi
+    body="$(runtime_body "$name")"
+    if echo "$body" | grep -qiE '//[[:space:]]*placeholder|placeholder:|return zeros for now'; then
+        add_error "$mod: @intrinsic(\"$cname\") -> '$name' is a placeholder in src/runtime.c (downgrade the module to [partial]/[stub] OR implement it)"
+    fi
+done
+
+# --- Report. ----------------------------------------------------------------
+if [ ${#errors[@]} -ne 0 ]; then
+    echo "error: [stable] stdlib modules reference unimplemented intrinsic(s):" >&2
+    printf '  - %s\n' "${errors[@]}" >&2
+    echo >&2
+    echo "Per AGENTS.md Doc Freshness, a [stable] module must not advertise" >&2
+    echo "behavior the runtime does not implement. Downgrade the module to" >&2
+    echo "[partial]/[stub] in docs/STDLIB.md, or add the missing runtime impl." >&2
+    exit 1
+fi
+echo "ok: all [stable] stdlib intrinsics resolve to implemented runtime functions"

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -49,4 +49,11 @@ else
     echo "ok: docs/STDLIB.md has the implementation-status legend"
 fi
 
+# --- Check 4: [stable] stdlib modules must not reference unimplemented intrinsics. #112. ---
+if bash "$(dirname "${BASH_SOURCE[0]}")/docs-check-intrinsics.sh"; then
+    :
+else
+    status=1
+fi
+
 exit $status

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -218,6 +218,7 @@ struct AionTensor* aion_ai_tensor_rand(struct AionVector* shape) {
 }
 
 void aion_ai_tensor_backward(struct AionTensor* t) {
+    // Placeholder: prints only, no gradient computation
     printf("Called t.backward()\n");
 }
 


### PR DESCRIPTION
## Summary

Implements the guard from #112 (audit recommendation #3): a `[stable]` module in `docs/STDLIB.md` must not reference an `@intrinsic` whose C runtime function is missing or a known placeholder. The first run surfaced two **more** doc-drift cases of the same class as #110/#111 (`std.time`, `std.date` claim `[stable]` but their `now()`/`sleep()`/`DateTime::now()` intrinsics resolve to `aion_time_*` / `aion_date_*` symbols absent from `src/runtime.c`); both are downgraded to `[partial]` in this PR.

## Changes

- **scripts/docs-check-intrinsics.sh** (new): for every `[stable]` module, parse `docs/STDLIB.md` → source file, collect `@intrinsic(...)` references, classify each as declaration-decorator (form 1 — attribute value is the C name) or expression-call (form 2 — normalize via the rules in `Expression::Intrinsic`, `src/codegen/compiler.rs`), and verify the resolved C function is defined and non-placeholder in `src/runtime.c` (or is a recognized libc/inline intrinsic). Reports the offending module + intrinsic + C name with a clear remediation hint.
- **scripts/docs-check.sh**: invoke the new script as check #4.
- **docs/STDLIB.md**: `std.time` `[stable]` → `[partial]` (`now()`/`sleep()` not implemented; `Duration` still works), `std.date` `[stable]` → `[partial]` (`DateTime::now()` not implemented; `Date` struct + literal arithmetic still work).
- **src/runtime.c**: tag `aion_ai_tensor_backward` with a `// Placeholder` marker so the guard's placeholder detection is consistent with `matmul`/`add` (the body is only a `printf`). `std.ai.tensor` is already `[partial]` (#111), so the guard skips it; the marker keeps the pattern complete for a future regression.

## Tests

This is a CI/lint + documentation change; per the #112 acceptance:

- [x] Nominal: guard passes on the current tree (no `[stable]` module has an unresolved/placeholder intrinsic). `bash scripts/docs-check.sh` → exit 0.
- [x] Edge: temporarily re-marking `std.time` as `[stable]` makes the guard fail with the expected message; flipping it back re-passes. A `[partial]` module (`std.ai.tensor`) with the same placeholder intrinsics is **not** flagged.
- [x] Error: the guard exits non-zero with a per-intrinsic message naming the module, the `@intrinsic(...)` call, and the missing/placeholder C function.
- [x] No false positives on the remaining `[stable]` modules (inline `sizeof`/`mem_is_null`/`mem_zero`/`str_ptr`, libc-backed `strlen`, and all `aion_*` runtime functions verify clean).
- [x] No compiler behavior change: 99 tests green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

## Docs

- [x] `docs/STDLIB.md` updated (`std.time`, `std.date` downgrades with the reason + the missing runtime symbols).
- [x] No `docs/SPEC.md` change (no language behavior changed).
- [x] The guard's own header comment documents the resolution rules and the `external_set` allowlist.

## Closes

Closes #112.