### PR TITLE
docs(roadmap): mark v0.7 lexer as partial pending #147 closure

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,12 +76,29 @@ This document outlines the technical path to transform Aion from its current Rus
 
 ### **v0.7: Aion Lexer**
 - [x] `lexer.ai` implementation. Validation by the Rust (Bootstrap) compiler.
+- [ ] **v0.7.1 — Lexer Gap Closure (#147)**: the v0.7 skeleton does not tokenize
+      string literals, integer/float literals (they are emitted as
+      `Identifier(...)`), `::intent` attribute values, f-strings, durations,
+      dates, or most keywords (`struct`, `enum`, `impl`, `while`, `for`,
+      `use`, `pub`, `unsafe`, `extern`, `interface`, ...). `hello.ai`
+      currently produces 4 `Illegal` tokens via `compiler/lexer.ai`.
+      Downgrades the v0.7 line to _partial_ and unblocks Phase 2 #129.
+      Hard-blocks #129 → #135.
+      Direct prerequisite: `std.string.to_int` (#148) so the lexer can
+      materialize `IntLiteral(i64)` from digit substrings.
 
 ### **v0.8: Aion Parser**
 - [x] `parser.ai` implementation. AST manipulation via Aion `struct` and `match`.
+- [ ] **v0.8.1 — Parser Gap Closure (depending on #147)**: `parser.ai`
+      structurally handles all AST types in `ast.ai`, but is gated by
+      the lexer gap above. Once #147 lands, every
+      `tests/fixtures/language/*.ai` (55 files) must parse end-to-end
+      into a `Program`. New issue to open after #147 closes.
 
 ### **v0.9: Aion LLVM Backend**
 - [ ] Direct generation of `.ll` (LLVM IR) text files from the AST.
+      Blocked by #147 + #148 (front-end gap) — see issue #9 for the
+      8-slice breakdown (#128 → #135) and the landing order.
 
 ---
 


### PR DESCRIPTION
## Summary

Doc Freshness update following discovery of a critical blocker while attempting to start #129. The ROADMAP marks v0.7 (lexer.ai) and v0.8 (parser.ai) as \`[x]\` completed, but on end-to-end exercise the self-hosted lexer cannot tokenize real Aion source (`hello.ai` produces 4 `Illegal` tokens, 0 `StringLiteral`, 0 `IntLiteral`).

The gap is tracked in **#147** (with its prerequisite **#148** `std.string.to_int`). Until both close, Phase 2 #129 → #135 are blocked. This PR rewrites the v0.7/v0.8/v0.9 sections to reflect reality, naming the sub-bullets v0.7.1 (lexer gap closure) and v0.8.1 (parser gap closure) with links to the corresponding issues.

No code or test changes — strict documentation update per AGENTS.md Doc Freshness rule.

## Changes

- **`ROADMAP.md`** — rewrites the v0.7/v0.8/v0.9 lines:
  - v0.7: keeps the original `[x]` line + adds a new v0.7.1 sub-bullet describing the gap, listing which token classes are missing, and linking #147 / #148.
  - v0.8: keeps the original `[x]` line + adds a v0.8.1 sub-bullet noting the parser is gated by the lexer gap above (parser itself is structurally OK per the audit).
  - v0.9: notes the explicit block on Phase 2 #129 → #135 due to #147 + #148.

### By area
- [x] docs — `ROADMAP.md` rewritten
- (no stdlib / testing / code changes)

## Tests

- N/A — pure docs change.
- `scripts/docs-check.sh` still passes (verified locally): SPEC/ROADMAP version match, README claims, STDLIB legend, and intrinsics check all green.

## Docs

- [x] `ROADMAP.md` updated
- [x] No SPEC.md / STDLIB.md change needed — this is a roadmap status correction, not a spec change
- [x] References to #147, #148 added inline so contributors reading the ROADMAP can find the blockers

## Closes

- Does not close any issue on its own. Sets ROADMAP accuracy for what is documented in #9 / #129 / #147 / #148.

## Related

- Parent: #9 (Phase 2 — LLVM Backend in Aion)
- Audit issue #128 already closed via #142; its output `docs/codegen_blockers.md` will be amended by #147 when the lexer gap closes (B12 addendum).
- Blocker issues:
  - #147 (CRITICAL) — Lexer gap
  - #148 (CRITICAL) — `std.string.to_int` (prerequisite for #147)
- Sub-issues of #9 blocked: #129, #130, #131, #132, #133, #134, #135 (status update already pushed to issue #9).