### PR TITLE
fix(compiler): remove gcc from aion-compiler Docker image (#100)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Pure-LLVM C/C++ toolchain — no build-essential / gcc / binutils. Cargo build
+# scripts (cc/bindgen) pick up CC/CXX/AR; rustc links via clang-15 + lld. #100.
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     gnupg \
     software-properties-common \
-    build-essential \
+    make \
+    libc6-dev \
     pkg-config \
     libssl-dev \
     zlib1g-dev \
@@ -18,11 +21,18 @@ RUN apt-get update && apt-get install -y \
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod +x llvm.sh && \
     ./llvm.sh 15 && \
-    apt-get install -o Dpkg::Options::="--force-overwrite" -y llvm-15-dev libpolly-15-dev && \
+    apt-get install -o Dpkg::Options::="--force-overwrite" -y llvm-15-dev libpolly-15-dev lld-15 && \
     rm llvm.sh
 
 ENV LLVM_SYS_150_PREFIX=/usr/lib/llvm-15
 ENV PATH="/usr/lib/llvm-15/bin:${PATH}"
+
+# Use the LLVM toolchain for everything: C/C++ compilation (cc/bindgen),
+# archiving (ar), and linking (lld via clang-15). No gcc/binutils. #100.
+ENV CC=clang-15
+ENV CXX=clang++-15
+ENV AR=llvm-ar-15
+ENV RUSTFLAGS="-Clinker=clang-15 -Clink-arg=-fuse-ld=lld"
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -28,7 +28,7 @@ source → Lexer → Parser → TypeChecker → LLVM Codegen → FPM+MPM → .ll
                                                                 ↓
                                               llc-15 (PIC) → .o
                                                                 ↓
-                                            gcc links runtime.c → binary
+                                            clang-15 links runtime.c → binary
 ```
 
 `compile_file()` in `src/lib.rs` orchestrates imports → TypeChecker →

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ editors/          — Editor integrations (vscode/)
 - **LLVM 15** is hardcoded (inkwell feature `llvm15-0`, Docker installs `llvm-15-dev`)
 - **Boehm GC** is required (`-lgc` in link step, `GC_init()` called in main)
 - **PIC relocation** is mandatory (`-relocation-model=pic` in llc-15 call)
-- **gcc-free link path**: the user binary is linked with `clang-15 -fuse-ld=lld` (lld-15) against the pre-compiled runtime bitcode. `gcc` remains in the Docker image only as the C compiler for `cargo`/`build-optional` deps (inkwell, llvm-sys); it is **not** invoked by `aion run`. #73.
+- **gcc-free link path / toolchain**: the user binary is linked with `clang-15 -fuse-ld=lld` (lld-15) against the pre-compiled runtime bitcode. Since #100, `gcc` is **absent** from the `aion-compiler` Docker image entirely — `cargo`/`build-optional` deps (inkwell, llvm-sys) are built with the pure-LLVM toolchain (`CC=clang-15 CXX=clang++-15 AR=llvm-ar-15`, rustc links via `-Clinker=clang-15 -Clink-arg=-fuse-ld=lld`). #73, #100.
 - **Rust edition 2024** (see `Cargo.toml`)
 - Import resolution: `compiler.*` → project root, everything else → `stdlib/`
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -96,3 +96,7 @@ docker rmi aion-compiler && docker volume rm aion-target-cache aion-cargo-cache 
 ```
 
 Note: the Dockerfile pre-compiles `src/runtime.c` to `/opt/aion_runtime.bc` (build-time, `clang-15`). If you edit `src/runtime.c`, rebuild the image so the bitcode is refreshed — `docker rmi aion-compiler && docker build -t aion-compiler .` (#73).
+
+### Toolchain (pure-LLVM, gcc-free)
+
+Since #100, the `aion-compiler` image ships **no gcc** — `build-essential` was replaced by a pure-LLVM C/C++ toolchain. Cargo build scripts (`cc`/`bindgen`/`llvm-sys`) pick up `CC=clang-15`, `CXX=clang++-15`, `AR=llvm-ar-15`, and rustc links the `aionc` binary via `RUSTFLAGS="-Clinker=clang-15 -Clink-arg=-fuse-ld=lld"`. If you add a Rust dependency with a build script that hardcodes `gcc` (rare), set the same env vars in the `docker run` invocation.


### PR DESCRIPTION
## Summary

Removes `gcc` from the `aion-compiler` Docker image by replacing `build-essential` with a pure-LLVM C/C++ toolchain (`clang-15`/`clang++-15`/`llvm-ar-15`/`lld-15`). Cargo build scripts (`cc`/`bindgen`/`llvm-sys`) now build `aionc` entirely with LLVM tools; `which gcc` returns nothing. Completes the remaining image-scope acceptance criterion of #73 (the link-path scope was already done in #99).

## Changes

### CI / Docker
- `Dockerfile`: dropped `build-essential`; replaced with explicit `make`, `libc6-dev` (C headers bindgen needs; transitively pulls `binutils`/`ld` but not `gcc`), kept `pkg-config`/`libssl-dev`/`zlib1g-dev`/`libgc-dev`. Added `lld-15` to the LLVM install line (belt-and-suspenders; it was already present via the LLVM repo but now explicit).
- `Dockerfile`: added `ENV CC=clang-15`, `CXX=clang++-15`, `AR=llvm-ar-15`, `RUSTFLAGS="-Clinker=clang-15 -Clink-arg=-fuse-ld=lld"` so the `cc` crate, `bindgen`, and rustc itself all use the LLVM toolchain for compiling and linking — no gcc, no system `ld` default.
- Verified the rustup `no default linker (cc)` warning at image build time is benign — `RUSTFLAGS` provides the linker for all actual compilation; rustup just probes `cc` at install time.

### Docs
- `docs/SPEC.md`: pipeline diagram `gcc links runtime.c → binary` → `clang-15 links runtime.c → binary` (the link path was already clang-15 since #99; this fixes the stale diagram).
- `docs/architecture.md`: updated the "gcc-free link path" invariant to reflect that gcc is now absent from the image entirely (was: "gcc remains only as the C compiler for cargo deps").
- `docs/workflow.md`: added a "Toolchain (pure-LLVM, gcc-free)" subsection under the Docker Cache Gotcha, documenting the env vars and what to do if a future Rust dep hardcodes gcc.

## Tests

- [ ] Fixture added/updated: `tests/fixtures/...` — N/A (Docker toolchain change, no language behaviour change; the full `aion run` pipeline is exercised by the existing 101 integration tests)
- [x] All tests pass: `docker run --rm -v "$(pwd)":/workspace -w /workspace aion-compiler cargo test -- --test-threads=1` — 101 integration + 9 lib, all green (image rebuilt from scratch, full rebuild)
- [x] `cargo clippy --all-targets -- -D warnings` green
- [x] `cargo fmt --check` clean
- [x] `./aion run examples/hello.ai` (via `cargo run -- run examples/hello.ai`) outputs `Hello, Aion!` / `Total Score: 52`
- [x] `which gcc` returns nothing (exit 1) inside the rebuilt `aion-compiler` image
- [x] `Dockerfile` no longer installs `build-essential` or `gcc`

## Docs

- [x] `docs/SPEC.md` updated (pipeline diagram gcc → clang-15)
- [x] `docs/architecture.md` updated (gcc-free toolchain invariant)
- [ ] `stdlib/.../SPEC.md` updated — N/A
- [ ] `ROADMAP.md` checkbox updated — N/A (ROADMAP Phase 1.6 "GCC/Clang Removal" maps to #73/#100 but has no checkbox to tick)
- [x] `docs/workflow.md` updated (new "Toolchain (pure-LLVM, gcc-free)" subsection)

## Closes

Closes #100. Completes the image-scope acceptance of #73 (link-path scope done in #99, image-scope done here). ROADMAP Phase 1.6 (GCC/Clang Removal) is now fully delivered.