### PR TITLE
feat(stdlib): std.string.join (#140)

### DIFF
--- a/docs/STDLIB.md
+++ b/docs/STDLIB.md
@@ -49,9 +49,9 @@ Common imports (`Option`, `Result`, `String`, `Vector`, `print`, `println`).
 Full string and character manipulation suite (`len`, `concat`, `from_int`,
 `from_float`, `to_float`, `at`, `substr`, `contains`, `starts_with`,
 `ends_with`, `find`, `trim`, `to_upper`, `to_lower`, `replace`,
-`escape_llvm_c_string`). Must be paired with a single NUL terminator
-appended by the caller — `str_len` stops at `\0`, so embedded NULs are
-not representable in Aion `String` literals.
+`escape_llvm_c_string`, `join`). Must be paired with a single NUL
+terminator appended by the caller — `str_len` stops at `\0`, so embedded
+NULs are not representable in Aion `String` literals.
 
 ### `std.iter` **[stub]**
 `Iterator` interface and `Range`.

--- a/stdlib/std/string.ai
+++ b/stdlib/std/string.ai
@@ -1,5 +1,7 @@
 module std.string
 
+use std.collections.vector
+
 pub fn len(s: String) -> i64 {
     @intrinsic("str_len", s)
 }
@@ -206,6 +208,27 @@ pub fn escape_llvm_c_string(s: String) -> String {
             _ => std.string.substr(s, i, 1),
         };
         result = std.string.concat(result, chunk);
