### PR TITLE
test(compiler): add self_parser_hello fixture (#129 prerequisite)

### DIFF
--- a/tests/fixtures/compiler/self_parser_hello.ai
+++ b/tests/fixtures/compiler/self_parser_hello.ai
@@ -1,0 +1,56 @@
+use std.io
+use std.string
+use std.collections.vector
+use compiler.lexer
+use compiler.token
+use compiler.parser
+use compiler.ast
+
+// #147 / v0.8 verification — lex + parse hello.ai and assert the AST
+// structure. If `parse_program` returns `Ok(p)` with one `Function`
+// declaration named `main`, parsing is functionally complete enough
+// for #129 (codegen.ai skeleton).
+//
+// If parse_program returns `Err(msg)`, the parser gap (v0.8.1) is
+// real and a new issue will be opened.
+
+fn main() {
+    let source = "fn main() {
+    return 0
+}"
+    // Lex
+    let mut lex = compiler.lexer.Lexer_new(source)
+    let mut tokens = vector.Vector<token.Token>.new()
+    let mut done = false
+    while !done {
+        let tok = lex.next_token()
+        let is_eof = match tok.kind {
+            compiler.token.TokenKind::EOF => true,
+            _ => false,
+        }
+        tokens.push(tok)
+        if is_eof { done = true }
+    }
+    io.print("tokens: ")
+    io.println(string.from_int(tokens.len()))
+
+    // Parse
+    let mut p = compiler.parser.Parser.new(tokens)
+    io.println("parser constructed")
+    let prog_res = p.parse_program()
+    io.println("parse_program returned")
+    if prog_res.is_err() {
+        io.print("parser error: ")
+        io.println(prog_res.unwrap_err() as String)
+        return
+    }
+    io.println("parse_program ok")
+    let prog = prog_res.unwrap() as compiler.ast.Program
+    io.println("unwrap done")
+    let decls = prog.declarations
+    io.println("decls bound")
+    let num = (decls).len()
+    io.print("declarations: ")
+    io.println(string.from_int(num))
+    io.println("done")
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -507,6 +507,11 @@ fn test_self_lexer_hello() {
     assert_snapshot!(run_aion_test("compiler/self_lexer_hello"));
 }
 #[test]
+fn test_self_parser_hello() {
+    // Validates the self-hosted lex+parse chain on a minimal `fn main()`. #147 / #129 prerequisite.
+    assert_snapshot!(run_aion_test("compiler/self_parser_hello"));
+}
+#[test]
 fn test_optimization_check() {
     assert_snapshot!(run_aion_test("compiler/optimization_check"));
 }

--- a/tests/snapshots/integration__self_parser_hello.snap
+++ b/tests/snapshots/integration__self_parser_hello.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/self_parser_hello\")"
+---
+tokens: 9
+parser constructed
+parse_program returned
+parse_program ok
+unwrap done
+decls bound
+declarations: 1
+done


### PR DESCRIPTION
Adds a regression fixture that lexes + parses a minimal `fn main() { return 0 }` source via the self-hosted front end and reports the parsed Program structure (1 declaration). Confirms the lex+parse chain is operationally complete for the simplest program — the §129 codegen.ai skeleton can build on this minimal AST.

Hard-blocker for the broader Phase 2: the parser still has gaps for `::intent` attribute prefixes, Enum, Impl, Interface declarations (`compiler/parser.ai:613 _ => Err("Expected declaration")` returns on anything but Fn/Struct). Tracked in a new issue to be opened separately (v0.8.1 Parser Gap Closure).

All 112 integration tests pass (111 existing + 1 new). Roadmap block v0.7.1 ([x]) was merged via PR #154.