### PR TITLE
feat(codegen): memory layout — struct/enum types + string globals (#130)

### DIFF
--- a/compiler/codegen.ai
+++ b/compiler/codegen.ai
@@ -43,6 +43,7 @@ pub struct Codegen {
     ssa_counter: i64,
     struct_types: ordered_map.OrderedMap<String>,
     function_signatures: ordered_map.OrderedMap<String>,
+    strings: vector.Vector<String>,
 }
 
 // LLVM type lowering for every primitive in `docs/SPEC.md` §2.
@@ -94,6 +95,7 @@ impl Codegen {
             ssa_counter: 0,
             struct_types: ordered_map.OrderedMap<String>.new(),
             function_signatures: ordered_map.OrderedMap<String>.new(),
+            strings: vector.Vector<String>.new(),
         }
     }
 
@@ -133,18 +135,46 @@ impl Codegen {
     // Full program compile. Returns the joined IR text so the caller can
     // `std.fs.write(path, content)` it (using `std.string.join`, #140)
     // and run `opt-15 -verify` on the file.
+    //
+    // Two-pass layout (#130):
+    //   1. Header + runtime declares.
+    //   2. Scan all function bodies for string literals, emit them as
+    //      `@.str.N` global constants (needs escape_llvm_c_string, #139).
+    //   3. Emit struct/enum type definitions in declaration order.
+    //   4. Emit function definitions.
     pub fn compile(mut self, prog: compiler.ast.Program) -> String {
         self.emit_header();
+        self.collect_strings_prog(prog);
+        self.emit_string_globals();
         let decls = prog.declarations;
         let n = (decls).len();
+        // Types first (structs + enums), so forward references to %Name
+        // inside function bodies resolve against an already-declared type.
         let mut i = 0;
         while i < n {
-            let decl_opt = (decls).get(i);
-            match decl_opt {
-                Option::Some(d) => {
-                    self.compile_decl(d);
+            let d = (decls).get(i).unwrap() as compiler.ast.Declaration;
+            match d {
+                compiler.ast.Declaration::Struct(s) => {
+                    self.compile_struct(s);
                 },
-                Option::None => {},
+                compiler.ast.Declaration::Enum(e) => {
+                    self.compile_enum(e);
+                },
+                _ => {},
+            }
+            i = i + 1;
+        }
+        // Then functions.
+        let mut i = 0;
+        while i < n {
+            let d = (decls).get(i).unwrap() as compiler.ast.Declaration;
+            match d {
+                compiler.ast.Declaration::Function(f) => {
+                    self.compile_function(f);
+                },
+                // Aggregate lowering (struct/enum INSTANTIATION, match)
+                // is the subject of #134.
+                _ => {},
             }
             i = i + 1;
         }
@@ -152,14 +182,130 @@ impl Codegen {
         return joined;
     }
 
-    fn compile_decl(mut self, d: compiler.ast.Declaration) {
-        match d {
-            compiler.ast.Declaration::Function(f) => {
-                self.compile_function(f);
+    // Pass 1 — walk every function body and collect string literals in
+    // declaration order (deterministic @.str.N numbering, #130).
+    fn collect_strings_prog(mut self, prog: compiler.ast.Program) {
+        let decls = prog.declarations;
+        let n = (decls).len();
+        let mut i = 0;
+        while i < n {
+            let d = (decls).get(i).unwrap() as compiler.ast.Declaration;
+            match d {
+                compiler.ast.Declaration::Function(f) => {
+                    self.collect_strings_fn(f);
+                },
+                _ => {},
+            }
+            i = i + 1;
+        }
+    }
+
+    fn collect_strings_fn(mut self, f: compiler.ast.Function) {
+        let body = f.body;
+        let n = (body).len();
+        let mut i = 0;
+        while i < n {
+            let s = (body).get(i).unwrap() as compiler.ast.Statement;
+            self.collect_strings_stmt(s);
+            i = i + 1;
+        }
+    }
+
+    fn collect_strings_stmt(mut self, s: compiler.ast.Statement) {
+        match s {
+            compiler.ast.Statement::Let(_name, value, _ty, _m) => {
+                self.collect_strings_expr(value);
             },
-            // #129 skeleton skips Struct/Enum/Impl/Interface — #134 covers them.
+            compiler.ast.Statement::Return(value, _ty) => {
+                self.collect_strings_expr(value);
+            },
+            compiler.ast.Statement::ExpressionStmt(e) => {
+                self.collect_strings_expr(e);
+            },
+            compiler.ast.Statement::Assignment(_target, value) => {
+                self.collect_strings_expr(value);
+            },
             _ => {},
         }
+    }
+
+    fn collect_strings_expr(mut self, e: compiler.ast.Expression) {
+        match e {
+            compiler.ast.Expression::StringLit(s) => {
+                self.strings.push(s);
+            },
+            compiler.ast.Expression::Infix(l, _op, r) => {
+                self.collect_strings_expr(l);
+                self.collect_strings_expr(r);
+            },
+            _ => {},
+        }
+    }
+
+    // Emit collected string literals as LLVM global constants:
+    //   @.str.0 = private unnamed_addr constant [12 x i8] c"hello, aion\00"
+    // Byte length = strlen(s) + 1 (NUL terminator). The contents are
+    // escaped via `std.string.escape_llvm_c_string` (#139) — non-ASCII
+    // input is out of scope (see that function's documented limitation).
+    fn emit_string_globals(mut self) {
+        let n = (self.strings).len();
+        let mut buf = self.output;
+        let mut i = 0;
+        while i < n {
+            let s = (self.strings).get(i).unwrap();
+            let escaped = std.string.escape_llvm_c_string(s);
+            let byte_len = std.string.len(s) + 1;
+            let mut line = std.string.concat("@.str.", std.string.from_int(i));
+            line = std.string.concat(line, " = private unnamed_addr constant [");
+            line = std.string.concat(line, std.string.from_int(byte_len));
+            line = std.string.concat(line, " x i8] c\"");
+            line = std.string.concat(line, escaped);
+            line = std.string.concat(line, "\\00\"");
+            buf.push(line);
+            i = i + 1;
+        }
+        if n > 0 {
+            buf.push("");
+        }
+        self.output = buf;
+    }
+
+    // Emit a struct type definition with the exact field order from the
+    // AST: `%Point = type { i64, i64 }`. Composite fields (String, other
+    // structs/enums, arrays, tuples) lower to opaque `ptr` — matching
+    // `src/codegen/types.rs:152-160`'s fall-through. Structs are passed
+    // by pointer per SPEC §3, so the type itself is the only layout the
+    // codegen must declare. #130.
+    fn compile_struct(mut self, s: compiler.ast.Struct) {
+        let fields = s.fields;
+        let nf = (fields).len();
+        let mut parts = vector.Vector<String>.new();
+        let mut i = 0;
+        while i < nf {
+            let f = (fields).get(i).unwrap() as compiler.ast.Field;
+            let ft = aion_type_to_llvm(f.type_name);
+            parts.push(ft);
+            i = i + 1;
+        }
+        let joined = std.string.join(parts, ", ");
+        let mut line = std.string.concat("%", s.name);
+        line = std.string.concat(line, " = type { ");
+        line = std.string.concat(line, joined);
+        line = std.string.concat(line, " }");
+        let mut buf = self.output;
+        buf.push(line);
+        self.output = buf;
+    }
+
+    // Emit an enum type definition: `%Name = type { i64, [64 x i8] }` —
+    // index 0 = tag, index 1 = 64-byte inline payload buffer. Mirrors
+    // `src/codegen/compiler.rs:424-432`. #130.
+    fn compile_enum(mut self, e: compiler.ast.Enum) {
+        let mut line = std.string.concat("%", e.name);
+        line = std.string.concat(line, " = type { i64, [64 x i8] }");
+        let mut buf = self.output;
+        buf.push(line);
+        self.output = buf;
     }
 
     // Emit `define <ret_ty> @<name>(...) { entry: ... }`.

--- a/tests/fixtures/compiler/codegen_memory_layout.ai
+++ b/tests/fixtures/compiler/codegen_memory_layout.ai
@@ -1,0 +1,69 @@
+use std.io
+use std.string
+use std.collections.vector
+use compiler.lexer
+use compiler.parser
+use compiler.ast
+use compiler.codegen
+
+// #130 — memory layout & runtime ABI: struct/enum type definitions and
+// string literal globals emitted by `compiler/codegen.ai`.
+//
+// Parses a source containing a struct (exact field order), an enum
+// (tagged-union layout), and a string literal in main, feeds the AST
+// to the codegen, and prints the emitted `.ll` to stdout.
+//
+// Acceptance (per #130):
+//   - Struct types emitted with exact AST field order        [x]
+//   - String literals lowered as @.str.N globals w/ length   [x]
+//   - Enums emit %Name = type { i64, [64 x i8] }             [x]
+//   - Output passes `opt-15 --opaque-pointers -verify`
+//     (verified separately — the integration runner does not
+//     invoke opt-15 today)
+//   - Snapshot committed                                     [x]
+
+fn main() {
+    let source = "struct Point {
+    x: i64,
+    label: String,
+    y: i64,
+}
+
+struct Empty {
+}
+
+enum Maybe {
+    Some(i64),
+    None,
+}
+
+fn main() {
+    let s = \"hello, aion\"
+    return 0
+}"
+    let mut lex = compiler.lexer.Lexer_new(source)
+    let mut tokens = vector.Vector<token.Token>.new()
+    let mut done = false
+    while !done {
+        let tok = lex.next_token()
+        let is_eof = match tok.kind {
+            compiler.token.TokenKind::EOF => true,
+            _ => false,
+        }
+        tokens.push(tok)
+        if is_eof { done = true }
+    }
+
+    let mut p = compiler.parser.Parser.new(tokens)
+    let prog_res = p.parse_program()
+    if prog_res.is_err() {
+        io.print("parser error: ")
+        io.println(prog_res.unwrap_err() as String)
+        return
+    }
+    let prog = prog_res.unwrap() as compiler.ast.Program
+
+    let mut cg = compiler.codegen.Codegen.new("aion_module")
+    let ir = cg.compile(prog)
+    io.println(ir)
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -520,6 +520,12 @@ fn test_codegen_skeleton() {
     assert_snapshot!(run_aion_test("compiler/codegen_skeleton"));
 }
 #[test]
+fn test_codegen_memory_layout() {
+    // #130 — struct/enum type definitions (exact field order, tagged-union
+    // enum layout) + string literal globals in the emitted `.ll`.
+    assert_snapshot!(run_aion_test("compiler/codegen_memory_layout"));
+}
+#[test]
 fn test_self_parser_call() {
     // #156 Slice 1 — verifies the parser's postfix dispatch loop produces
     // a Call AST node for `io.println("hello")` (vs the pre-#156 fold-only

--- a/tests/snapshots/integration__codegen_memory_layout.snap
+++ b/tests/snapshots/integration__codegen_memory_layout.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration.rs
+expression: "run_aion_test(\"compiler/codegen_memory_layout\")"
+---
+; ModuleID = 'aion_module'
+source_filename = "aion_module"
+
+declare i32 @printf(i8*, ...)
+declare void @exit(i32)
+declare void @GC_init()
+declare ptr @aion_malloc(i64)
+declare void @aion_io_println(ptr)
+declare void @aion_io_print(ptr)
+declare ptr @aion_int_to_str(i64)
+@aion_argc = global i64 0
+@aion_argv = global ptr null
+
+@.str.0 = private unnamed_addr constant [12 x i8] c"hello, aion\00"
+
+%Point = type { i64, ptr, i64 }
+%Empty = type {  }
+%Maybe = type { i64, [64 x i8] }
+define i32 @main() {
+entry:
+  ret i32 0
+}


### PR DESCRIPTION
## Summary

Closes #130 — the second codegen slice (#9.2 of the #9 sequence). `compiler/codegen.ai` now emits the memory layout of aggregate types and string literals alongside function definitions.

## Changes

- **`compiler/codegen.ai`**:
  - Struct type definitions with exact AST field order (`%Point = type { i64, ptr, i64 }`); composite fields → opaque `ptr` (mirrors `src/codegen/types.rs:152-160`).
  - Enum type definitions (`%Maybe = type { i64, [64 x i8] }` — tag + 64-byte payload, mirrors `src/codegen/compiler.rs:424-432`).
  - String literal globals `@.str.N` with deterministic numbering and `escape_llvm_c_string` escaping (#139 — first consumer of that helper).
  - Two-pass compile: pass 1 collects string literals from all bodies (Let/Return/ExpressionStmt/Assignment + Infix recursion); pass 2 emits types then functions (forward references resolve).
- **`tests/fixtures/compiler/codegen_memory_layout.ai`** (new) — struct (mixed fields), empty struct, enum, string literal → `.ll` printed.
- **`tests/snapshots/integration__codegen_memory_layout.snap`** (new, insta-generated + reviewed).
- **`tests/integration.rs`** — `test_codegen_memory_layout` entry.

### By area
- [x] compiler — `codegen.ai` layout emission
- [x] testing — fixture + snapshot + integration entry

## Tests

- [x] Nominal: struct with mixed field types (i64, String, i64 — order preserved), enum tagged-union layout, string literal global with NUL-terminated byte length ([12 x i8] for 11 chars).
- [x] Edge cases: empty struct (`%Empty = type {  }`), string with punctuation/comma, declaration-order preservation of all type definitions.
- [x] `opt-15 --opaque-pointers -verify` accepts the emitted `.ll` (ret=0, verified manually).
- [x] No regressions: 118/118 integration tests pass.
- [x] `scripts/docs-check.sh` passes.

## Docs

- [x] No SPEC change (the layout matches what the Rust codegen already emits — see SPEC §2/§3).
- [x] Method-level comments document the layout contract and the two-pass order.

## Closes

- Closes #130 (#9.2 — memory layout & runtime ABI)

## Related

- Parent: #9 (Phase 2). Sequence: #129 ✅ → **#130 ✅** → #131 (simple expressions) → #132 (control flow) → #133 (calls/generics) → #134 (aggregates/match) → #135 (Ouroboros test).
- Depends on: #139 (escape_llvm_c_string — first real consumer), #140 (join), #136 (OrderedMap).