### PR TITLE
fix(checker+codegen): bind all match-arm params positionally (#161)

### DIFF
--- a/src/analysis/checker.rs
+++ b/src/analysis/checker.rs
@@ -111,6 +111,66 @@ impl TypeChecker {
         Type::parse(trimmed)
     }
 
+    /// Bind the pattern params of a match arm to their corresponding
+    /// variant element types. Multi-element variants (e.g.
+    /// `Match(Expression, Vector<MatchArm>)` in the self-hosted AST)
+    /// bind each param positionally — previously only `params[0]` was
+    /// bound, leaving `params[1..]` untyped so any use errored as
+    /// "method call on unknown". #161.
+    fn bind_match_params(&mut self, cond_name: &str, all_patterns: &[String], params: &[String]) {
+        if params.is_empty() {
+            return;
+        }
+        let mut data_types: Vec<String> = Vec::new();
+        let mut matched_struct: Option<String> = None;
+
+        if let Some(Declaration::Enum(e)) = self.decls.get(cond_name) {
+            for pat in all_patterns {
+                let mut found = false;
+                for v in &e.variants {
+                    if pat == &v.name
+                        || pat.ends_with(&format!(".{}", v.name))
+                        || pat.ends_with(&format!("::{}", v.name))
+                    {
+                        data_types = v.data_types.clone();
+                        found = true;
+                        break;
+                    }
+                }
+                if found {
+                    break;
+                }
+            }
+        } else if cond_name == "i64" {
+            data_types = vec!["i64".to_string()];
+        } else if cond_name == "String" {
+            data_types = vec!["String".to_string()];
+        } else if let Some(Declaration::Struct(_)) = self.decls.get(cond_name) {
+            matched_struct = Some(cond_name.to_string());
+        }
+
+        if let Some(sname) = matched_struct {
+            if let Some(Declaration::Struct(s)) = self.decls.get(&sname) {
+                // Add struct fields to environment
+                for (field_name, field_type_str) in &s.fields {
+                    let field_type = self.resolve_type(field_type_str);
+                    self.env
+                        .set(format!("{}.{}", params[0], field_name), field_type);
+                }
+            }
+            self.env
+                .set(params[0].clone(), Type::Struct { name: sname });
+        } else {
+            for (i, param) in params.iter().enumerate() {
+                let payload = match data_types.get(i) {
+                    Some(dt) => self.resolve_type(dt),
+                    None => Type::i64(),
+                };
+                self.env.set(param.clone(), payload);
+            }
+        }
+    }
+
     fn register_builtins(&mut self) {
         self.env.set(
             "aion_read_file".to_string(),
@@ -585,40 +645,7 @@ impl TypeChecker {
 
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
-                        let mut payload = Type::i64();
-
-                        // Check patterns for enum type
-                        if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
-                            for pat in &all_patterns {
-                                for v in &e.variants {
-                                    if pat == &v.name
-                                        || pat.ends_with(&format!(".{}", v.name))
-                                        || pat.ends_with(&format!("::{}", v.name))
-                                    {
-                                        if !v.data_types.is_empty() {
-                                            payload = self.resolve_type(&v.data_types[0]);
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
-                        } else if cond_name == "i64" {
-                            payload = Type::i64();
-                        } else if cond_name == "String" {
-                            payload = Type::String;
-                        } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
-                            payload = Type::Struct {
-                                name: cond_name.clone(),
-                            };
-                            // Add struct fields to environment
-                            for (field_name, field_type_str) in &s.fields {
-                                let field_type = self.resolve_type(field_type_str);
-                                self.env
-                                    .set(format!("{}.{}", arm.params[0], field_name), field_type);
-                            }
-                        }
-
-                        self.env.set(arm.params[0].clone(), payload);
+                        self.bind_match_params(&cond_name, &all_patterns, &arm.params);
                     }
 
                     // Evaluate guard if present
@@ -1062,38 +1089,7 @@ impl TypeChecker {
 
                     if !arm.params.is_empty() {
                         self.env = Environment::new_enclosed(old_env.clone());
-                        let mut payload = Type::i64();
-
-                        if let Some(Declaration::Enum(e)) = self.decls.get(&cond_name) {
-                            for pat in &all_patterns {
-                                for v in &e.variants {
-                                    if pat == &v.name
-                                        || pat.ends_with(&format!(".{}", v.name))
-                                        || pat.ends_with(&format!("::{}", v.name))
-                                    {
-                                        if !v.data_types.is_empty() {
-                                            payload = self.resolve_type(&v.data_types[0]);
-                                        }
-                                        break;
-                                    }
-                                }
-                            }
-                        } else if cond_name == "i64" {
-                            payload = Type::i64();
-                        } else if cond_name == "String" {
-                            payload = Type::String;
-                        } else if let Some(Declaration::Struct(s)) = self.decls.get(&cond_name) {
-                            payload = Type::Struct {
-                                name: cond_name.clone(),
-                            };
-                            for (field_name, field_type_str) in &s.fields {
-                                let field_type = self.resolve_type(field_type_str);
-                                self.env
-                                    .set(format!("{}.{}", arm.params[0], field_name), field_type);
-                            }
-                        }
-
-                        self.env.set(arm.params[0].clone(), payload);
+                        self.bind_match_params(&cond_name, &all_patterns, &arm.params);
                     }
 
                     if let Some(guard_expr) = &arm.guard {

--- a/src/codegen/control_flow.rs
+++ b/src/codegen/control_flow.rs
@@ -418,34 +418,56 @@ impl<'ctx> Compiler<'ctx> {
                             let mut av = variables.clone();
                             if !arm.params.is_empty() {
                                 let dp = self.builder.build_struct_gep(et, ep, 1, "arm_dataptr")?;
-                                let mut ptn = "i64".to_string();
+                                // Resolve the matched variant's element types once,
+                                // then bind each param positionally: element i lives
+                                // at byte offset i*8 in the enum payload buffer (all
+                                // Aion values are 8 bytes — ptr or i64). Previously
+                                // only params[0] was bound, leaving params[1..]
+                                // unbound at codegen. #161.
+                                let mut data_types: Vec<String> = Vec::new();
                                 if let Some(Declaration::Enum(e_decl)) = self.decls.get(&fen) {
                                     for v in &e_decl.variants {
                                         if arm.pattern == v.name
                                             || arm.pattern.ends_with(&format!(".{}", v.name))
                                             || arm.pattern.ends_with(&format!("::{}", v.name))
                                         {
-                                            if !v.data_types.is_empty() {
-                                                ptn = v.data_types[0].clone();
-                                            }
+                                            data_types = v.data_types.clone();
                                             break;
                                         }
                                     }
                                 }
-                                let lt = self.aion_type_to_llvm(&ptn);
-                                let cp = self.builder.build_bit_cast(
-                                    dp,
-                                    self.context.ptr_type(AddressSpace::default()),
-                                    "arm_datacast",
-                                )?;
-                                let lv_val = self.builder.build_load(
-                                    lt,
-                                    cp.into_pointer_value(),
-                                    &arm.params[0],
-                                )?;
-                                let pa = self.builder.build_alloca(lt, &arm.params[0])?;
-                                self.builder.build_store(pa, lv_val)?;
-                                av.insert(arm.params[0].clone(), (pa, lt, ptn));
+                                let base_ptr = self
+                                    .builder
+                                    .build_bit_cast(
+                                        dp,
+                                        self.context.ptr_type(AddressSpace::default()),
+                                        "arm_datacast",
+                                    )?
+                                    .into_pointer_value();
+                                for (i, param) in arm.params.iter().enumerate() {
+                                    let ptn = data_types
+                                        .get(i)
+                                        .cloned()
+                                        .unwrap_or_else(|| "i64".to_string());
+                                    let lt = self.aion_type_to_llvm(&ptn);
+                                    let elem_ptr = if i == 0 {
+                                        base_ptr
+                                    } else {
+                                        let byte_off = (i * 8) as u64;
+                                        unsafe {
+                                            self.builder.build_in_bounds_gep(
+                                                self.context.i8_type(),
+                                                base_ptr,
+                                                &[i64_t.const_int(byte_off, false)],
+                                                &format!("arm_off_{}", i),
+                                            )?
+                                        }
+                                    };
+                                    let lv_val = self.builder.build_load(lt, elem_ptr, param)?;
+                                    let pa = self.builder.build_alloca(lt, param)?;
+                                    self.builder.build_store(pa, lv_val)?;
+                                    av.insert(param.clone(), (pa, lt, ptn));
+                                }
                             }
 
                             // Evaluate guard condition if present

--- a/src/codegen/expressions.rs
+++ b/src/codegen/expressions.rs
@@ -665,13 +665,30 @@ impl<'ctx> Compiler<'ctx> {
                         i64_t.const_int(tv, false),
                     )?;
                     if !arguments.is_empty() {
-                        let val = self.compile_expr(&arguments[0], variables, function)?;
-                        let cp = self.builder.build_bit_cast(
-                            self.builder.build_struct_gep(et, pr, 1, "data")?,
-                            pt,
-                            "datacast",
-                        )?;
-                        self.builder.build_store(cp.into_pointer_value(), val)?;
+                        // Serialize each payload element at byte offset
+                        // i*8 in the data buffer — mirrors the positional
+                        // binding of match-arm params (all Aion values are
+                        // 8 bytes: ptr or i64). Previously only arguments[0]
+                        // was stored, so multi-element variants lost their
+                        // extra payloads. #161.
+                        for (i, arg) in arguments.iter().enumerate() {
+                            let val = self.compile_expr(arg, variables, function)?;
+                            let data_gep = self.builder.build_struct_gep(et, pr, 1, "data")?;
+                            let cp = self.builder.build_bit_cast(data_gep, pt, "datacast")?;
+                            let elem_ptr = if i == 0 {
+                                cp.into_pointer_value()
+                            } else {
+                                unsafe {
+                                    self.builder.build_in_bounds_gep(
+                                        self.context.i8_type(),
+                                        cp.into_pointer_value(),
+                                        &[i64_t.const_int((i * 8) as u64, false)],
+                                        &format!("enum_data_off_{}", i),
+                                    )?
+                                }
+                            };
+                            self.builder.build_store(elem_ptr, val)?;
+                        }
                     }
                     Ok(pr.into())
                 } else {

--- a/tests/fixtures/compiler/self_parser_match.ai
+++ b/tests/fixtures/compiler/self_parser_match.ai
@@ -6,37 +6,37 @@ use compiler.parser
 use compiler.ast
 use compiler.token
 
-// #156 Slice 4 — `match` parsing: statement + expression positions,
-// pattern forms (identifier/path, int, int range, string, wildcard,
-// multi-pattern `|`, binding params, guard).
+// #156 Slice 4 + #161 — `match` parsing: statement + expression
+// positions, all pattern forms (identifier/path, int, int range,
+// string, wildcard, multi-pattern `|`, binding params, guard).
 //
-// Checker-limitation note: this fixture verifies that match statements
-// and match EXPRESSIONS parse into the expected Statement/Expression
-// variants (via boolean helpers). It cannot introspect the arms
-// Vector: the type checker fails to type match bindings carrying a
-// Vector whose element type comes from another module
-// (`Statement::Match(c, arms)` -> `arms.len()` = "method call on
-// unknown"). Tracked separately; the parse succeeding is itself the
-// assertion — any malformed arm would surface as "parser error".
+// Introspects the parsed match arms (patterns, params, guards) — made
+// possible by #161 (cross-module Vector bindings now typed at both
+// checker and codegen level).
 
-fn stmt_kind(s: compiler.ast.Statement) -> String {
-    match s {
-        compiler.ast.Statement::Match(_c, _a) => {
-            return "Match"
-        },
-        compiler.ast.Statement::Return(_v, _i) => {
-            return "Return"
-        },
-        compiler.ast.Statement::Let(_n, _v, _t, _m) => {
-            return "Let"
-        },
-        compiler.ast.Statement::ExpressionStmt(_e) => {
-            return "ExpressionStmt"
-        },
-        _ => {
-            return "Other"
-        },
+fn arm_pattern(arms: vector.Vector<compiler.ast.MatchArm>, i: i64) -> String {
+    let a = (arms).get(i).unwrap() as compiler.ast.MatchArm
+    let p = a.pattern
+    return p
+}
+
+fn arm_param(arms: vector.Vector<compiler.ast.MatchArm>, i: i64) -> String {
+    let a = (arms).get(i).unwrap() as compiler.ast.MatchArm
+    let params = a.params
+    let n = (params).len()
+    if n == 0 {
+        return "-"
     }
+    let p = (params).get(0).unwrap()
+    return p
+}
+
+fn arm_has_guard(arms: vector.Vector<compiler.ast.MatchArm>, i: i64) -> String {
+    let a = (arms).get(i).unwrap() as compiler.ast.MatchArm
+    if a.has_guard {
+        return "guard"
+    }
+    return "-"
 }
 
 fn is_match_expr_return(s: compiler.ast.Statement) -> bool {
@@ -54,6 +54,25 @@ fn is_match_expr_return(s: compiler.ast.Statement) -> bool {
         _ => {
             return false
         },
+    }
+}
+
+fn dump_match_arms(label: String, arms: vector.Vector<compiler.ast.MatchArm>) {
+    let n = (arms).len()
+    io.print(label)
+    io.print(" arms: ")
+    io.println(string.from_int(n))
+    let mut i = 0
+    while i < n {
+        io.print("  [")
+        io.print(string.from_int(i))
+        io.print("] ")
+        io.print(arm_pattern(arms, i))
+        io.print(" bind=")
+        io.print(arm_param(arms, i))
+        io.print(" ")
+        io.println(arm_has_guard(arms, i))
+        i = i + 1
     }
 }
 
@@ -131,12 +150,15 @@ fn grade(score: i64) -> String {
                 let mut si = 0
                 while si < nb {
                     let s = (body).get(si).unwrap() as compiler.ast.Statement
-                    io.print("  [")
-                    io.print(string.from_int(si))
-                    io.print("] ")
-                    io.println(stmt_kind(s))
-                    if is_match_expr_return(s) {
-                        io.println("      ^ return value is a match expression")
+                    match s {
+                        compiler.ast.Statement::Match(_c, arms) => {
+                            dump_match_arms("stmt-match", arms)
+                        },
+                        _ => {
+                            if is_match_expr_return(s) {
+                                io.println("  return-value: match expression")
+                            }
+                        },
                     }
                     si = si + 1
                 }

--- a/tests/snapshots/integration__self_parser_match.snap
+++ b/tests/snapshots/integration__self_parser_match.snap
@@ -6,12 +6,17 @@ tokens: 141
 parse ok
 declarations: 4
 == fn classify
-  [0] Return
-      ^ return value is a match expression
+  return-value: match expression
 == fn describe
-  [0] Match
-  [1] Return
+stmt-match arms: 3
+  [0] Color.Red bind=- -
+  [1] Color.Green bind=- -
+  [2] _ bind=- -
 == fn unwrap2
-  [0] Match
+stmt-match arms: 2
+  [0] Some bind=v -
+  [1] None bind=- -
 == fn grade
-  [0] Match
+stmt-match arms: 2
+  [0] n bind=n guard
+  [1] _ bind=- -


### PR DESCRIPTION
## Summary

Fixes #161 — match arms destructuring multi-element enum variants only bound `params[0]`; `params[1..]` were silently untyped (checker) and unbound (codegen), so any use errored with "method call on unknown" / "variable not found". This was blocking the codegen slices (#131+) which must introspect `compiler.ast` Vectors from match bindings.

## Changes

- **`src/analysis/checker.rs`** — factored the duplicated variant-lookup logic (Statement::Match + Expression::Match paths) into one `bind_match_params(cond_name, all_patterns, params)` helper; binds each param to `resolve_type(data_types[i])` positionally (fallback `i64`, matching the previous single-param default). Struct-subject field-prefix binding preserved.
- **`src/codegen/control_flow.rs`** — match lowering resolves the variant's full `data_types` list and binds each param by loading element `i` from byte offset `i*8` of the payload buffer (`build_in_bounds_gep` on i8). Element 0 stays at offset 0 — identical to the old behaviour.
- **`src/codegen/expressions.rs`** — `Expression::EnumInst` serializes each argument at offset `i*8`, mirroring the read side. Single-argument enums (Option/Result) are byte-identical to before.
- **`tests/fixtures/compiler/self_parser_match.ai`** — extended to introspect every match arm (pattern, binding param, guard) for all four fixture functions.
- **`tests/snapshots/integration__self_parser_match.snap`** — updated.

### By area
- [x] checker — `bind_match_params` helper, both Match paths
- [x] codegen — positional payload load (match) + store (EnumInst)
- [x] testing — fixture extended + snapshot updated

### Layout contract (new, documented at both sites)

Enum payload buffer: element `i` at byte offset `i * 8`. All Aion values are 8 bytes (ptr or i64) so this is a uniform layout. Reader (match binding) and writer (EnumInst) now agree — previously the writer only ever wrote element 0.

## Tests

- [x] Nominal: repro from #161 — `match s { compiler.ast.Statement::Match(cond, arms) => count_arms(arms) }` now returns the correct arm count with full introspection (patterns, params, guards dumped per arm).
- [x] Edge cases: `Some(v) => v` (single binding), `Color.Red` path patterns (no binding), `n if n > 90` (guard), multi-pattern return match.
- [x] No regressions: 117/117 integration tests pass — Option/Result single-payload matching is byte-identical at offset 0.
- [x] `cargo fmt --check` + `cargo clippy` clean.

## Docs

- [x] No SPEC change (bug fix — behaviour now matches what the AST structure implies).
- [x] Layout contract documented in comments at both the writer (expressions.rs) and reader (control_flow.rs) sites.

## Closes

- Closes #161 (checker/codegen cross-module Vector match bindings)

## Related

- Unblocks: #131 → #134 (codegen.ai slices introspecting `ast` Vectors from match bindings).
- Discovered by: #156 Slice 4 fixture (PR #162).
- Parent: #9 (Phase 2).