### PR TITLE
feat(type-system): add function-as-value support (function pointers) (#84)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -89,6 +89,16 @@ LLVM Compiler → optimization passes → writes the `.ll` file.
   ("cannot return stack-allocated array ... it does not outlive the call"),
   preventing dangling-pointer use-after-scope (#107). Heap-allocated
   arrays are a planned follow-up.
+- **Function pointers**: bare function names can be used as values and
+  passed to higher-order functions (#84). `let f = double` stores the
+  function's address as an opaque `ptr`; `f(5)` emits an indirect call
+  (`build_indirect_call`) through the loaded pointer. Function-type
+  annotations use `fn(P1, P2) -> Ret` syntax, e.g. `fn apply(f: fn(i64) ->
+  i64, x: i64) -> i64`. No closures (captured variables) — only top-level
+  non-generic function pointers are supported. Generic functions cannot be
+  taken as a pointer because they require monomorphization at the call
+  site.
+
 - **Fuzzy resolution**: if a simple name is not found, the compiler
   searches for qualified names ending with that suffix (e.g. `args` →
   `std.env.args`). Avoids complex AST rewriting for imports.

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -91,6 +91,28 @@ impl Type {
         if let Some(stripped) = trimmed.strip_prefix('*') {
             return Type::Pointer(Box::new(Type::parse(stripped.trim())));
         }
+        // Function type: `fn(P1, P2) -> Ret`. #84.
+        if trimmed.starts_with("fn(")
+            && let Some(close) = find_matching_paren(trimmed, 2)
+        {
+            let params_str = &trimmed[3..close];
+            let after = trimmed[close + 1..].trim();
+            if let Some(ret_str) = after.strip_prefix("->") {
+                let mut params = Vec::new();
+                for part in split_top_level_commas(params_str) {
+                    let p = part.trim();
+                    if !p.is_empty() {
+                        params.push(Type::parse(p));
+                    }
+                }
+                let return_type = Box::new(Type::parse(ret_str.trim()));
+                return Type::Function {
+                    is_unsafe: false,
+                    params,
+                    return_type,
+                };
+            }
+        }
         // Tuple type: `(T, U, ...)`. #53.
         if trimmed.starts_with('(') && trimmed.ends_with(')') {
             let inner = &trimmed[1..trimmed.len() - 1];
@@ -246,6 +268,25 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
+}
+
+/// Find the index of the closing `)` matching the `(` at `open_idx`. Returns
+/// `None` if unbalanced. Used by `Type::parse` for `fn(...) -> Ret`. #84.
+fn find_matching_paren(s: &str, open_idx: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    for (i, b) in s.bytes().enumerate().skip(open_idx) {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Split `s` on top-level commas (depth 0), respecting nested `<>` and `()`

--- a/src/codegen/expressions.rs
+++ b/src/codegen/expressions.rs
@@ -53,6 +53,23 @@ impl<'ctx> Compiler<'ctx> {
                     {
                         return Ok(self.builder.build_load(pt, g.as_pointer_value(), "argv")?);
                     }
+                    // Bare function name used as a value → return the function
+                    // pointer. #84. Only non-generic functions (generic
+                    // functions need monomorphization and can't be taken as a
+                    // single pointer).
+                    if let Some(Declaration::Function(f)) = self.decls.get(name)
+                        && f.generic_params.is_empty()
+                    {
+                        if let Some(fv) = self
+                            .resolve_fuzzy_name(&self.decls, name)
+                            .and_then(|n| self.module.get_function(&n))
+                        {
+                            return Ok(fv.as_global_value().as_pointer_value().into());
+                        }
+                        if let Some(fv) = self.module.get_function(name) {
+                            return Ok(fv.as_global_value().as_pointer_value().into());
+                        }
+                    }
                     Err(self.err(format!("variable '{}' not found", name), e))
                 }
             }
@@ -65,6 +82,47 @@ impl<'ctx> Compiler<'ctx> {
                 let mut afn = fnm.clone();
                 let mut aga = generic_args.clone();
                 let mut aa = arguments.clone();
+                // Indirect call: if the callee name is a local variable holding
+                // a function pointer, load it and emit an indirect call instead
+                // of resolving a direct function name. #84.
+                if aga.is_empty()
+                    && let Some((ptr, vt, tn)) = variables.get(fnm)
+                    && tn.starts_with("fn(")
+                {
+                    let parsed = crate::analysis::types::Type::parse(tn);
+                    if let crate::analysis::types::Type::Function {
+                        return_type,
+                        params,
+                        ..
+                    } = parsed
+                    {
+                        let fp = self.builder.build_load(*vt, *ptr, "fptr")?;
+                        let fp = if fp.is_int_value() {
+                            self.builder
+                                .build_int_to_ptr(fp.into_int_value(), pt, "i2p")?
+                        } else {
+                            fp.into_pointer_value()
+                        };
+                        let llvm_ret = self.aion_type_to_llvm(&return_type.name());
+                        let llvm_params: Vec<inkwell::types::BasicMetadataTypeEnum> = params
+                            .iter()
+                            .map(|p| self.aion_type_to_llvm(&p.name()).into())
+                            .collect();
+                        let fn_type = llvm_ret.fn_type(&llvm_params, false);
+                        let mut ca: Vec<inkwell::values::BasicMetadataValueEnum> = Vec::new();
+                        for arg in &aa {
+                            let v = self.compile_expr(arg, variables, function)?;
+                            ca.push(v.into());
+                        }
+                        let call = self
+                            .builder
+                            .build_indirect_call(fn_type, fp, &ca, "icall")?;
+                        return Ok(match call.try_as_basic_value() {
+                            ValueKind::Basic(v) => v,
+                            _ => i64_t.const_zero().into(),
+                        });
+                    }
+                }
                 let mut is_mc = false;
                 let mut tga_from_receiver: Vec<String> = vec![];
                 if let Some((rn, mn)) = fnm.rsplit_once('.') {

--- a/src/codegen/type_helpers.rs
+++ b/src/codegen/type_helpers.rs
@@ -106,10 +106,19 @@ impl<'ctx> Compiler<'ctx> {
                     return ct.replace(" ", "");
                 }
                 if let Some((_, _, t)) = variables.get(name) {
-                    t.clone().replace(" ", "")
-                } else {
-                    "unknown".to_string()
+                    return t.clone().replace(" ", "");
                 }
+                // Bare function name used as a value → recover its signature
+                // from the declaration so `let f = double` stores a
+                // recognizable `fn(...)->...` type-name. #84.
+                if let Some(Declaration::Function(f)) = self.decls.get(name)
+                    && f.generic_params.is_empty()
+                {
+                    let params: Vec<String> =
+                        f.params.iter().map(|(_, pt, _)| pt.clone()).collect();
+                    return format!("fn({})->{}", params.join(","), f.return_type).replace(" ", "");
+                }
+                "unknown".to_string()
             }
             Expression::Call {
                 function: name,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -457,6 +457,34 @@ impl<'a> Parser<'a> {
         }
 
         let mut full_type;
+        // Function type: `fn(P1, P2) -> Ret`. #84. `fn` is a keyword, not an
+        // identifier, so it needs its own arm before the Identifier fallback.
+        if self.current_token.kind == TokenKind::Fn {
+            self.next_token();
+            full_type = "fn".to_string();
+            if self.current_token.kind == TokenKind::LParen {
+                self.next_token();
+                let mut parts = Vec::new();
+                while self.current_token.kind != TokenKind::RParen
+                    && self.current_token.kind != TokenKind::EOF
+                {
+                    parts.push(self.parse_type_name());
+                    if self.current_token.kind == TokenKind::Comma {
+                        self.next_token();
+                    }
+                }
+                if self.current_token.kind == TokenKind::RParen {
+                    self.next_token();
+                }
+                full_type = format!("fn({})", parts.join(", "));
+                if self.current_token.kind == TokenKind::Arrow {
+                    self.next_token();
+                    full_type.push_str(" -> ");
+                    full_type.push_str(&self.parse_type_name());
+                }
+            }
+            return full_type;
+        }
         if let TokenKind::Identifier(id) = self.current_token.clone().kind {
             full_type = id;
             self.next_token();

--- a/tests/fixtures/language/function_as_param.ai
+++ b/tests/fixtures/language/function_as_param.ai
@@ -1,0 +1,23 @@
+use std.io
+use std.string
+
+// Function as parameter: a `fn(i64) -> i64` parameter receives a bare
+// function name and calls it indirectly. #84.
+
+fn double(x: i64) -> i64 {
+    return x * 2
+}
+
+fn apply(f: fn(i64) -> i64, x: i64) -> i64 {
+    return f(x)
+}
+
+fn main() {
+    let r1 = apply(double, 5)
+    io.println(string.from_int(r1))
+
+    let r2 = apply(double, 21)
+    io.println(string.from_int(r2))
+
+    return 0
+}

--- a/tests/fixtures/language/function_pointer.ai
+++ b/tests/fixtures/language/function_pointer.ai
@@ -1,0 +1,26 @@
+use std.io
+use std.string
+
+// Function pointer: store a bare function name as a value, then call it
+// indirectly. #84. No syntax change — `let f = double` stores the function
+// pointer; `f(5)` dispatches via an indirect call.
+
+fn double(x: i64) -> i64 {
+    return x * 2
+}
+
+fn add_one(x: i64) -> i64 {
+    return x + 1
+}
+
+fn main() {
+    let f = double
+    let result = f(5)
+    io.println(string.from_int(result))
+
+    let g = add_one
+    let r2 = g(10)
+    io.println(string.from_int(r2))
+
+    return 0
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -556,3 +556,13 @@ fn run_aion_doc(path: &str) -> String {
 fn test_doc_gen() {
     assert_snapshot!(run_aion_doc("compiler/doc_gen"));
 }
+
+#[test]
+fn test_function_pointer() {
+    assert_snapshot!(run_aion_test("language/function_pointer"));
+}
+
+#[test]
+fn test_function_as_param() {
+    assert_snapshot!(run_aion_test("language/function_as_param"));
+}

--- a/tests/snapshots/integration__function_as_param.snap
+++ b/tests/snapshots/integration__function_as_param.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/function_as_param\")"
+---
+10
+42

--- a/tests/snapshots/integration__function_pointer.snap
+++ b/tests/snapshots/integration__function_pointer.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"language/function_pointer\")"
+---
+10
+11


### PR DESCRIPTION
## Summary

Adds first-class function pointers to Aion (#84): bare non-generic function names can be used as values (`let f = double`), stored in variables, passed as parameters (`fn apply(f: fn(i64) -> i64, x: i64)`), and called indirectly (`f(5)`). No new syntax — the parser already produces `Call { function: "f", ... }` for any identifier followed by `(`; the change is in the type system, parser type annotations, and codegen. No closures (captured variables) — out of scope per the issue.

## Changes

### Type System
- `src/analysis/types.rs`: `Type::parse` now recognizes `fn(P1, P2) -> Ret` syntax (using a `find_matching_paren` helper for the params list). `Type::Function` already existed for declarations; this extends it to expression-position type strings. The `Type::Function` → LLVM lowering already falls through the `type_to_llvm` catch-all to opaque `ptr`.

### Parser
- `src/parser/mod.rs`: `parse_type_name` now handles `TokenKind::Fn` (the `fn` keyword) followed by `(params) -> Ret`, producing the type string `fn(P1, P2) -> Ret`. This enables `fn(i64) -> i64` as a parameter type annotation and `let f: fn(i64) -> i64 = double`.

### Codegen
- `src/codegen/expressions.rs` — `Identifier` arm: when a bare name is not a local variable and not a global, falls back to `self.decls` / `self.module.get_function` — if it's a non-generic function, returns the function pointer (`fv.as_global_value().as_pointer_value()`). Generic functions are excluded (they require monomorphization).
- `src/codegen/expressions.rs` — `Call` arm: pre-flight before direct-call resolution. If the callee name is a local variable whose type-name starts with `fn(`, loads the pointer, reconstructs the `FunctionType` from the parsed signature, and emits `build_indirect_call` (LLVM indirect call) instead of `build_call` with a direct `FunctionValue`.
- `src/codegen/type_helpers.rs` — `get_expr_type_name` for `Identifier`: when a bare name resolves to a non-generic function declaration, returns its signature as `fn(P1,P2)->Ret` (spaces stripped) so the `let` binding stores a recognizable type-name for the Call pre-flight.

### Docs
- `docs/SPEC.md`: added a "Function pointers" subsection under §2 (Type System) documenting the syntax, semantics, and the no-closures / no-generic-functions limitations.

## Tests

Two new fixtures cover the acceptance criteria:

- [x] `tests/fixtures/language/function_pointer.ai` — `let f = double; let result = f(5)` → 10; also `let g = add_one; let r2 = g(10)` → 11. Tests storing + indirect calling.
- [x] `tests/fixtures/language/function_as_param.ai` — `fn apply(f: fn(i64) -> i64, x: i64) -> i64 { return f(x) }` called with `double` as 5→10 and 21→42. Tests function-type params + indirect call through a parameter.
- [x] All 103 tests pass (101 existing + 2 new; snapshots byte-identical for existing, new snapshots generated via `INSTA_UPDATE=always` and reviewed).
- [x] `cargo clippy --all-targets -- -D warnings` green.
- [x] `cargo fmt --check` clean.
- [x] `docs-check` clean.

Edge cases verified manually:
- `f(5)` where `f` is a `let` binding → indirect call (fixture).
- `fn f(f2: fn(i64) -> i64)` parameter → `f2(x)` dispatches as indirect call (fixture).
- `double(5)` direct call → unaffected (pre-flight only triggers on `variables.get(fnm)` with `fn(` type-name; direct function names are not in `variables`).

No Vector::map fixture yet — that requires Vector::map itself (issue #35), which this unblocks but does not implement.

## Docs

- [x] `docs/SPEC.md` updated (Function pointers subsection in §2 Type System)
- [ ] `docs/architecture.md` — N/A (no architectural invariant changed; function pointers reuse the opaque-ptr convention)
- [ ] `stdlib/.../SPEC.md` — N/A
- [ ] `ROADMAP.md` — N/A (#84 is not a ROADMAP line)

## Closes

Closes #84. Unblocks #35 (Vector map/filter/fold — needs function pointers for callbacks). Related: #10 (LSP — function pointer types need hover support), #53 (Tuple — multi-return could benefit).