### PR TITLE
feat(stdlib): std.string.escape_llvm_c_string (#139)

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -48,7 +48,10 @@ Common imports (`Option`, `Result`, `String`, `Vector`, `print`, `println`).
 ### `std.string` **[stable]** & `std.char` **[stable]**
 Full string and character manipulation suite (`len`, `concat`, `from_int`,
 `from_float`, `to_float`, `at`, `substr`, `contains`, `starts_with`,
-`ends_with`, `find`, `trim`, `to_upper`, `to_lower`, `replace`).
+`ends_with`, `find`, `trim`, `to_upper`, `to_lower`, `replace`,
+`escape_llvm_c_string`). Must be paired with a single NUL terminator
+appended by the caller — `str_len` stops at `\0`, so embedded NULs are
+not representable in Aion `String` literals.
 
 ### `std.iter` **[stub]**
 `Iterator` interface and `Range`.

--- a/stdlib/std/string.ai
+++ b/stdlib/std/string.ai
@@ -174,3 +174,39 @@ pub fn replace(s: String, from: String, to: String) -> String {
     }
     return result
 }
+
+// LLVM IR `c"..."` string escape per #139.
+// Returns ONLY the inner escaped contents — caller wraps with `c"..."` and
+// appends the NUL terminator `\00` per the LLVM textual IR spec.
+//
+// Escape rules (input char code -> output literal substring):
+//   0x00 NUL  -> "\00"
+//   0x09 \t   -> "\09"
+//   0x0A \n   -> "\0A"
+//   0x0D \r   -> "\0D"
+//   0x22 "    -> "\22"
+//   0x5C \    -> "\5C"
+// All other printable ASCII chars pass through verbatim. Non-ASCII (>127)
+// is not supported here — the codegen only emits ASCII source literals
+// today; once Unicode string literals land in Aion, this helper must be
+// extended to emit `\XX` octets for the UTF-8 encoding.
+pub fn escape_llvm_c_string(s: String) -> String {
+    let s_len = std.string.len(s);
+    let mut result = "";
+    let mut i = 0;
+    while i < s_len {
+        let c = std.string.at(s, i);
+        let chunk = match c {
+            0 => "\\00",
+            9 => "\\09",
+            10 => "\\0A",
+            13 => "\\0D",
+            34 => "\\22",
+            92 => "\\5C",
+            _ => std.string.substr(s, i, 1),
+        };
+        result = std.string.concat(result, chunk);
+        i = i + 1;
+    }
+    return result;
+}

