### PR TITLE
test(compiler): verify mutual use works for cross-module split (#141)

### DIFF
--- a/compiler/mut_a.ai
+++ b/compiler/mut_a.ai
@@ -1,0 +1,39 @@
+module compiler.mut_a
+
+// Mutual-use test fixture (issue #141, audit blocker B9).
+//
+// This module `use`s `compiler.mut_b`, and `compiler.mut_b` `use`s back
+// `compiler.mut_a`. The Aion import resolver must handle the cycle by
+// short-circuiting in `process_imports`'s `visited` set (`src/lib.rs`).
+// Both modules expose one public function that recurse into each other.
+//
+// `call_b(n)`: returns 0 when `n <= 0`; otherwise calls
+// `compiler.mut_b.call_a(n - 1)`.
+// Together with `call_a(n)`, the chain `call_b(10) -> call_a(9) ->
+// call_b(8) -> ... -> call_a(1) -> call_b(0) -> 0` yields 0.
+//
+// This fixture exercises every requirement of issue #141:
+//   * Two sibling modules with two-way `use` of each other.
+//   * Cross-module recursive calls (depth > 1).
+//   * Both modules live under `compiler/` — the same directory the
+//     upcoming `compiler/codegen.ai` (#9) and its potential split into
+//     `compiler/codegen/expressions.ai` + `compiler/codegen/lvalues.ai`
+//     will occupy.
+
+use compiler.mut_b
+
+pub fn call_b(n: i64) -> i64 {
+    if n <= 0 {
+        return 0
+    }
+    return compiler.mut_b.call_a(n - 1)
+}
+
+// Self-call (single-module recursion, base case 1) — confirms the same
+// module's own functions still resolve once a mutual import is present.
+pub fn call_self(n: i64) -> i64 {
+    if n <= 0 {
+        return n
+    }
+    return compiler.mut_a.call_self(n - 1)
+}

--- a/compiler/mut_b.ai
+++ b/compiler/mut_b.ai
@@ -1,0 +1,27 @@
+module compiler.mut_b
+
+// Mutual-use test fixture (issue #141, audit blocker B9) — the other
+// half of the cycle. See `compiler/mut_a.ai` for the contract and
+// recursion-shaped rationale.
+//
+// `call_a(n)`: returns 1 when `n <= 0`; otherwise calls
+// `compiler.mut_a.call_b(n - 1)`.
+// Together with `call_b(n)`, the chain `call_a(11) -> call_b(10) ->
+// call_a(9) -> ... -> call_b(0) -> 0` yields 0. Starting with `call_a`
+// and even `n`, the final return alternates 0 vs 1 depending on parity.
+
+use compiler.mut_a
+
+pub fn call_a(n: i64) -> i64 {
+    if n <= 0 {
+        return 1
+    }
+    return compiler.mut_a.call_b(n - 1)
+}
+
+// Single-hop cross-call: invokes `mut_a` directly without further
+// recursion. Used to isolate forward-reference behaviour from the
+// recursion depth test.
+pub fn ping_a() -> i64 {
+    return compiler.mut_a.call_self(0)
+}

--- a/tests/fixtures/compiler/mut_use.ai
+++ b/tests/fixtures/compiler/mut_use.ai
@@ -1,0 +1,45 @@
+use compiler.mut_a
+use compiler.mut_b
+use std.io
+use std.string
+
+fn main() {
+    // Nominal: depth 10 — call_b alternates with call_a, each subtracts 1.
+    // call_b(10) -> call_a(9) -> call_b(8) -> ... -> call_a(1) -> call_b(0) -> 0
+    let r10 = compiler.mut_a.call_b(10)
+    io.print("depth 10: ")
+    io.println(string.from_int(r10))
+
+    // Starting from call_a with odd parity — alternates similarly.
+    // call_a(11) -> call_b(10) -> call_a(9) -> ... -> call_b(0) -> 0
+    let r11 = compiler.mut_b.call_a(11)
+    io.print("depth 11: ")
+    io.println(string.from_int(r11))
+
+    // Base case 0 — direct invocation, no cross-call.
+    let r0_b = compiler.mut_a.call_b(0)
+    let r0_a = compiler.mut_b.call_a(0)
+    io.print("call_b(0): ")
+    io.println(string.from_int(r0_b))
+    io.print("call_a(0): ")
+    io.println(string.from_int(r0_a))
+
+    // Depth 1 — exactly one cross-call before hitting the base case.
+    let r1_b = compiler.mut_a.call_b(1)
+    let r1_a = compiler.mut_b.call_a(1)
+    io.print("call_b(1): ")
+    io.println(string.from_int(r1_b))
+    io.print("call_a(1): ")
+    io.println(string.from_int(r1_a))
+
+    // Ping-pong single-hop call into mut_a (no recursion).
+    let ping = compiler.mut_b.ping_a()
+    io.print("ping_a: ")
+    io.println(string.from_int(ping))
+
+    // Self-recursion in mut_a — confirms the same module's own function
+    // still resolves when a mutual import is present.
+    let self5 = compiler.mut_a.call_self(5)
+    io.print("call_self(5): ")
+    io.println(string.from_int(self5))
+}

--- a/tests/fixtures/compiler/mut_use_missing.ai
+++ b/tests/fixtures/compiler/mut_use_missing.ai
@@ -1,0 +1,11 @@
+// Mutual-use error-path fixture (issue #141).
+//
+// Imports a non-existent module to verify the Aion resolver surfaces a
+// clear "Import not found" error rather than crashing or silently
+// accepting the dangling reference. Snapshots the resolver's stderr.
+
+use compiler.missing_module
+
+fn main() {
+    let _ = compiler.missing_module.does_not_exist()
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -523,6 +523,18 @@ fn test_error_undefined_method() {
 fn test_error_internal() {
     assert_snapshot!(run_aion_test("compiler/error_internal"));
 }
+#[test]
+fn test_mut_use() {
+    // #141 — verifies two-way cross-module `use` (mutual imports) compiles
+    // and runs correctly between sibling files in `compiler/`.
+    assert_snapshot!(run_aion_test("compiler/mut_use"));
+}
+#[test]
+fn test_mut_use_missing() {
+    // #141 — error path: importing a non-existent module surfaces the
+    // "Import not found" resolver error rather than crashing silently.
+    assert_snapshot!(run_aion_test("compiler/mut_use_missing"));
+}
 
 // --- Example Tests ---
 

--- a/tests/snapshots/integration__mut_use.snap
+++ b/tests/snapshots/integration__mut_use.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/mut_use\")"
+---
+depth 10: 0
+depth 11: 0
+call_b(0): 0
+call_a(0): 1
+call_b(1): 1
+call_a(1): 0
+ping_a: 0
+call_self(5): 0

--- a/tests/snapshots/integration__mut_use_missing.snap
+++ b/tests/snapshots/integration__mut_use_missing.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/mut_use_missing\")"
+---
+Import error: Import not found: "./compiler/missing_module.ai"


### PR DESCRIPTION
## Summary

Lands the last blocker (#141, B9) identified by the codegen audit #128. Verifies that two-way cross-module `use` works between sibling files under `compiler/`, ahead of the upcoming codegen split into `compiler/codegen/expressions.ai` + `compiler/codegen/lvalues.ai` (#133).

The audit identified this as a soft blocker for #133 (function calls + lvaluemutual recursion), not for #129 (single-file codegen skeleton).

## Changes

- **`compiler/mut_a.ai`** (new) — `module compiler.mut_a` + `use compiler.mut_b`. Exposes `call_b(n)`, `call_self(n)`.
- **`compiler/mut_b.ai`** (new) — `module compiler.mut_b` + `use compiler.mut_a`. Exposes `call_a(n)`, `ping_a()`.
- **`tests/fixtures/compiler/mut_use.ai`** (new) — nominal cases: depth-10 + depth-11 mutual recursion, depth-0 + depth-1 base cases, single-hop cross call, single-module self-recursion.
- **`tests/snapshots/integration__mut_use.snap`** (new, insta-generated + reviewed).
- **`tests/fixtures/compiler/mut_use_missing.ai`** (new) — error path: `use compiler.missing_module` surfaces the documented "Import not found:"
- **`tests/snapshots/integration__mut_use_missing.snap`** (new, insta-generated + reviewed).
- **`tests/integration.rs`** — `test_mut_use` + `test_mut_use_missing` entries (closing-brace placement fixed during the edit).

### By area
- [x] testing — fixtures + snapshots + integration entries
- [x] compiler — two supporting modules under `compiler/mut_{a,b}.ai`

## Tests

- [x] Nominal: depth 10/11 mutual recursion, depth 0/1 base cases, ping_a single-hop, call_self(5) — confirms two-way `use` + forward references + callable imports all resolve
- [x] Edge cases: single-hop cross-call (`ping_a`), single-module recursion (`call_self`), depth-1 (exactly one cross-call before hitting the base case)
- [x] Error cases: missing-import surfaces `Import error: Import not found: "./compiler/missing_module.ai"` — snapshot guards silent acceptance
- [x] No regressions: 109/109 integration tests pass (`cargo test --test integration -- --test-threads=1`)
- [x] Both snapshots reviewed — output matches the documented function contracts (`call_b(0)=0`, `call_a(0)=1`, `call_b(1)=1`, `call_a(1)=0`, `ping_a=0`, `call_self(5)=0`)

## Docs

- [x] No stdlib change (mut_a/mut_b are test-support infrastructure, not stdlib modules)
- [x] No SPEC.md change (`use` behaviour already documented; this fixture exercises it)
- [x] File-level comments in `mut_a.ai`/`mut_b.ai` explain which audit blocker this addresses and what the upcoming codegen split will rely on
- [x] Reference to `docs/codegen_blockers.md` B9 in commit message

## Closes

- Closes #141 (mutual `use` test)

## Related

- Parent: #9 (LLVM Backend in Aion, Phase 2 v0.9)
- Audit blocker: B9 in `docs/codegen_blockers.md` (committed in #142)
- Unblocks #133 (codegen calls + lvalue mutual recursion path) — can be implemented either as a single file or a split across `compiler/codegen/{expressions,lvalues,call}.ai` without upstream language work
- With #136, #137, #139, #140, #141 all closed, the hard + soft blocker queue for Phase 2 is empty except for the deferred #138 (`?` operator, post-Phase 2). #129 (codegen.ai skeleton) is fully unblocked.