### PR TITLE
ci(audit): add cargo-audit workflow for supply-chain guarding (#114)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,41 @@
+name: cargo-audit
+
+# Guards the supply chain: audits Cargo.lock against the RustSec advisory
+# database. Runs on every push/PR (catches a newly-added vulnerable crate
+# before merge) and on a weekly schedule (catches a new advisory filed
+# against an already-pinned crate even with no PR activity). #114.
+#
+# cargo-audit parses Cargo.lock only — no LLVM/GC toolchain is needed, so the
+# job runs on the bare ubuntu runner and stays fast. `cargo audit` exits
+# non-zero on vulnerability advisories (RustSec IDs of kind `vulnerability`);
+# `unmaintained`/`notice` advisories are reported but do not fail the build,
+# because they often target transitive crates this project cannot upgrade
+# directly. Add an `--ignore RUSTSEC-XXXX-XXXX` flag below if a specific
+# advisory is reviewed and accepted.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan (Sunday 00:00 UTC) — matches the CodeQL cadence.
+    - cron: "0 0 * * 0"
+
+jobs:
+  audit:
+    name: Audit Cargo.lock for vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit Cargo.lock
+        run: cargo audit


### PR DESCRIPTION
## Summary

Adds `cargo-audit` to CI per #114 (audit recommendation #5). The compiler has only 3 direct dependencies today, but there is no supply-chain advisory check in `.github/`. This adds a dedicated `audit.yml` workflow that runs `cargo-audit` against `Cargo.lock` on every push/PR and on a weekly Sunday cron, mirroring the existing CodeQL cadence (so a new advisory filed against an already-pinned crate is caught even with no PR activity — relevant once the LLVM-backend-in-Aion work (#9) grows the dependency surface).

## Changes

- **.github/workflows/audit.yml** (new): `audit` job installs `cargo-audit --locked` on a bare ubuntu runner (no LLVM/GC toolchain needed — `cargo-audit` only parses `Cargo.lock`) and runs `cargo audit`.

Design choices (documented in the workflow header):
- `cargo audit` exits non-zero on **vulnerability** advisories (the gate that matters); `unmaintained`/`notice` advisories are reported but do not fail the build, because they often target transitive crates this project cannot upgrade directly.
- **Dependabot** for Rust version-updates is intentionally out of scope (the issue marks it optional); this PR closes the audit-advisory gap only. A follow-up can add `dependabot.yml` if desired.

## Tests

- [x] Nominal: workflow YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`); trigger structure mirrors `.github/workflows/codeql.yml`.
- [x] Edge: cadence includes the weekly scheduled run, so a stale advisory is caught without PR activity (matches CodeQL cadence and the #114 acceptance).
- [x] Error: the job fails on a vulnerability advisory (verified by `cargo audit`\'s documented non-zero exit on RustSec vulnerability IDs); unmaintained advisories are informational only.
- [x] No compiler behavior change: 0 source lines touched in `src/`; `scripts/docs-check.sh` re-run locally stays green.
- [x] `cargo install cargo-audit --locked` is the canonical install command; `--locked` pins the audit tool\'s own deps for reproducibility.

## Docs

- [x] No `docs/SPEC.md` / `docs/STDLIB.md` change (no language/stdlib change).
- [x] The workflow header documents the trigger rationale, the `unmaintained`-advisory policy, and how to `--ignore` a reviewed advisory.

## Closes

Closes #114.