--- a/tests/fixtures/stdlib/string_escape_llvm.ai
+++ b/tests/fixtures/stdlib/string_escape_llvm.ai
@@ -1,0 +1,49 @@
+use std.string
+use std.io
+
+fn show(label: String, raw: String) {
+    let escaped = std.string.escape_llvm_c_string(raw)
+    io.print(label)
+    io.print(": ")
+    io.println(escaped)
+}
+
+fn main() {
+    // Nominal: ASCII text mixed with every escape-triggering char.
+    // Input chars: a, \n, b, ", c, \, d (7 chars)
+    // Output tokens: a, \0A, b, \22, c, \5C, d (13 chars)
+    show("mixed", "a\nb\"c\\d")
+
+    // Each escape char in isolation.
+    show("newline", "a\nb")
+    show("tab", "a\tb")
+    show("cr", "a\rb")
+    show("quote", "say \"hi\"")
+    show("backslash", "path\\to\\file")
+    show("nul", "a\0b")
+
+    // All escape chars together.
+    show("all", "\n\t\r\"\\")
+
+    // No-escape ASCII — verbatim pass-through.
+    show("plain", "hello, world")
+    show("numbers", "0123456789")
+    show("symbols", "!@#$%^&*(){}[]")
+
+    // Edge cases: empty string, single-char strings of each escape type.
+    show("empty", "")
+    show("solo_backslash", "\\")
+    show("solo_quote", "\"")
+    show("solo_newline", "\n")
+    show("solo_tab", "\t")
+    show("solo_cr", "\r")
+    show("solo_nul", "\0")
+
+    // Length sanity: count input vs output chars for a 7-char input.
+    let raw = "a\nb\"c\\d"
+    let out = std.string.escape_llvm_c_string(raw)
+    io.print("in_len: ")
+    io.println(string.from_int(string.len(raw)))
+    io.print("out_len: ")
+    io.println(string.from_int(string.len(out)))
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -414,6 +414,11 @@ fn test_ordered_map_basic() {
     assert_snapshot!(run_aion_test("stdlib/ordered_map_basic"));
 }
 #[test]
+fn test_string_escape_llvm() {
+    // #139 — escapes a String for inclusion inside an LLVM `c"..."` literal.
+    assert_snapshot!(run_aion_test("stdlib/string_escape_llvm"));
+}
+#[test]
 fn test_tensor_basic() {
     assert_snapshot!(run_aion_test("stdlib/tensor_basic"));
 }

--- a/tests/snapshots/integration__string_escape_llvm.snap
+++ b/tests/snapshots/integration__string_escape_llvm.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/string_escape_llvm\")"
+---
+mixed: a\0Ab\22c\5Cd
+newline: a\0Ab
+tab: a\09b
+cr: a\0Db
+quote: say \22hi\22
+backslash: path\5Cto\5Cfile
+nul: a
+all: \0A\09\0D\22\5C
+plain: hello, world
+numbers: 0123456789
+symbols: !@#$%^&*(){}[]
+empty: 
+solo_backslash: \5C
+solo_quote: \22
+solo_newline: \0A
+solo_tab: \09
+solo_cr: \0D
+solo_nul: 
+in_len: 7
+out_len: 13


### PR DESCRIPTION
## Summary

Adds `std.string.escape_llvm_c_string` — the second hard blocker identified by the codegen audit #128 / `docs/codegen_blockers.md` (B4). Escapes the six special chars (`\0`, `\t`, `\n`, `\r`, `"`, `\`) into LLVM IR `c"..."` `\XX` hex form.

## Changes

- **`stdlib/std/string.ai`** — new `escape_llvm_c_string(s) -> String` function (24 LOC + comment). Returns only the inner escaped contents; the caller wraps with `c"..."` and appends the NUL terminator `\00`.
- **`tests/fixtures/stdlib/string_escape_llvm.ai`** (new) — coverage: nominal mixed-escape input, each escape char in isolation, all escapes together, plain ASCII pass-through, empty string, every single escape char, plus input/output length sanity check.
- **`tests/snapshots/integration__string_escape_llvm.snap`** (new, insta-generated + reviewed).
- **`tests/integration.rs`** — `test_string_escape_llvm` entry.
- **`docs/STDLIB.md`** — lists the new function and documents the embedded-NUL limitation.

### By area
- [x] stdlib — `escape_llvm_c_string` added to `string.ai`
- [x] testing — fixture + snapshot + integration entry
- [x] docs — `STDLIB.md` entry + limitation note

## Tests

- [x] Nominal: mixed-escape input (7 chars → 13-char output), each escape char in isolation, all-escapes input
- [x] Edge cases: empty string (no chars), single-char strings of every escape type, plain ASCII pass-through (digits/symbols), input/output length sanity
- [x] Error cases: N/A — only documented limitation is embedded NULs (str_len stops at `\0`) — tested via the `nul` and `solo_nul` lines of the snapshot
- [x] No regressions: 105/105 integration tests pass (`cargo test --test integration -- --test-threads=1`)
- [x] Snapshot reviewed — every line correct against the LLVM IR spec

## Docs

- [x] `docs/STDLIB.md` updated (function listed under `std.string`)
- [x] No SPEC.md change needed (stdlib-only addition)
- [x] Function comment documents the escape table + non-ASCII limitation

## Closes

- Closes #139 (escape_llvm_c_string helper)

## Related

- Parent: #9 (LLVM Backend in Aion, Phase 2 v0.9)
- Hard-blocks: #130 (codegen memory layout / string literal emission depends on this helper)
- Audit blocker: B4 in `docs/codegen_blockers.md` (committed in #142)
- Next blockers in queue: #140 (`std.string.join` — also hard-blocks #130)