+        i = i + 1;
+    }
+    return result;
+}
+
+// Concatenate the entries of `parts` separated by `sep`, with the separator
+// inserted only between elements (not appended after the last). Returns ""
+// for an empty vector, and the sole element verbatim for a single-element
+// vector. Issue #140 — used by `compiler/codegen.ai` (#9) to assemble the
+// LLVM IR text buffer (`Vector<String>` of lines) into a single `String`
+// before writing it via `std.fs.write`.
+pub fn join(parts: vector.Vector<String>, sep: String) -> String {
+    let n = parts.len();
+    if n == 0 {
+        return "";
+    }
+    let mut result = parts.get(0).unwrap();
+    let mut i = 1;
+    while i < n {
+        result = std.string.concat(result, sep);
+        result = std.string.concat(result, parts.get(i).unwrap());
         i = i + 1;
     }
     return result;

--- a/tests/fixtures/stdlib/string_join.ai
+++ b/tests/fixtures/stdlib/string_join.ai
@@ -1,0 +1,80 @@
+use std.string
+use std.collections.vector
+use std.io
+
+fn show(label: String, parts: vector.Vector<String>, sep: String) {
+    let joined = std.string.join(parts, sep)
+    io.print(label)
+    io.print(": ")
+    io.println(joined)
+}
+
+fn main() {
+    // Nominal: 3 elements, comma+space separator.
+    let mut v1 = vector.Vector<String>.new()
+    v1.push("a")
+    v1.push("b")
+    v1.push("c")
+    show("comma_list", v1, ", ")
+
+    // n-element vector with newline separator (simulating IR line buffer).
+    let mut v2 = vector.Vector<String>.new()
+    v2.push("define i64 @main() {")
+    v2.push("  ret i64 0")
+    v2.push("}")
+    show("ir_block", v2, "\n")
+
+    // Edge: empty vector -> "".
+    let empty = vector.Vector<String>.new()
+    show("empty", empty, ", ")
+
+    // Edge: single-element vector -> element verbatim (no separator inserted).
+    let mut solo = vector.Vector<String>.new()
+    solo.push("lone")
+    show("single", solo, ", ")
+
+    // Edge: two empty strings.
+    let mut two_empty = vector.Vector<String>.new()
+    two_empty.push("")
+    two_empty.push("")
+    show("two_empty", two_empty, "|")
+
+    // Edge: empty separator.
+    let mut v3 = vector.Vector<String>.new()
+    v3.push("ab")
+    v3.push("cd")
+    v3.push("ef")
+    show("no_sep", v3, "")
+
+    // Length sanity: 3 entries "a","b","c" joined with ", " -> 8 chars total.
+    let mut chk = vector.Vector<String>.new()
+    chk.push("a")
+    chk.push("b")
+    chk.push("c")
+    let out = std.string.join(chk, ", ")
+    io.print("len: ")
+    io.println(string.from_int(string.len(out)))
+
+    // Re-using a separator multiple times — repeated separator at every gap.
+    let mut v4 = vector.Vector<String>.new()
+    v4.push("x")
+    v4.push("y")
+    v4.push("z")
+    v4.push("w")
+    show("four_dashes", v4, "---")
+
+    // Edge: empty string entries interleaved with non-empty.
+    let mut v5 = vector.Vector<String>.new()
+    v5.push("a")
+    v5.push("")
+    v5.push("b")
+    show("middle_empty", v5, ",")
+
+    // Round-trip: split-like sanity (manual split via known separator).
+    let mut v6 = vector.Vector<String>.new()
+    v6.push("key=value")
+    let one = std.string.join(v6, "&")
+    if string.equals(one, "key=value") {
+        io.println("round-trip single ok")
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -419,6 +419,11 @@ fn test_string_escape_llvm() {
     assert_snapshot!(run_aion_test("stdlib/string_escape_llvm"));
 }
 #[test]
+fn test_string_join() {
+    // #140 — concatenates a Vector<String> with a separator between elements.
+    assert_snapshot!(run_aion_test("stdlib/string_join"));
+}
+#[test]
 fn test_tensor_basic() {
     assert_snapshot!(run_aion_test("stdlib/tensor_basic"));
 }

--- a/tests/snapshots/integration__string_join.snap
+++ b/tests/snapshots/integration__string_join.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"stdlib/string_join\")"
+---
+comma_list: a, b, c
+ir_block: define i64 @main() {
+  ret i64 0
+}
+empty: 
+single: lone
+two_empty: |
+no_sep: abcdef
+len: 7
+four_dashes: x---y---z---w
+middle_empty: a,,b
+round-trip single ok


### PR DESCRIPTION
## Summary

Adds `std.string.join` — the third hard blocker identified by the codegen audit #128 / `docs/codegen_blockers.md` (B6). Concatenates a `Vector<String>` into a single `String` with a separator inserted only between elements. No trailing separator.

## Changes

- **`stdlib/std/string.ai`** — adds `use std.collections.vector` and the new `join(parts: Vector<String>, sep: String) -> String` function (15 LOC + comment).
- **`tests/fixtures/stdlib/string_join.ai`** (new) — nominal + edge cases (comma list, multi-char separator, newline-separated IR block mock, empty vector, single element, two empty strings, empty separator, length sanity, middle-empty entry, single-element round-trip).
- **`tests/snapshots/integration__string_join.snap`** (new, insta-generated + reviewed).
- **`tests/integration.rs`** — `test_string_join` entry.
- **`docs/STDLIB.md`** — adds `join` to the `std.string` operations list.

### By area
- [x] stdlib — `join` added to `string.ai`
- [x] testing — fixture + snapshot + integration entry
- [x] docs — `STDLIB.md` updated

## Tests

- [x] Nominal: 3-element comma list, n-element newline-separated IR block mock, multi-char (`---`) separator
- [x] Edge cases: empty vector (returns `""`), single element (no separator inserted), two empty strings, empty separator, empty middle entry, length sanity (`len("a, b, c") == 7`)
- [x] Error cases: N/A — no error path (concat + len are the only intrinsics used, both in `docs-check-intrinsics.sh`'s approved set)
- [x] No regressions: 106/106 integration tests pass (`cargo test --test integration -- --test-threads=1`)
- [x] Snapshot reviewed — every line correct against the join semantics

## Docs

- [x] `docs/STDLIB.md` updated (function listed under `std.string`)
- [x] No SPEC.md change needed (stdlib-only addition)
- [x] Function comment documents the contract + intended use case

## Closes

- Closes #140 (`std.string.join`)

## Related

- Parent: #9 (LLVM Backend in Aion, Phase 2 v0.9)
- Hard-blocks: #130 (codegen memory layout — string literal pool emission + final `.ll` write depend on `join`)
- Audit blocker: B6 in `docs/codegen_blockers.md` (committed in #142)
- Hard blocker queue is now clear — soft blockers remaining: #137 (`std.fmt.s`, recommended before #131) and #141 (mutual `use` test, before #133)